### PR TITLE
fix: prevent duplicate SM colors in Rota do Dia when portal list exceeds 8

### DIFF
--- a/rota-do-dia-map.js
+++ b/rota-do-dia-map.js
@@ -12,7 +12,11 @@
     '#7c3aed', '#0891b2', '#db2777', '#ea580c',
   ];
 
-  function colorForIndex(i) { return PORTAL_COLORS[i % PORTAL_COLORS.length]; }
+  function colorForIndex(i, total) {
+    if (!total || total <= PORTAL_COLORS.length) return PORTAL_COLORS[i % PORTAL_COLORS.length];
+    const hue = Math.round((i * 360) / total);
+    return `hsl(${hue}, 65%, 45%)`;
+  }
 
   function makeMarkerSVG(label, color) {
     const w = 80, h = 38, r = 7;
@@ -313,7 +317,7 @@
 
     const chipsContainer = document.getElementById('rmPortalChips');
     portals.forEach((p, i) => {
-      const color = colorForIndex(i);
+      const color = colorForIndex(i, portals.length);
       const chip = document.createElement('div');
       chip.className = 'rm-portal-chip';
       chip.dataset.portalId = p.id;


### PR DESCRIPTION
## Summary

- `PORTAL_COLORS` only had 8 entries; with 9+ portals the index wrapped around (`i % 8`) causing portal 0 and portal 8 to share the same blue, etc.
- `colorForIndex` now receives the total portal count and, when it exceeds 8, distributes colours evenly across the HSL hue wheel instead of repeating.

## Test plan

- [ ] Open Rota do Dia with 3+ SMs selected — all chips should show distinct colours
- [ ] Verify the map routes and markers use the correct unique colour per SM
- [ ] With ≤8 portals, confirm the original fixed palette colours are still used

https://claude.ai/code/session_01XwF4rKXz3KTxXkWq4fvnJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwF4rKXz3KTxXkWq4fvnJX)_