### PR TITLE
fix: parse extra JSON in script-tail card renderer

### DIFF
--- a/rota-do-dia-map.js
+++ b/rota-do-dia-map.js
@@ -12,7 +12,11 @@
     '#7c3aed', '#0891b2', '#db2777', '#ea580c',
   ];
 
-  function colorForIndex(i) { return PORTAL_COLORS[i % PORTAL_COLORS.length]; }
+  function colorForIndex(i, total) {
+    if (!total || total <= PORTAL_COLORS.length) return PORTAL_COLORS[i % PORTAL_COLORS.length];
+    const hue = Math.round((i * 360) / total);
+    return `hsl(${hue}, 65%, 45%)`;
+  }
 
   function makeMarkerSVG(label, color) {
     const w = 80, h = 38, r = 7;
@@ -313,7 +317,7 @@
 
     const chipsContainer = document.getElementById('rmPortalChips');
     portals.forEach((p, i) => {
-      const color = colorForIndex(i);
+      const color = colorForIndex(i, portals.length);
       const chip = document.createElement('div');
       chip.className = 'rm-portal-chip';
       chip.dataset.portalId = p.id;

--- a/script-tail.js
+++ b/script-tail.js
@@ -60,7 +60,9 @@ const telBtn = phone ? `
     a.calibration ? `<span class="m-chip m-chip-calib">⊕ CALIB</span>` : '',
     a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
   ].filter(Boolean).join('');
-  const notes = [a.client_name, a.extra, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  let _extraDisp = a.extra || '';
+  if (_extraDisp) { try { const _p = JSON.parse(_extraDisp); _extraDisp = _p.eurocode || ''; } catch(e) {} }
+  const notes = [a.client_name, _extraDisp, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');

--- a/script.js
+++ b/script.js
@@ -2361,9 +2361,13 @@ function buildDesktopCard(a){
   const service = a.service || 'PB';
   const car = (a.car || '').toUpperCase();
   const clientNameStr = a.client_name ? a.client_name : '';
+  let _extraDisplay = a.extra || '';
+  if (_extraDisplay) {
+    try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
+  }
   const sub = loja
-    ? [clientNameStr, a.extra, a.notes].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, a.extra, a.notes].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Problema

O `script-tail.js` (renderizador dos cartões móveis) tinha o mesmo bug — usava `a.extra` diretamente no HTML, mostrando o JSON em bruto ao utilizador.

## Correção

Igual ao PR #3: extrai apenas o `eurocode` do JSON antes de incluir no cartão.

https://claude.ai/code/session_01XwF4rKXz3KTxXkWq4fvnJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwF4rKXz3KTxXkWq4fvnJX)_