### PR TITLE
fix: corrigir lógica da função Não atendeu nos pedidos comerciais

### DIFF
--- a/commercial-requests-poll.js
+++ b/commercial-requests-poll.js
@@ -192,6 +192,7 @@ function sugerirDataParaLocalidade(locality) {
 
   const POLL_INTERVAL = 30000;
   const BANNER_ID = 'crBannerContainer';
+  const _noAnswerState = {}; // { [requestId]: remindAtTimestamp }
 
   function shouldRun() {
     var role = window.authClient && window.authClient.getUser && window.authClient.getUser() && window.authClient.getUser().role;
@@ -327,6 +328,22 @@ function sugerirDataParaLocalidade(locality) {
     card.appendChild(metaEl);
     card.appendChild(agBtn);
     card.appendChild(naBtn);
+
+    // Restaurar estado "não atendeu" se ainda activo (sobrevive ao rebuild do poll)
+    var naRemind = _noAnswerState[req.id];
+    if (naRemind && naRemind > Date.now()) {
+      var rD = new Date(naRemind);
+      var remStr = String(rD.getHours()).padStart(2,'0') + ':' + String(rD.getMinutes()).padStart(2,'0');
+      card.classList.remove('cr-orange', 'cr-red');
+      card.classList.add('cr-no-answer');
+      naBtn.disabled = true;
+      naBtn.textContent = '⏳ Aguardar até ' + remStr;
+      var remBadge = document.createElement('div');
+      remBadge.className = 'cr-reminder';
+      remBadge.textContent = '🔔 Ligar novamente às ' + remStr;
+      card.appendChild(remBadge);
+    }
+
     return card;
   }
 
@@ -503,6 +520,9 @@ function sugerirDataParaLocalidade(locality) {
     btn.disabled = true;
     btn.textContent = '⏳ Aguardar até ' + remindStr;
 
+    // Guardar estado para sobreviver ao rebuild do poll
+    _noAnswerState[id] = remind.getTime();
+
     // Notificar comercial via Telegram
     if (window.authClient && window.authClient.authenticatedFetch) {
       window.authClient.authenticatedFetch('/.netlify/functions/commercial-request', {
@@ -514,11 +534,13 @@ function sugerirDataParaLocalidade(locality) {
 
     // Reativar ao chegar a hora
     setTimeout(function() {
+      delete _noAnswerState[id];
       var c2 = document.getElementById('crCard-' + id);
       var b2 = document.getElementById('crBtnNA-' + id);
       if (!c2 || !b2) return;
       c2.classList.remove('cr-no-answer');
-      c2.classList.add('cr-orange');
+      var currentAgeMin = (Date.now() - new Date(req.created_at).getTime()) / 60000;
+      c2.classList.add(currentAgeMin > 60 ? 'cr-red' : 'cr-orange');
       b2.disabled = false;
       b2.textContent = '📞 Tentar de novo';
       var bdg = c2.querySelector('.cr-reminder');

--- a/netlify/functions/commercial-request.js
+++ b/netlify/functions/commercial-request.js
@@ -51,6 +51,19 @@ exports.handler = async (event) => {
       const p = event.queryStringParameters || {};
       const portalId = p.portal_id ? parseInt(p.portal_id) : null;
 
+      // Admin sem portal seleccionado — todos os pedidos pendentes
+      if (p.all === '1') {
+        const { rows } = await pool.query(`
+          SELECT cr.*, u.username as commercial_name
+          FROM commercial_requests cr
+          JOIN users u ON u.id = cr.commercial_id
+          WHERE cr.status = 'pending'
+            AND cr.created_at > NOW() - INTERVAL '7 days'
+          ORDER BY cr.created_at DESC
+        `);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, requests: rows }) };
+      }
+
       // Comercial a ver os seus próprios pedidos
       if (p.mine === '1') {
         const { rows } = await pool.query(`


### PR DESCRIPTION
$(cat <<'EOF'
## Problemas encontrados e corrigidos

### Bug 1 (Crítico) — Estado "Não atendeu" reiniciava a cada 30 segundos
`renderBanner` fazia `container.innerHTML = ''` e reconstruía todos os cartões do zero. Qualquer cartão marcado como "Não atendeu" perdia o estado visual (cinzento + badge de lembrete) no próximo ciclo de polling, mesmo com o `setTimeout` de 30 min ainda ativo.

**Correção:** Introduzido `_noAnswerState` (mapa em memória) que persiste `{ [requestId]: remindAtTimestamp }`. O `buildCard` verifica este mapa ao reconstruir e restaura o visual, o botão desativado e o badge de lembrete.

### Bug 2 (Crítico) — `?all=1` ignorado no handler GET do backend
`fetchPendingRequests` envia GET `?all=1` quando não há portal selecionado (admin), mas o backend só tratava `all=1` no handler POST. No handler GET, o parâmetro era ignorado e caía no `else` que retornava apenas os pedidos do próprio utilizador — admin não via nada.

**Correção:** Adicionado bloco explícito `if (p.all === '1')` no handler GET com a query correta (todos os pedidos `pending` dos últimos 7 dias).

### Bug 3 (Menor) — Reativação após 30 min sempre usava `cr-orange`
Após o timer de 30 min, o cartão recebia sempre a classe `cr-orange` independentemente da idade real do pedido. Pedidos com >60 min de espera deveriam ser `cr-red`.

**Correção:** A urgência é agora calculada no momento da reativação com base na idade atual do pedido.

## Ficheiros alterados
- `commercial-requests-poll.js` — estado persistente + urgência correta
- `netlify/functions/commercial-request.js` — handler GET para `all=1`

https://claude.ai/code/session_01963KiRARV4x9uaajuc8NwT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01963KiRARV4x9uaajuc8NwT)_