### PR TITLE
feat: Flash Glass — concurso semanal de fotografia

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Painel Administrativo - Expressglass</title>
   <link rel="stylesheet" href="admin-style.css">
+  <link rel="stylesheet" href="flash-glass.css?v=2026-05-18a">
 </head>
 <body>
   <div class="admin-container">
@@ -30,6 +31,7 @@
       <button class="nav-tab" data-tab="settings">⚙️ Configurações</button>
       <button class="nav-tab" data-tab="reports">📊 Relatórios</button>
       <button class="nav-tab" data-tab="audit">🔍 Auditoria</button>
+      <button class="nav-tab" data-tab="flashglass">📸 Flash Glass</button>
     </nav>
 
     <!-- Tab Content: Portais -->
@@ -344,6 +346,54 @@
     <div id="auditPagination" style="display:flex;gap:8px;justify-content:center;margin-top:16px;"></div>
   </div>
 
+    <!-- Tab: Flash Glass -->
+    <div id="flashglassTab" class="tab-content">
+      <div class="content-header">
+        <h2>📸 Flash Glass — Concurso Semanal</h2>
+        <button onclick="fgAdmin.openCreateForm()" class="btn-primary">+ Novo Concurso</button>
+      </div>
+
+      <!-- Create/Edit Form -->
+      <div id="fgCreateForm" class="fg-admin-create-form" style="display:none;">
+        <h3>📅 Criar Concurso Semanal</h3>
+        <div class="fg-form-row">
+          <div class="fg-form-group" style="flex:0 0 170px;">
+            <label>Semana (2ª feira)</label>
+            <input type="date" id="fgWeekStart" />
+          </div>
+          <div class="fg-form-group" style="flex:2;">
+            <label>Tema *</label>
+            <input type="text" id="fgThemeInput" placeholder="Ex: A Melhor Refeição" maxlength="100" />
+          </div>
+          <div class="fg-form-group" style="flex:3;">
+            <label>Descrição (opcional)</label>
+            <input type="text" id="fgDescInput" placeholder="Ex: Mostrem o vosso talento!" maxlength="200" />
+          </div>
+          <button class="fg-btn-primary" onclick="fgAdmin.saveContest()">Guardar</button>
+          <button onclick="fgAdmin.closeCreateForm()" style="padding:9px 16px;background:#fff;border:1px solid #d1d5db;border-radius:8px;cursor:pointer;font-size:14px;">Cancelar</button>
+        </div>
+      </div>
+
+      <!-- Contests List -->
+      <div id="fgContestsList" class="fg-contests-list">
+        <div style="color:#94a3b8;text-align:center;padding:32px;">A carregar...</div>
+      </div>
+
+      <!-- Submissions Panel -->
+      <div id="fgAdminSubmissionsPanel" style="display:none;">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;flex-wrap:wrap;gap:10px;">
+          <h4 id="fgSubmissionsPanelTitle" style="margin:0;">Submissões</h4>
+          <div style="display:flex;gap:8px;">
+            <button id="fgPublishBtn" class="fg-btn-publish" onclick="fgAdmin.publishMural()">🚀 Publicar Mural</button>
+            <button onclick="fgAdmin.closeSubmissions()" style="padding:7px 14px;background:#fff;border:1px solid #d1d5db;border-radius:8px;cursor:pointer;font-size:13px;">✕ Fechar</button>
+          </div>
+        </div>
+        <div id="fgAdminSubsGrid" class="fg-submissions-grid">
+          <div style="color:#94a3b8;padding:20px;">A carregar submissões...</div>
+        </div>
+      </div>
+    </div>
+
 </div><!-- fim admin-container -->
 
   <!-- Modal: Portal -->
@@ -576,5 +626,6 @@
   </script>
   <script src="admin-comercial-patch.js"></script>
   <script src="admin-coord-only.js?v=2026-05-01"></script>
+  <script src="flash-glass-admin.js?v=2026-05-18a"></script>
 </body>
 </html>

--- a/flash-glass-admin.js
+++ b/flash-glass-admin.js
@@ -1,0 +1,201 @@
+// flash-glass-admin.js — Admin panel for Flash Glass photo contest
+(function () {
+  'use strict';
+
+  let activeContestId = null;
+  const API = '/.netlify/functions/flash-glass';
+
+  async function api(method, qs = {}, body = null) {
+    const token = window.authClient?.getToken();
+    const url = new URL(API, window.location.origin);
+    Object.entries(qs).forEach(([k, v]) => url.searchParams.set(k, v));
+    const opts = {
+      method,
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+    };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch(url, opts);
+    return res.json();
+  }
+
+  async function loadContests() {
+    const list = document.getElementById('fgContestsList');
+    if (!list) return;
+    list.innerHTML = '<div style="color:#94a3b8;text-align:center;padding:32px;">A carregar...</div>';
+    try {
+      const data = await api('GET', { action: 'all-contests' });
+      if (!data.success) { list.innerHTML = '<div style="color:#dc2626;padding:20px;">Erro ao carregar concursos.</div>'; return; }
+      if (!data.contests.length) {
+        list.innerHTML = '<div style="color:#94a3b8;text-align:center;padding:32px;">Nenhum concurso criado ainda. Clique em "+ Novo Concurso" para começar.</div>';
+        return;
+      }
+      list.innerHTML = data.contests.map(c => renderContestRow(c)).join('');
+    } catch (e) {
+      list.innerHTML = `<div style="color:#dc2626;padding:20px;">Erro: ${e.message}</div>`;
+    }
+  }
+
+  function renderContestRow(c) {
+    const ws = new Date(c.week_start + 'T12:00:00');
+    const we = new Date(ws); we.setDate(we.getDate() + 6);
+    const fmt = d => d.toLocaleDateString('pt-PT', { day: 'numeric', month: 'short', year: 'numeric' });
+    const badge = c.published
+      ? '<span class="fg-contest-badge fg-badge-published">✓ Publicado</span>'
+      : '<span class="fg-contest-badge fg-badge-pending">⏳ Pendente</span>';
+    return `
+      <div class="fg-contest-row">
+        <div class="fg-contest-info">
+          <div class="fg-contest-week">${fmt(ws)} – ${fmt(we)}</div>
+          <div class="fg-contest-theme">${escHtml(c.theme)}</div>
+          <div class="fg-contest-meta">${c.submission_count} submissões${c.description ? ' · ' + escHtml(c.description) : ''}</div>
+        </div>
+        ${badge}
+        <div style="display:flex;gap:8px;">
+          <button class="fg-btn-view" onclick="fgAdmin.viewSubmissions('${c.week_start}', ${c.id}, ${c.published})">👁 Ver Fotos</button>
+          ${!c.published ? `<button onclick="fgAdmin.editContest(${c.id}, '${c.week_start}', '${escHtml(c.theme)}', '${escHtml(c.description || '')}')" style="padding:7px 12px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;cursor:pointer;font-size:13px;">✏️ Editar</button>` : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  async function viewSubmissions(weekStart, contestId, published) {
+    activeContestId = contestId;
+    const panel = document.getElementById('fgAdminSubmissionsPanel');
+    const grid = document.getElementById('fgAdminSubsGrid');
+    const titleEl = document.getElementById('fgSubmissionsPanelTitle');
+    const publishBtn = document.getElementById('fgPublishBtn');
+
+    const ws = new Date(weekStart + 'T12:00:00');
+    const we = new Date(ws); we.setDate(we.getDate() + 6);
+    const fmt = d => d.toLocaleDateString('pt-PT', { day: 'numeric', month: 'short' });
+    if (titleEl) titleEl.textContent = `Submissões — ${fmt(ws)} a ${fmt(we)}`;
+    if (publishBtn) publishBtn.style.display = published ? 'none' : '';
+
+    panel.style.display = 'block';
+    grid.innerHTML = '<div style="color:#94a3b8;padding:20px;">A carregar...</div>';
+    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    try {
+      const data = await api('GET', { action: 'week-submissions', week_start: weekStart });
+      if (!data.success) { grid.innerHTML = '<div style="color:#dc2626;">Erro ao carregar.</div>'; return; }
+      if (!data.submissions.length) {
+        grid.innerHTML = '<div style="color:#94a3b8;padding:20px;">Sem submissões ainda nesta semana.</div>';
+        return;
+      }
+      const medals = ['', '🥇', '🥈', '🥉'];
+      grid.innerHTML = data.submissions.map(s => `
+        <div class="fg-admin-sub-card">
+          <img src="${s.photo_data}" alt="${escHtml(s.username)}" loading="lazy">
+          <div class="fg-admin-sub-info">
+            ${medals[s.medal] || ''} ${escHtml(s.username)}
+            <small>⭐ ${s.vote_count} votos</small>
+            <small>${new Date(s.submitted_at).toLocaleDateString('pt-PT')}</small>
+          </div>
+        </div>
+      `).join('');
+    } catch (e) {
+      grid.innerHTML = `<div style="color:#dc2626;">Erro: ${e.message}</div>`;
+    }
+  }
+
+  function closeSubmissions() {
+    document.getElementById('fgAdminSubmissionsPanel').style.display = 'none';
+    activeContestId = null;
+  }
+
+  async function publishMural() {
+    if (!activeContestId) return;
+    if (!confirm('Publicar o mural desta semana? Esta ação atribui as medalhas com base nos votos atuais.')) return;
+    try {
+      const data = await api('POST', {}, { action: 'publish-mural', contest_id: activeContestId });
+      if (data.success) {
+        showAdminToast('✅ Mural publicado com sucesso!', 'success');
+        closeSubmissions();
+        loadContests();
+      } else {
+        showAdminToast(data.error || 'Erro ao publicar.', 'error');
+      }
+    } catch (e) {
+      showAdminToast('Erro: ' + e.message, 'error');
+    }
+  }
+
+  function openCreateForm() {
+    const form = document.getElementById('fgCreateForm');
+    form.style.display = 'block';
+    // Default to next Monday
+    const today = new Date();
+    const day = today.getDay();
+    const daysToNextMonday = day === 0 ? 1 : 8 - day;
+    const nextMonday = new Date(today);
+    nextMonday.setDate(today.getDate() + daysToNextMonday);
+    document.getElementById('fgWeekStart').value = nextMonday.toISOString().split('T')[0];
+    document.getElementById('fgThemeInput').value = '';
+    document.getElementById('fgDescInput').value = '';
+    form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function closeCreateForm() {
+    document.getElementById('fgCreateForm').style.display = 'none';
+  }
+
+  function editContest(id, weekStart, theme, desc) {
+    openCreateForm();
+    document.getElementById('fgWeekStart').value = weekStart;
+    document.getElementById('fgThemeInput').value = theme;
+    document.getElementById('fgDescInput').value = desc;
+  }
+
+  async function saveContest() {
+    const weekStart = document.getElementById('fgWeekStart').value;
+    const theme = document.getElementById('fgThemeInput').value.trim();
+    const desc = document.getElementById('fgDescInput').value.trim();
+    if (!weekStart || !theme) { showAdminToast('Preenche a semana e o tema.', 'error'); return; }
+
+    // Ensure it's a Monday
+    const d = new Date(weekStart + 'T12:00:00');
+    if (d.getDay() !== 1) { showAdminToast('A data deve ser uma segunda-feira.', 'error'); return; }
+
+    try {
+      const data = await api('POST', {}, { action: 'create-contest', week_start: weekStart, theme, description: desc });
+      if (data.success) {
+        showAdminToast('✅ Concurso guardado!', 'success');
+        closeCreateForm();
+        loadContests();
+      } else {
+        showAdminToast(data.error || 'Erro ao guardar.', 'error');
+      }
+    } catch (e) {
+      showAdminToast('Erro: ' + e.message, 'error');
+    }
+  }
+
+  function escHtml(str) {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function showAdminToast(msg, type) {
+    if (typeof window.showToast === 'function') { window.showToast(msg, type); return; }
+    const el = Object.assign(document.createElement('div'), { textContent: msg });
+    Object.assign(el.style, {
+      position: 'fixed', bottom: '30px', right: '30px',
+      background: type === 'error' ? '#dc2626' : '#16a34a',
+      color: '#fff', padding: '12px 20px', borderRadius: '10px',
+      zIndex: '9999', fontSize: '14px', fontWeight: '600',
+      boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
+    });
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3500);
+  }
+
+  // Hook into admin tab switching
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.nav-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        if (tab.dataset.tab === 'flashglass') loadContests();
+      });
+    });
+  });
+
+  window.fgAdmin = { openCreateForm, closeCreateForm, saveContest, editContest, viewSubmissions, closeSubmissions, publishMural, loadContests };
+})();

--- a/flash-glass-admin.js
+++ b/flash-glass-admin.js
@@ -36,7 +36,8 @@
   }
 
   function renderContestRow(c) {
-    const ws = new Date(c.week_start + 'T12:00:00');
+    const rawDate = String(c.week_start).substring(0, 10);
+    const ws = new Date(rawDate + 'T12:00:00');
     const we = new Date(ws); we.setDate(we.getDate() + 6);
     const fmt = d => d.toLocaleDateString('pt-PT', { day: 'numeric', month: 'short', year: 'numeric' });
     const badge = c.published
@@ -123,13 +124,13 @@
   function openCreateForm() {
     const form = document.getElementById('fgCreateForm');
     form.style.display = 'block';
-    // Default to next Monday
+    // Default to current week's Monday
     const today = new Date();
     const day = today.getDay();
-    const daysToNextMonday = day === 0 ? 1 : 8 - day;
-    const nextMonday = new Date(today);
-    nextMonday.setDate(today.getDate() + daysToNextMonday);
-    document.getElementById('fgWeekStart').value = nextMonday.toISOString().split('T')[0];
+    const daysToMonday = day === 0 ? 6 : day - 1;
+    const monday = new Date(today);
+    monday.setDate(today.getDate() - daysToMonday);
+    document.getElementById('fgWeekStart').value = monday.toISOString().split('T')[0];
     document.getElementById('fgThemeInput').value = '';
     document.getElementById('fgDescInput').value = '';
     form.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/flash-glass.css
+++ b/flash-glass.css
@@ -1,0 +1,578 @@
+/* =====================================================
+   FLASH GLASS - Weekly Photo Contest Styles
+   ===================================================== */
+
+/* ── Button ── */
+.header-btn.fg-btn {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: #fff;
+  border: none;
+  position: relative;
+}
+.header-btn.fg-btn.fg-submitted::after {
+  content: '✓';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #22c55e;
+  color: #fff;
+  font-size: 9px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  line-height: 14px;
+  text-align: center;
+}
+
+.fg-mobile-btn {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 8px 4px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  position: relative;
+}
+.fg-mobile-btn.fg-submitted::after {
+  content: '✓';
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: #22c55e;
+  color: #fff;
+  font-size: 9px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  line-height: 14px;
+  text-align: center;
+}
+
+/* ── Main Modal ── */
+#flashGlassModal .modal-content {
+  max-width: 420px;
+  border-radius: 20px;
+  overflow: hidden;
+}
+.fg-modal-header {
+  background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+  padding: 20px 24px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fg-modal-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.fg-modal-title .fg-logo-text {
+  font-size: 20px;
+  font-weight: 900;
+  color: #f59e0b;
+  letter-spacing: -0.5px;
+}
+.fg-modal-title .fg-slogan {
+  font-size: 11px;
+  color: #94a3b8;
+  font-style: italic;
+}
+.fg-theme-banner {
+  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+  margin: 0;
+  padding: 18px 24px;
+  text-align: center;
+}
+.fg-theme-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: #93c5fd;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+.fg-theme-text {
+  font-size: 22px;
+  font-weight: 900;
+  color: #fff;
+  line-height: 1.2;
+}
+.fg-theme-desc {
+  font-size: 13px;
+  color: #bfdbfe;
+  margin-top: 6px;
+}
+.fg-modal-body {
+  padding: 20px 24px;
+  background: #0f172a;
+}
+.fg-status-ok {
+  color: #22c55e;
+  font-size: 13px;
+  font-weight: 600;
+}
+.fg-status-pending {
+  color: #94a3b8;
+  font-size: 13px;
+}
+.fg-action-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 16px;
+}
+.fg-action-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 12px;
+  border: none;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.fg-action-btn:active { transform: scale(0.97); }
+.fg-action-btn .fg-btn-icon { font-size: 26px; }
+.fg-action-btn.primary {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: #fff;
+  grid-column: 1 / -1;
+  flex-direction: row;
+  justify-content: center;
+  gap: 10px;
+  padding: 18px;
+  font-size: 15px;
+}
+.fg-action-btn.secondary { background: #1e293b; color: #94a3b8; }
+.fg-action-btn.mural { background: #1e293b; color: #818cf8; }
+.fg-action-btn.ranking { background: #1e293b; color: #fbbf24; }
+.fg-action-btns-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+/* ── Camera Modal ── */
+#flashCameraModal .modal-content {
+  max-width: 500px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #000;
+}
+.fg-camera-header {
+  background: #0f172a;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fg-camera-header h3 { color: #f59e0b; font-size: 16px; margin: 0; }
+#fgCameraStep {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#fgCameraVideo {
+  width: 100%;
+  max-height: 70vh;
+  object-fit: cover;
+  display: block;
+}
+.fg-capture-bar {
+  background: #0f172a;
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+}
+.fg-capture-btn {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: #fff;
+  border: 4px solid #f59e0b;
+  cursor: pointer;
+  transition: transform 0.1s, background 0.1s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+}
+.fg-capture-btn:active { transform: scale(0.92); background: #f3f4f6; }
+
+#fgPreviewStep {
+  flex-direction: column;
+  align-items: center;
+}
+#fgPreviewImg {
+  width: 100%;
+  max-height: 70vh;
+  object-fit: contain;
+  display: block;
+  background: #000;
+}
+.fg-preview-bar {
+  background: #0f172a;
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 40px;
+}
+.fg-preview-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: transform 0.1s;
+}
+.fg-preview-action:active { transform: scale(0.93); }
+.fg-preview-action .fg-paction-icon {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+}
+.fg-preview-action.retake .fg-paction-icon { background: #374151; color: #d1d5db; }
+.fg-preview-action.confirm .fg-paction-icon { background: #22c55e; color: #fff; }
+.fg-preview-action.retake { color: #9ca3af; }
+.fg-preview-action.confirm { color: #22c55e; }
+
+/* ── Mural Modal ── */
+#flashMuralModal .modal-content {
+  max-width: 700px;
+  max-height: 90vh;
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.fg-mural-modal-header {
+  background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+.fg-mural-modal-header h3 { color: #f59e0b; margin: 0; font-size: 18px; }
+.fg-mural-scroll {
+  overflow-y: auto;
+  padding: 20px;
+  background: #0f172a;
+  flex: 1;
+}
+
+.fg-mural-card {
+  background: #1e293b;
+  border-radius: 16px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.fg-mural-card-header {
+  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+  padding: 14px 18px;
+}
+.fg-mural-week-label {
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: #93c5fd;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.fg-mural-theme-name {
+  font-size: 18px;
+  font-weight: 900;
+  color: #fff;
+  margin-top: 2px;
+}
+.fg-mural-date-range {
+  font-size: 12px;
+  color: #bfdbfe;
+  margin-top: 2px;
+}
+.fg-photos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 2px;
+  padding: 2px;
+}
+.fg-photo-card {
+  position: relative;
+  aspect-ratio: 1;
+  overflow: hidden;
+  cursor: pointer;
+  background: #0f172a;
+}
+.fg-photo-card.fg-gold { outline: 3px solid #f59e0b; }
+.fg-photo-card.fg-silver { outline: 3px solid #94a3b8; }
+.fg-photo-card.fg-bronze { outline: 3px solid #cd7c3a; }
+.fg-photo-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.2s;
+}
+.fg-photo-card:hover .fg-photo-img { transform: scale(1.05); }
+.fg-photo-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(transparent, rgba(0,0,0,0.85));
+  padding: 20px 8px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.fg-medal-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  font-size: 20px;
+  filter: drop-shadow(0 1px 3px rgba(0,0,0,0.5));
+}
+.fg-photo-author {
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.8);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fg-vote-btn {
+  background: rgba(255,255,255,0.15);
+  border: 1px solid rgba(255,255,255,0.3);
+  color: #fff;
+  border-radius: 12px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  white-space: nowrap;
+}
+.fg-vote-btn:hover { background: rgba(245,158,11,0.4); }
+.fg-vote-btn.fg-voted { background: #f59e0b; border-color: #f59e0b; color: #fff; }
+.fg-vote-btn:active { transform: scale(0.93); }
+.fg-vote-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.fg-empty-photos {
+  padding: 24px;
+  text-align: center;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+/* ── Ranking Modal ── */
+#flashRankingModal .modal-content {
+  max-width: 500px;
+  max-height: 85vh;
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.fg-ranking-header {
+  background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+.fg-ranking-header h3 { color: #f59e0b; margin: 0; font-size: 18px; }
+.fg-ranking-scroll { overflow-y: auto; background: #0f172a; flex: 1; padding: 16px; }
+
+.fg-ranking-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  color: #e2e8f0;
+}
+.fg-ranking-table th {
+  text-align: left;
+  padding: 8px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: #64748b;
+  text-transform: uppercase;
+  border-bottom: 1px solid #1e293b;
+}
+.fg-ranking-table td { padding: 10px 10px; border-bottom: 1px solid #1e293b; }
+.fg-ranking-table tr.fg-rank-top td { color: #fff; font-weight: 700; }
+.fg-ranking-table tr:first-child td { color: #f59e0b; }
+.fg-ranking-table tr:hover td { background: #1e293b; }
+
+/* ── Shared ── */
+.fg-loading, .fg-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: #64748b;
+  font-size: 14px;
+}
+.fg-close-btn {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 22px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.fg-close-btn:hover { color: #e2e8f0; }
+
+/* ── Admin tab ── */
+.fg-admin-section { padding: 24px; max-width: 900px; }
+.fg-admin-create-form {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 28px;
+}
+.fg-admin-create-form h3 { margin: 0 0 16px; font-size: 16px; color: #1e293b; }
+.fg-form-row { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
+.fg-form-group { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 150px; }
+.fg-form-group label { font-size: 12px; font-weight: 700; color: #64748b; text-transform: uppercase; letter-spacing: 0.5px; }
+.fg-form-group input, .fg-form-group textarea {
+  padding: 9px 12px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  background: #fff;
+  color: #1e293b;
+  transition: border-color 0.15s;
+}
+.fg-form-group input:focus, .fg-form-group textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+.fg-btn-primary {
+  padding: 9px 20px;
+  background: #f59e0b;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.fg-btn-primary:hover { background: #d97706; }
+.fg-btn-publish {
+  padding: 7px 16px;
+  background: #22c55e;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.fg-btn-publish:hover { background: #16a34a; }
+.fg-btn-view {
+  padding: 7px 16px;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.fg-btn-view:hover { background: #2563eb; }
+.fg-contests-list { margin-top: 0; }
+.fg-contest-row {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 14px 18px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.fg-contest-info { flex: 1; min-width: 160px; }
+.fg-contest-week { font-size: 12px; color: #64748b; font-weight: 600; }
+.fg-contest-theme { font-size: 15px; font-weight: 800; color: #1e293b; }
+.fg-contest-meta { font-size: 12px; color: #94a3b8; margin-top: 2px; }
+.fg-contest-badge {
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.fg-badge-published { background: #dcfce7; color: #16a34a; }
+.fg-badge-pending { background: #fef3c7; color: #d97706; }
+
+/* ── Submissions panel (admin) ── */
+#fgAdminSubmissionsPanel {
+  margin-top: 20px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+}
+#fgAdminSubmissionsPanel h4 { margin: 0 0 14px; color: #1e293b; }
+.fg-submissions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+.fg-admin-sub-card {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 2px solid #e2e8f0;
+  background: #f8fafc;
+}
+.fg-admin-sub-card img { width: 100%; aspect-ratio: 1; object-fit: cover; display: block; }
+.fg-admin-sub-info { padding: 8px; font-size: 12px; color: #374151; font-weight: 600; text-align: center; }
+.fg-admin-sub-info small { display: block; color: #94a3b8; font-weight: 400; font-size: 11px; }
+
+@media (max-width: 600px) {
+  #flashGlassModal .modal-content,
+  #flashMuralModal .modal-content,
+  #flashRankingModal .modal-content {
+    border-radius: 20px 20px 0 0;
+    max-height: 92vh;
+    margin-top: auto;
+  }
+  .fg-photos-grid { grid-template-columns: repeat(2, 1fr); }
+  .fg-action-btns-row { grid-template-columns: 1fr; }
+}

--- a/flash-glass.css
+++ b/flash-glass.css
@@ -2,66 +2,181 @@
    FLASH GLASS - Weekly Photo Contest Styles
    ===================================================== */
 
-/* ── Button ── */
-.header-btn.fg-btn {
-  background: linear-gradient(135deg, #f59e0b, #d97706);
-  color: #fff;
-  border: none;
+/* ══════════════════════════════════════════
+   FLASH GLASS — Contest Banner (desktop)
+   ══════════════════════════════════════════ */
+.fg-contest-banner {
   position: relative;
+  background: linear-gradient(100deg, #08172e 0%, #0f2a52 40%, #1a3a6e 70%, #0e2040 100%);
+  border-bottom: 1px solid rgba(245,158,11,0.25);
+  cursor: pointer;
+  overflow: hidden;
+  transition: filter 0.15s;
 }
-.header-btn.fg-btn.fg-submitted::after {
-  content: '✓';
+.fg-contest-banner:hover { filter: brightness(1.06); }
+
+/* Amber glow pulse */
+.fg-banner-glow {
   position: absolute;
-  top: -4px;
-  right: -4px;
-  background: #22c55e;
-  color: #fff;
-  font-size: 9px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
+  right: -60px; top: 50%;
+  transform: translateY(-50%);
+  width: 300px; height: 300px;
+  background: radial-gradient(circle, rgba(245,158,11,0.18) 0%, transparent 65%);
+  pointer-events: none;
+  animation: fgGlowPulse 3s ease-in-out infinite;
+}
+@keyframes fgGlowPulse {
+  0%, 100% { opacity: 0.7; transform: translateY(-50%) scale(1); }
+  50% { opacity: 1; transform: translateY(-50%) scale(1.15); }
+}
+
+/* Subtle star particles */
+.fg-contest-banner::before {
+  content: '★ ✦ ★';
+  position: absolute;
+  left: 50%; top: 4px;
+  transform: translateX(-50%);
+  font-size: 8px;
+  color: rgba(245,158,11,0.2);
+  letter-spacing: 8px;
+  pointer-events: none;
+}
+
+.fg-banner-inner {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 800;
-  line-height: 14px;
+  padding: 12px 20px;
+  gap: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+/* Logo zone */
+.fg-banner-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.fg-banner-icon {
+  width: 46px; height: 46px;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  border-radius: 13px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 0 0 2px rgba(245,158,11,0.3), 0 4px 16px rgba(245,158,11,0.35);
+  flex-shrink: 0;
+}
+.fg-banner-brand { display: flex; flex-direction: column; gap: 1px; }
+.fg-banner-wordmark { font-size: 17px; font-weight: 900; line-height: 1; letter-spacing: -0.5px; }
+.fg-wm-flash { color: #fff; }
+.fg-wm-glass { color: #f59e0b; }
+.fg-banner-slogan { font-size: 10px; color: #64748b; font-style: italic; }
+
+/* Separator */
+.fg-banner-sep {
+  width: 1px; height: 38px;
+  background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.12), transparent);
+  flex-shrink: 0;
+}
+
+/* Theme zone */
+.fg-banner-theme { flex: 1; min-width: 0; }
+.fg-banner-theme-label {
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 2.5px; text-transform: uppercase;
+  color: #f59e0b; margin-bottom: 3px;
+}
+.fg-banner-theme-name {
+  font-size: 20px; font-weight: 900; color: #fff;
+  line-height: 1.15;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  text-shadow: 0 0 20px rgba(245,158,11,0.3);
+}
+
+/* CTA zone */
+.fg-banner-cta { flex-shrink: 0; display: flex; flex-direction: column; align-items: center; gap: 5px; }
+.fg-banner-participate-btn {
+  display: flex; align-items: center; gap: 7px;
+  background: linear-gradient(135deg, #f59e0b 0%, #e07c00 100%);
+  color: #fff; border: none;
+  border-radius: 30px;
+  padding: 11px 22px;
+  font-size: 13px; font-weight: 900;
+  letter-spacing: 0.8px;
+  cursor: pointer;
+  box-shadow: 0 0 0 2px rgba(245,158,11,0.25), 0 4px 18px rgba(245,158,11,0.4);
+  transition: transform 0.15s, box-shadow 0.15s;
+  white-space: nowrap;
+}
+.fg-banner-participate-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 0 3px rgba(245,158,11,0.3), 0 6px 22px rgba(245,158,11,0.55);
+}
+.fg-banner-participate-btn:active { transform: scale(0.96); }
+.fg-banner-participate-btn.fg-submitted {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  box-shadow: 0 0 0 2px rgba(34,197,94,0.2), 0 4px 14px rgba(34,197,94,0.35);
+}
+.fg-banner-status-text {
+  font-size: 10px; color: #22c55e; font-weight: 600;
   text-align: center;
 }
 
-.fg-mobile-btn {
-  background: linear-gradient(135deg, #f59e0b, #d97706);
-  color: #fff;
-  border: none;
-  border-radius: 10px;
-  padding: 8px 4px;
-  font-size: 12px;
-  font-weight: 700;
+/* ══════════════════════════════════════════
+   FLASH GLASS — Mobile Banner
+   ══════════════════════════════════════════ */
+.fg-banner-mobile {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  background: linear-gradient(95deg, #08172e 0%, #0f2a52 60%, #1a3a6e 100%);
+  border-bottom: 1px solid rgba(245,158,11,0.2);
   cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  min-width: 0;
   position: relative;
+  overflow: hidden;
 }
-.fg-mobile-btn.fg-submitted::after {
-  content: '✓';
+.fg-banner-mobile::after {
+  content: '';
   position: absolute;
-  top: 4px;
-  right: 6px;
-  background: #22c55e;
-  color: #fff;
-  font-size: 9px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 800;
-  line-height: 14px;
-  text-align: center;
+  right: 80px; top: 50%;
+  transform: translateY(-50%);
+  width: 120px; height: 120px;
+  background: radial-gradient(circle, rgba(245,158,11,0.12) 0%, transparent 70%);
+  pointer-events: none;
 }
+.fg-bm-left {
+  display: flex; align-items: center; gap: 9px;
+  min-width: 0; flex: 1;
+}
+.fg-bm-icon {
+  width: 34px; height: 34px;
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  border-radius: 9px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  box-shadow: 0 2px 10px rgba(245,158,11,0.4);
+}
+.fg-bm-wordmark { font-size: 14px; font-weight: 900; line-height: 1; letter-spacing: -0.3px; }
+.fg-bm-theme {
+  font-size: 11px; color: #94a3b8; margin-top: 1px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fg-bm-btn {
+  background: linear-gradient(135deg, #f59e0b, #e07c00);
+  color: #fff; border: none;
+  border-radius: 20px;
+  padding: 8px 14px;
+  font-size: 11px; font-weight: 900;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  flex-shrink: 0;
+  box-shadow: 0 2px 10px rgba(245,158,11,0.35);
+  transition: transform 0.1s;
+}
+.fg-bm-btn:active { transform: scale(0.94); }
+.fg-bm-btn.fg-submitted { background: linear-gradient(135deg, #22c55e, #16a34a); }
 
 /* ── Main Modal ── */
 #flashGlassModal .modal-content {

--- a/flash-glass.js
+++ b/flash-glass.js
@@ -273,7 +273,7 @@
   }
 
   function renderMuralCard(mural) {
-    const ws = new Date(mural.week_start + 'T12:00:00');
+    const ws = new Date(String(mural.week_start).substring(0, 10) + 'T12:00:00');
     const we = new Date(ws); we.setDate(we.getDate() + 6);
     const fmt = d => d.toLocaleDateString('pt-PT', { day: 'numeric', month: 'short' });
     const medals = ['🥇', '🥈', '🥉'];

--- a/flash-glass.js
+++ b/flash-glass.js
@@ -26,8 +26,6 @@
   async function init() {
     if (!window.authClient?.isAuthenticated()) return;
     await loadCurrentContest();
-    document.getElementById('flashGlassBtn')?.addEventListener('click', openMainModal);
-    document.getElementById('flashGlassBtnMobile')?.addEventListener('click', openMainModal);
   }
 
   async function loadCurrentContest() {
@@ -35,33 +33,57 @@
       const data = await api('GET', { action: 'current' });
       if (data.success) {
         currentContest = data.contest;
-        updateButtonState();
+        updateBanners();
       }
     } catch (e) {
       console.error('Flash Glass init:', e);
     }
   }
 
-  function updateButtonState() {
-    const buttons = [
-      document.getElementById('flashGlassBtn'),
-      document.getElementById('flashGlassBtnMobile')
-    ];
-    buttons.forEach(btn => {
-      if (!btn) return;
-      if (currentContest) {
-        btn.style.display = '';
-        if (currentContest.mySubmission) {
-          btn.classList.add('fg-submitted');
-          btn.title = 'Flash Glass — Foto enviada ✓';
-        } else {
-          btn.classList.remove('fg-submitted');
-          btn.title = 'Flash Glass — Participa!';
+  function updateBanners() {
+    const hasContest = !!currentContest;
+    const submitted = hasContest && !!currentContest.mySubmission;
+
+    // ── Desktop banner ──
+    const banner = document.getElementById('fgContestBanner');
+    if (banner) {
+      banner.style.display = hasContest ? '' : 'none';
+      if (hasContest) {
+        const themeEl = document.getElementById('fgBannerTheme');
+        const btn = document.getElementById('fgBannerBtn');
+        const status = document.getElementById('fgBannerStatus');
+        if (themeEl) themeEl.textContent = currentContest.theme;
+        if (btn) {
+          btn.classList.toggle('fg-submitted', submitted);
+          btn.innerHTML = submitted
+            ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> ENVIADA`
+            : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg> PARTICIPAR`;
         }
-      } else {
-        btn.style.display = 'none';
+        if (status) {
+          if (submitted) {
+            const d = new Date(currentContest.mySubmission.updated_at);
+            status.textContent = `✓ ${d.toLocaleDateString('pt-PT', { weekday: 'short', day: 'numeric', month: 'short' })}`;
+          } else {
+            status.textContent = '';
+          }
+        }
       }
-    });
+    }
+
+    // ── Mobile banner ──
+    const bannerM = document.getElementById('fgContestBannerMobile');
+    if (bannerM) {
+      bannerM.style.display = hasContest ? '' : 'none';
+      if (hasContest) {
+        const themeM = document.getElementById('fgBannerThemeMobile');
+        const btnM = document.getElementById('fgBannerBtnMobile');
+        if (themeM) themeM.textContent = currentContest.theme;
+        if (btnM) {
+          btnM.classList.toggle('fg-submitted', submitted);
+          btnM.textContent = submitted ? '✓ ENVIADA' : 'PARTICIPAR';
+        }
+      }
+    }
   }
 
   // ── Main Modal ────────────────────────────────────────────────────────────
@@ -187,6 +209,7 @@
       if (data.success) {
         closeCameraModal();
         await loadCurrentContest();
+        updateBanners();
         showToast('🎉 Foto enviada com sucesso!', 'success');
       } else {
         showToast(data.error || 'Erro ao enviar foto.', 'error');

--- a/flash-glass.js
+++ b/flash-glass.js
@@ -1,0 +1,365 @@
+// flash-glass.js — Frontend module for the Flash Glass weekly photo contest
+(function () {
+  'use strict';
+
+  let currentContest = null;
+  let cameraStream = null;
+  let capturedPhoto = null;
+
+  const API = '/.netlify/functions/flash-glass';
+
+  async function api(method, qs = {}, body = null) {
+    const token = window.authClient?.getToken();
+    const url = new URL(API, window.location.origin);
+    Object.entries(qs).forEach(([k, v]) => url.searchParams.set(k, v));
+    const opts = {
+      method,
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+    };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch(url, opts);
+    return res.json();
+  }
+
+  // ── Init ──────────────────────────────────────────────────────────────────
+
+  async function init() {
+    if (!window.authClient?.isAuthenticated()) return;
+    await loadCurrentContest();
+    document.getElementById('flashGlassBtn')?.addEventListener('click', openMainModal);
+    document.getElementById('flashGlassBtnMobile')?.addEventListener('click', openMainModal);
+  }
+
+  async function loadCurrentContest() {
+    try {
+      const data = await api('GET', { action: 'current' });
+      if (data.success) {
+        currentContest = data.contest;
+        updateButtonState();
+      }
+    } catch (e) {
+      console.error('Flash Glass init:', e);
+    }
+  }
+
+  function updateButtonState() {
+    const buttons = [
+      document.getElementById('flashGlassBtn'),
+      document.getElementById('flashGlassBtnMobile')
+    ];
+    buttons.forEach(btn => {
+      if (!btn) return;
+      if (currentContest) {
+        btn.style.display = '';
+        if (currentContest.mySubmission) {
+          btn.classList.add('fg-submitted');
+          btn.title = 'Flash Glass — Foto enviada ✓';
+        } else {
+          btn.classList.remove('fg-submitted');
+          btn.title = 'Flash Glass — Participa!';
+        }
+      } else {
+        btn.style.display = 'none';
+      }
+    });
+  }
+
+  // ── Main Modal ────────────────────────────────────────────────────────────
+
+  async function openMainModal() {
+    if (!currentContest) {
+      showToast('Não há concurso ativo esta semana.', 'info');
+      return;
+    }
+    const el = id => document.getElementById(id);
+    const theme = el('fgTheme');
+    const desc = el('fgDescription');
+    const status = el('fgStatus');
+    const muralBtn = el('fgMuralBtn');
+
+    if (theme) theme.textContent = currentContest.theme;
+    if (desc) {
+      desc.textContent = currentContest.description || '';
+      desc.style.display = currentContest.description ? '' : 'none';
+    }
+    if (status) {
+      if (currentContest.mySubmission) {
+        const d = new Date(currentContest.mySubmission.updated_at);
+        const ds = d.toLocaleDateString('pt-PT', { weekday: 'short', day: 'numeric', month: 'short' });
+        status.innerHTML = `<span class="fg-status-ok">✓ Foto enviada — ${ds}</span>`;
+      } else {
+        status.innerHTML = `<span class="fg-status-pending">Ainda não participaste esta semana</span>`;
+      }
+    }
+
+    // Show mural btn only if there's a published mural
+    if (muralBtn) {
+      const d = await api('GET', { action: 'mural' });
+      muralBtn.style.display = (d.success && d.murals?.length) ? '' : 'none';
+    }
+
+    document.getElementById('flashGlassModal').classList.add('show');
+  }
+
+  function closeMainModal() {
+    document.getElementById('flashGlassModal')?.classList.remove('show');
+  }
+
+  // ── Camera ────────────────────────────────────────────────────────────────
+
+  async function openCamera() {
+    closeMainModal();
+    const modal = document.getElementById('flashCameraModal');
+    modal.classList.add('show');
+    showCameraStep('camera');
+
+    try {
+      cameraStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' }, width: { ideal: 1280 }, height: { ideal: 960 } },
+        audio: false
+      });
+      const video = document.getElementById('fgCameraVideo');
+      video.srcObject = cameraStream;
+      await video.play();
+    } catch (e) {
+      stopCamera();
+      modal.classList.remove('show');
+      showToast('Não foi possível aceder à câmara. Verifique as permissões.', 'error');
+    }
+  }
+
+  function stopCamera() {
+    if (cameraStream) {
+      cameraStream.getTracks().forEach(t => t.stop());
+      cameraStream = null;
+    }
+  }
+
+  function capturePhoto() {
+    const video = document.getElementById('fgCameraVideo');
+    const raw = document.createElement('canvas');
+    raw.width = video.videoWidth;
+    raw.height = video.videoHeight;
+    raw.getContext('2d').drawImage(video, 0, 0);
+    stopCamera();
+
+    const maxDim = 1200;
+    const scale = Math.min(maxDim / raw.width, maxDim / raw.height, 1);
+    const out = document.createElement('canvas');
+    out.width = Math.round(raw.width * scale);
+    out.height = Math.round(raw.height * scale);
+    out.getContext('2d').drawImage(raw, 0, 0, out.width, out.height);
+    capturedPhoto = out.toDataURL('image/jpeg', 0.75);
+
+    document.getElementById('fgPreviewImg').src = capturedPhoto;
+    showCameraStep('preview');
+  }
+
+  function retakePhoto() {
+    capturedPhoto = null;
+    showCameraStep('camera');
+    navigator.mediaDevices.getUserMedia({ video: { facingMode: { ideal: 'environment' } }, audio: false })
+      .then(stream => {
+        cameraStream = stream;
+        const video = document.getElementById('fgCameraVideo');
+        video.srcObject = stream;
+        video.play();
+      })
+      .catch(() => {
+        closeCameraModal();
+        showToast('Não foi possível aceder à câmara.', 'error');
+      });
+  }
+
+  async function confirmPhoto() {
+    if (!capturedPhoto || !currentContest) return;
+    const btn = document.getElementById('fgConfirmBtn');
+    btn.disabled = true;
+    const origText = btn.innerHTML;
+    btn.innerHTML = '⏳';
+
+    try {
+      const data = await api('POST', {}, {
+        action: 'submit',
+        contest_id: currentContest.id,
+        photo_data: capturedPhoto
+      });
+      if (data.success) {
+        closeCameraModal();
+        await loadCurrentContest();
+        showToast('🎉 Foto enviada com sucesso!', 'success');
+      } else {
+        showToast(data.error || 'Erro ao enviar foto.', 'error');
+        btn.innerHTML = origText;
+        btn.disabled = false;
+      }
+    } catch {
+      showToast('Erro ao enviar foto.', 'error');
+      btn.innerHTML = origText;
+      btn.disabled = false;
+    }
+  }
+
+  function showCameraStep(step) {
+    const camera = document.getElementById('fgCameraStep');
+    const preview = document.getElementById('fgPreviewStep');
+    if (camera) camera.style.display = step === 'camera' ? 'flex' : 'none';
+    if (preview) preview.style.display = step === 'preview' ? 'flex' : 'none';
+  }
+
+  function closeCameraModal() {
+    stopCamera();
+    capturedPhoto = null;
+    document.getElementById('flashCameraModal')?.classList.remove('show');
+  }
+
+  // ── Mural ─────────────────────────────────────────────────────────────────
+
+  async function openMural() {
+    closeMainModal();
+    const modal = document.getElementById('flashMuralModal');
+    const container = document.getElementById('fgMuralContainer');
+    container.innerHTML = '<div class="fg-loading">⏳ A carregar mural...</div>';
+    modal.classList.add('show');
+
+    try {
+      const data = await api('GET', { action: 'mural' });
+      if (!data.success || !data.murals?.length) {
+        container.innerHTML = '<div class="fg-empty">Nenhum mural publicado ainda.</div>';
+        return;
+      }
+      container.innerHTML = data.murals.map(renderMuralCard).join('');
+
+      container.querySelectorAll('.fg-vote-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const contestId = parseInt(btn.dataset.contestId);
+          const subId = parseInt(btn.dataset.subId);
+          btn.disabled = true;
+          const result = await api('POST', {}, { action: 'vote', contest_id: contestId, submission_id: subId });
+          if (result.success) {
+            await openMural(); // refresh
+          } else {
+            showToast(result.error || 'Erro ao votar.', 'error');
+            btn.disabled = false;
+          }
+        });
+      });
+    } catch {
+      container.innerHTML = '<div class="fg-empty">Erro ao carregar mural.</div>';
+    }
+  }
+
+  function renderMuralCard(mural) {
+    const ws = new Date(mural.week_start + 'T12:00:00');
+    const we = new Date(ws); we.setDate(we.getDate() + 6);
+    const fmt = d => d.toLocaleDateString('pt-PT', { day: 'numeric', month: 'short' });
+    const medals = ['🥇', '🥈', '🥉'];
+
+    const photosHtml = mural.submissions.length
+      ? mural.submissions.slice(0, 9).map(s => `
+        <div class="fg-photo-card ${s.medal === 1 ? 'fg-gold' : s.medal === 2 ? 'fg-silver' : s.medal === 3 ? 'fg-bronze' : ''}">
+          ${s.medal >= 1 && s.medal <= 3 ? `<div class="fg-medal-badge">${medals[s.medal - 1]}</div>` : ''}
+          <img src="${s.photo_data}" class="fg-photo-img" loading="lazy" alt="Foto de ${escHtml(s.username)}">
+          <div class="fg-photo-overlay">
+            <span class="fg-photo-author">${escHtml(s.username)}</span>
+            <button class="fg-vote-btn ${mural.myVote === s.id ? 'fg-voted' : ''}"
+              data-contest-id="${mural.id}" data-sub-id="${s.id}">⭐ ${s.vote_count}</button>
+          </div>
+        </div>
+      `).join('')
+      : '<div class="fg-empty-photos">Sem fotos nesta semana</div>';
+
+    return `
+      <div class="fg-mural-card">
+        <div class="fg-mural-card-header">
+          <div class="fg-mural-week-label">Semana</div>
+          <div class="fg-mural-theme-name">📷 ${escHtml(mural.theme)}</div>
+          <div class="fg-mural-date-range">${fmt(ws)} – ${fmt(we)}</div>
+          ${mural.description ? `<div style="font-size:12px;color:#bfdbfe;margin-top:4px;">${escHtml(mural.description)}</div>` : ''}
+        </div>
+        <div class="fg-photos-grid">${photosHtml}</div>
+      </div>
+    `;
+  }
+
+  function closeMuralModal() {
+    document.getElementById('flashMuralModal')?.classList.remove('show');
+  }
+
+  // ── Ranking ───────────────────────────────────────────────────────────────
+
+  async function openRanking() {
+    closeMainModal();
+    const modal = document.getElementById('flashRankingModal');
+    const container = document.getElementById('fgRankingContainer');
+    container.innerHTML = '<div class="fg-loading">⏳ A carregar ranking...</div>';
+    modal.classList.add('show');
+
+    try {
+      const data = await api('GET', { action: 'ranking' });
+      if (!data.success || !data.ranking?.length) {
+        container.innerHTML = '<div class="fg-empty">Sem dados de ranking ainda.</div>';
+        return;
+      }
+      const medals = ['🥇', '🥈', '🥉'];
+      container.innerHTML = `
+        <table class="fg-ranking-table">
+          <thead>
+            <tr><th>#</th><th>Técnico</th><th>⭐ Votos</th><th>Fotos</th><th>Medalhas</th></tr>
+          </thead>
+          <tbody>
+            ${data.ranking.map((r, i) => `
+              <tr class="${i < 3 ? 'fg-rank-top' : ''}">
+                <td>${i < 3 ? medals[i] : i + 1}</td>
+                <td>${escHtml(r.username)}</td>
+                <td>${r.total_votes}</td>
+                <td>${r.participations}</td>
+                <td>${'🥇'.repeat(Number(r.gold))}${'🥈'.repeat(Number(r.silver))}${'🥉'.repeat(Number(r.bronze))}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      `;
+    } catch {
+      container.innerHTML = '<div class="fg-empty">Erro ao carregar ranking.</div>';
+    }
+  }
+
+  function closeRankingModal() {
+    document.getElementById('flashRankingModal')?.classList.remove('show');
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  function escHtml(str) {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function showToast(msg, type) {
+    if (typeof window.showToast === 'function') { window.showToast(msg, type); return; }
+    const t = Object.assign(document.createElement('div'), { textContent: msg });
+    Object.assign(t.style, {
+      position: 'fixed', bottom: '90px', left: '50%', transform: 'translateX(-50%)',
+      background: '#1e293b', color: '#fff', padding: '12px 20px',
+      borderRadius: '10px', zIndex: '9999', fontSize: '14px', boxShadow: '0 4px 20px rgba(0,0,0,0.4)'
+    });
+    document.body.appendChild(t);
+    setTimeout(() => t.remove(), 3000);
+  }
+
+  // ── Expose ────────────────────────────────────────────────────────────────
+
+  window.flashGlass = {
+    openMainModal, closeMainModal,
+    openCamera, closeCameraModal, capturePhoto, retakePhoto, confirmPhoto,
+    openMural, closeMuralModal,
+    openRanking, closeRankingModal
+  };
+
+  // Boot after authClient is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => setTimeout(init, 600));
+  } else {
+    setTimeout(init, 600);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@600;700;800;900&family=Figtree:wght@400;500;600;700;800&family=Roboto:wght@400;500&family=Rajdhani:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css?v=2026-05-15b"/>
+  <link rel="stylesheet" href="flash-glass.css?v=2026-05-18a"/>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png">
@@ -131,6 +132,7 @@
           <span id="statusIcon">🌐</span>
           <span id="statusText">Online</span>
         </div>
+        <button id="flashGlassBtn" class="header-btn fg-btn" title="Flash Glass — Participa!" style="display:none;">📸</button>
         <button id="glassAlertBtn" class="header-btn" title="Vidros a Encomendar" onclick="openGlassAlertModal()">⚠️</button>
         <button id="backupBtn" class="header-btn" title="Backup de dados">💾</button>
         <button id="statsBtn" class="header-btn" title="Estatísticas">📊</button>
@@ -232,7 +234,10 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
           </button>
         </div>
-        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
+          <button id="flashGlassBtnMobile" class="fg-mobile-btn" style="display:none;" title="Flash Glass">
+            📸<span style="font-size:10px;">Flash Glass</span>
+          </button>
           <button id="btnRelatorio" class="m-report-btn" style="color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
             Relatório
@@ -623,6 +628,7 @@
   <script src="rota-do-dia-map.js?v=2026-05-14o"></script>
   <script src="timeline-rota.js?v=2026-05-14g"></script>
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
+  <script src="flash-glass.js?v=2026-05-18a"></script>
 
   <script>
     function fillPrintSectionsSafely(){
@@ -635,6 +641,107 @@
       setTimeout(()=>window.print(), 20);
     });
   </script>
+
+  <!-- ══════════════════════════════════════════════
+       FLASH GLASS MODALS
+       ══════════════════════════════════════════════ -->
+
+  <!-- Modal Principal Flash Glass -->
+  <div id="flashGlassModal" class="modal">
+    <div class="modal-content" style="max-width:420px;padding:0;background:#0f172a;border-radius:20px;overflow:hidden;">
+      <div class="fg-modal-header">
+        <div class="fg-modal-title">
+          <span style="font-size:28px;">📸</span>
+          <div>
+            <div class="fg-logo-text">Flash Glass</div>
+            <div class="fg-slogan">O lado divertido da estrada</div>
+          </div>
+        </div>
+        <button class="fg-close-btn" onclick="flashGlass.closeMainModal()">✕</button>
+      </div>
+      <div class="fg-theme-banner">
+        <div class="fg-theme-label">Tema da Semana</div>
+        <div class="fg-theme-text" id="fgTheme">—</div>
+        <div class="fg-theme-desc" id="fgDescription"></div>
+      </div>
+      <div class="fg-modal-body">
+        <div id="fgStatus" style="text-align:center;margin-bottom:14px;"></div>
+        <button class="fg-action-btn primary" onclick="flashGlass.openCamera()">
+          <span class="fg-btn-icon">📷</span>
+          Tirar Foto &amp; Participar
+        </button>
+        <div class="fg-action-btns-row" style="margin-top:10px;">
+          <button id="fgMuralBtn" class="fg-action-btn mural" onclick="flashGlass.openMural()" style="display:none;">
+            <span class="fg-btn-icon">🖼️</span>
+            Ver Mural
+          </button>
+          <button class="fg-action-btn ranking" onclick="flashGlass.openRanking()">
+            <span class="fg-btn-icon">🏆</span>
+            Ranking
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Câmara -->
+  <div id="flashCameraModal" class="modal">
+    <div class="modal-content" style="max-width:500px;padding:0;background:#000;border-radius:20px;overflow:hidden;">
+      <div class="fg-camera-header">
+        <h3>📸 Flash Glass</h3>
+        <button class="fg-close-btn" onclick="flashGlass.closeCameraModal()">✕</button>
+      </div>
+      <!-- Camera step -->
+      <div id="fgCameraStep" style="flex-direction:column;align-items:center;display:flex;">
+        <video id="fgCameraVideo" autoplay playsinline muted
+          style="width:100%;max-height:65vh;object-fit:cover;display:block;background:#111;"></video>
+        <div class="fg-capture-bar">
+          <button class="fg-capture-btn" onclick="flashGlass.capturePhoto()" title="Tirar foto">📷</button>
+        </div>
+      </div>
+      <!-- Preview step -->
+      <div id="fgPreviewStep" style="flex-direction:column;align-items:center;display:none;">
+        <img id="fgPreviewImg" src="" alt="Preview"
+          style="width:100%;max-height:65vh;object-fit:contain;display:block;background:#000;">
+        <div class="fg-preview-bar">
+          <button class="fg-preview-action retake" onclick="flashGlass.retakePhoto()">
+            <div class="fg-paction-icon">↩</div>
+            Repetir
+          </button>
+          <button id="fgConfirmBtn" class="fg-preview-action confirm" onclick="flashGlass.confirmPhoto()">
+            <div class="fg-paction-icon">✓</div>
+            Enviar
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Mural -->
+  <div id="flashMuralModal" class="modal">
+    <div class="modal-content" style="max-width:700px;max-height:90vh;padding:0;background:#0f172a;border-radius:20px;overflow:hidden;display:flex;flex-direction:column;">
+      <div class="fg-mural-modal-header">
+        <h3>🖼️ Mural Flash Glass</h3>
+        <button class="fg-close-btn" onclick="flashGlass.closeMuralModal()">✕</button>
+      </div>
+      <div class="fg-mural-scroll" id="fgMuralContainer">
+        <div class="fg-loading">A carregar...</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Ranking -->
+  <div id="flashRankingModal" class="modal">
+    <div class="modal-content" style="max-width:500px;max-height:85vh;padding:0;background:#0f172a;border-radius:20px;overflow:hidden;display:flex;flex-direction:column;">
+      <div class="fg-ranking-header">
+        <h3>🏆 Ranking Flash Glass</h3>
+        <button class="fg-close-btn" onclick="flashGlass.closeRankingModal()">✕</button>
+      </div>
+      <div class="fg-ranking-scroll" id="fgRankingContainer">
+        <div class="fg-loading">A carregar...</div>
+      </div>
+    </div>
+  </div>
 
   <!-- Modal Não Realizado -->
   <div id="notDoneModal" class="modal" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -132,7 +132,6 @@
           <span id="statusIcon">🌐</span>
           <span id="statusText">Online</span>
         </div>
-        <button id="flashGlassBtn" class="header-btn fg-btn" title="Flash Glass — Participa!" style="display:none;">📸</button>
         <button id="glassAlertBtn" class="header-btn" title="Vidros a Encomendar" onclick="openGlassAlertModal()">⚠️</button>
         <button id="backupBtn" class="header-btn" title="Backup de dados">💾</button>
         <button id="statsBtn" class="header-btn" title="Estatísticas">📊</button>
@@ -142,6 +141,49 @@
     <div id="searchBar" class="search-bar hidden">
       <input type="text" id="searchInput" placeholder="Pesquisar por matrícula, carro ou localidade..." />
       <button id="clearSearch" class="search-clear">✕</button>
+    </div>
+
+    <!-- ══ FLASH GLASS CONTEST BANNER (desktop) ══ -->
+    <div id="fgContestBanner" class="fg-contest-banner" style="display:none;" onclick="flashGlass.openMainModal()">
+      <div class="fg-banner-glow"></div>
+      <div class="fg-banner-inner">
+        <!-- Logo -->
+        <div class="fg-banner-logo">
+          <div class="fg-banner-icon">
+            <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="1" y="9" width="34" height="22" rx="5" fill="#fff" fill-opacity="0.15" stroke="#fff" stroke-opacity="0.3" stroke-width="1.2"/>
+              <rect x="12" y="5" width="10" height="7" rx="3" fill="#fff" fill-opacity="0.15" stroke="#fff" stroke-opacity="0.3" stroke-width="1.2"/>
+              <circle cx="18" cy="20" r="7" fill="#fff" fill-opacity="0.1" stroke="#fff" stroke-opacity="0.6" stroke-width="1.5"/>
+              <circle cx="18" cy="20" r="4" fill="#f59e0b"/>
+              <circle cx="20.5" cy="17.5" r="1.5" fill="#fff" fill-opacity="0.7"/>
+              <line x1="4" y1="13" x2="7" y2="13" stroke="#fff" stroke-opacity="0.6" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="fg-banner-brand">
+            <div class="fg-banner-wordmark">
+              <span class="fg-wm-flash">Flash</span><span class="fg-wm-glass">Glass</span>
+            </div>
+            <div class="fg-banner-slogan">O lado divertido da estrada</div>
+          </div>
+        </div>
+
+        <div class="fg-banner-sep"></div>
+
+        <!-- Theme -->
+        <div class="fg-banner-theme">
+          <div class="fg-banner-theme-label">TEMA DA SEMANA</div>
+          <div class="fg-banner-theme-name" id="fgBannerTheme">—</div>
+        </div>
+
+        <!-- CTA -->
+        <div class="fg-banner-cta">
+          <button id="fgBannerBtn" class="fg-banner-participate-btn" onclick="event.stopPropagation();flashGlass.openMainModal()">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+            PARTICIPAR
+          </button>
+          <div id="fgBannerStatus" class="fg-banner-status-text"></div>
+        </div>
+      </div>
     </div>
 
     <div class="nav-bar">
@@ -221,6 +263,23 @@
     </section>
 
     <section id="mobileDayView" class="mobile-day-container">
+      <!-- ══ FLASH GLASS MOBILE BANNER ══ -->
+      <div id="fgContestBannerMobile" class="fg-banner-mobile" style="display:none;" onclick="flashGlass.openMainModal()">
+        <div class="fg-bm-left">
+          <div class="fg-bm-icon">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18">
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" fill="rgba(255,255,255,0.2)" stroke="#fff" stroke-width="1.5"/>
+              <circle cx="12" cy="13" r="4" fill="#f59e0b"/>
+            </svg>
+          </div>
+          <div>
+            <div class="fg-bm-wordmark"><span class="fg-wm-flash">Flash</span><span class="fg-wm-glass">Glass</span></div>
+            <div class="fg-bm-theme" id="fgBannerThemeMobile">—</div>
+          </div>
+        </div>
+        <button class="fg-bm-btn" id="fgBannerBtnMobile" onclick="event.stopPropagation();flashGlass.openMainModal()">PARTICIPAR</button>
+      </div>
+
       <div class="mobile-day-header">
         <div class="m-nav-row">
           <button id="prevDay" class="m-nav-arrow" aria-label="Dia anterior">
@@ -234,10 +293,7 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
           </button>
         </div>
-        <div style="display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
-          <button id="flashGlassBtnMobile" class="fg-mobile-btn" style="display:none;" title="Flash Glass">
-            📸<span style="font-size:10px;">Flash Glass</span>
-          </button>
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
           <button id="btnRelatorio" class="m-report-btn" style="color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
             Relatório

--- a/netlify/functions/flash-glass.js
+++ b/netlify/functions/flash-glass.js
@@ -1,0 +1,268 @@
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+function getUserFromToken(event) {
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
+  const token = authHeader.substring(7);
+  return jwt.verify(token, JWT_SECRET);
+}
+
+function getCurrentWeekStart() {
+  const today = new Date();
+  const day = today.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - diff);
+  return monday.toISOString().split('T')[0];
+}
+
+async function migrate(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS flash_glass_contests (
+      id SERIAL PRIMARY KEY,
+      week_start DATE NOT NULL UNIQUE,
+      theme TEXT NOT NULL,
+      description TEXT DEFAULT '',
+      published BOOLEAN DEFAULT false,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS flash_glass_submissions (
+      id SERIAL PRIMARY KEY,
+      contest_id INTEGER REFERENCES flash_glass_contests(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL,
+      portal_id INTEGER,
+      username TEXT NOT NULL,
+      photo_data TEXT NOT NULL,
+      vote_count INTEGER DEFAULT 0,
+      medal INTEGER DEFAULT 0,
+      submitted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(contest_id, user_id)
+    )
+  `);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS flash_glass_votes (
+      id SERIAL PRIMARY KEY,
+      contest_id INTEGER REFERENCES flash_glass_contests(id) ON DELETE CASCADE,
+      voter_id INTEGER NOT NULL,
+      submission_id INTEGER REFERENCES flash_glass_submissions(id) ON DELETE CASCADE,
+      voted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(contest_id, voter_id)
+    )
+  `);
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+
+  const client = await pool.connect();
+  try {
+    await migrate(client);
+    const user = getUserFromToken(event);
+    const params = event.queryStringParameters || {};
+    const body = event.body ? JSON.parse(event.body) : {};
+
+    // ---- GET ----
+    if (event.httpMethod === 'GET') {
+      const action = params.action || 'current';
+
+      if (action === 'current') {
+        const weekStart = getCurrentWeekStart();
+        const contestRes = await client.query(
+          'SELECT * FROM flash_glass_contests WHERE week_start = $1', [weekStart]
+        );
+        if (!contestRes.rows.length) {
+          return { statusCode: 200, headers, body: JSON.stringify({ success: true, contest: null }) };
+        }
+        const contest = contestRes.rows[0];
+        const mySubRes = await client.query(
+          'SELECT id, submitted_at, updated_at FROM flash_glass_submissions WHERE contest_id = $1 AND user_id = $2',
+          [contest.id, user.userId]
+        );
+        return {
+          statusCode: 200, headers,
+          body: JSON.stringify({ success: true, contest: { ...contest, mySubmission: mySubRes.rows[0] || null } })
+        };
+      }
+
+      if (action === 'mural') {
+        const muralsRes = await client.query(`
+          SELECT id, week_start, theme, description, published, created_at
+          FROM flash_glass_contests
+          WHERE published = true
+          ORDER BY week_start DESC
+        `);
+        const murals = [];
+        for (const contest of muralsRes.rows) {
+          const subsRes = await client.query(`
+            SELECT id, username, photo_data, vote_count, medal
+            FROM flash_glass_submissions
+            WHERE contest_id = $1
+            ORDER BY vote_count DESC, submitted_at ASC
+          `, [contest.id]);
+          const myVoteRes = await client.query(
+            'SELECT submission_id FROM flash_glass_votes WHERE contest_id = $1 AND voter_id = $2',
+            [contest.id, user.userId]
+          );
+          murals.push({ ...contest, submissions: subsRes.rows, myVote: myVoteRes.rows[0]?.submission_id || null });
+        }
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, murals }) };
+      }
+
+      if (action === 'ranking') {
+        const res = await client.query(`
+          SELECT s.username,
+            SUM(s.vote_count) as total_votes,
+            COUNT(*) as participations,
+            SUM(CASE WHEN s.medal = 1 THEN 1 ELSE 0 END) as gold,
+            SUM(CASE WHEN s.medal = 2 THEN 1 ELSE 0 END) as silver,
+            SUM(CASE WHEN s.medal = 3 THEN 1 ELSE 0 END) as bronze
+          FROM flash_glass_submissions s
+          JOIN flash_glass_contests c ON c.id = s.contest_id AND c.published = true
+          GROUP BY s.username
+          ORDER BY total_votes DESC, participations DESC
+        `);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, ranking: res.rows }) };
+      }
+
+      if (action === 'week-submissions') {
+        if (user.role !== 'admin') return { statusCode: 403, headers, body: JSON.stringify({ error: 'Sem permissão' }) };
+        const weekStart = params.week_start || getCurrentWeekStart();
+        const res = await client.query(`
+          SELECT s.id, s.username, s.photo_data, s.vote_count, s.medal, s.submitted_at, s.updated_at,
+                 c.id as contest_id, c.week_start, c.published
+          FROM flash_glass_submissions s
+          JOIN flash_glass_contests c ON c.id = s.contest_id
+          WHERE c.week_start = $1
+          ORDER BY s.vote_count DESC, s.submitted_at ASC
+        `, [weekStart]);
+        const contestRes = await client.query('SELECT * FROM flash_glass_contests WHERE week_start = $1', [weekStart]);
+        return {
+          statusCode: 200, headers,
+          body: JSON.stringify({ success: true, submissions: res.rows, contest: contestRes.rows[0] || null })
+        };
+      }
+
+      if (action === 'all-contests') {
+        if (user.role !== 'admin') return { statusCode: 403, headers, body: JSON.stringify({ error: 'Sem permissão' }) };
+        const res = await client.query(`
+          SELECT c.*,
+            (SELECT COUNT(*) FROM flash_glass_submissions WHERE contest_id = c.id) as submission_count
+          FROM flash_glass_contests c
+          ORDER BY c.week_start DESC
+        `);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, contests: res.rows }) };
+      }
+    }
+
+    // ---- POST ----
+    if (event.httpMethod === 'POST') {
+      const { action } = body;
+
+      if (action === 'submit') {
+        const { contest_id, photo_data } = body;
+        if (!contest_id || !photo_data) {
+          return { statusCode: 400, headers, body: JSON.stringify({ error: 'Dados inválidos' }) };
+        }
+        const contestRes = await client.query('SELECT id FROM flash_glass_contests WHERE id = $1', [contest_id]);
+        if (!contestRes.rows.length) {
+          return { statusCode: 404, headers, body: JSON.stringify({ error: 'Concurso não encontrado' }) };
+        }
+        await client.query(`
+          INSERT INTO flash_glass_submissions (contest_id, user_id, portal_id, username, photo_data)
+          VALUES ($1, $2, $3, $4, $5)
+          ON CONFLICT (contest_id, user_id)
+          DO UPDATE SET photo_data = $5, updated_at = NOW()
+        `, [contest_id, user.userId, user.portalId, user.username, photo_data]);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
+
+      if (action === 'vote') {
+        const { contest_id, submission_id } = body;
+        const contestRes = await client.query('SELECT id, published FROM flash_glass_contests WHERE id = $1', [contest_id]);
+        if (!contestRes.rows.length || !contestRes.rows[0].published) {
+          return { statusCode: 400, headers, body: JSON.stringify({ error: 'Concurso não disponível para votação' }) };
+        }
+        const ownRes = await client.query(
+          'SELECT id FROM flash_glass_submissions WHERE id = $1 AND user_id = $2',
+          [submission_id, user.userId]
+        );
+        if (ownRes.rows.length) {
+          return { statusCode: 400, headers, body: JSON.stringify({ error: 'Não podes votar na tua própria foto' }) };
+        }
+        const prevVoteRes = await client.query(
+          'SELECT submission_id FROM flash_glass_votes WHERE contest_id = $1 AND voter_id = $2',
+          [contest_id, user.userId]
+        );
+        if (prevVoteRes.rows.length) {
+          const prevSubId = prevVoteRes.rows[0].submission_id;
+          await client.query('UPDATE flash_glass_submissions SET vote_count = vote_count - 1 WHERE id = $1', [prevSubId]);
+          await client.query('DELETE FROM flash_glass_votes WHERE contest_id = $1 AND voter_id = $2', [contest_id, user.userId]);
+        }
+        await client.query(
+          'INSERT INTO flash_glass_votes (contest_id, voter_id, submission_id) VALUES ($1, $2, $3)',
+          [contest_id, user.userId, submission_id]
+        );
+        await client.query('UPDATE flash_glass_submissions SET vote_count = vote_count + 1 WHERE id = $1', [submission_id]);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
+
+      if (action === 'create-contest') {
+        if (user.role !== 'admin') return { statusCode: 403, headers, body: JSON.stringify({ error: 'Sem permissão' }) };
+        const { week_start, theme, description } = body;
+        if (!week_start || !theme) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Dados obrigatórios em falta' }) };
+        const res = await client.query(`
+          INSERT INTO flash_glass_contests (week_start, theme, description)
+          VALUES ($1, $2, $3)
+          ON CONFLICT (week_start) DO UPDATE SET theme = $2, description = $3
+          RETURNING *
+        `, [week_start, theme, description || '']);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, contest: res.rows[0] }) };
+      }
+
+      if (action === 'publish-mural') {
+        if (user.role !== 'admin') return { statusCode: 403, headers, body: JSON.stringify({ error: 'Sem permissão' }) };
+        const { contest_id } = body;
+        await client.query('UPDATE flash_glass_contests SET published = true WHERE id = $1', [contest_id]);
+        // Assign medals to top 3 by vote_count
+        const topRes = await client.query(`
+          SELECT id FROM flash_glass_submissions WHERE contest_id = $1
+          ORDER BY vote_count DESC, submitted_at ASC LIMIT 3
+        `, [contest_id]);
+        await client.query('UPDATE flash_glass_submissions SET medal = 0 WHERE contest_id = $1', [contest_id]);
+        for (let i = 0; i < topRes.rows.length; i++) {
+          await client.query('UPDATE flash_glass_submissions SET medal = $1 WHERE id = $2', [i + 1, topRes.rows[i].id]);
+        }
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Método não suportado' }) };
+
+  } catch (err) {
+    console.error('Flash Glass error:', err);
+    if (err.message === 'Não autenticado' || err.name === 'JsonWebTokenError') {
+      return { statusCode: 401, headers, body: JSON.stringify({ error: 'Não autenticado' }) };
+    }
+    return { statusCode: 500, headers, body: JSON.stringify({ error: err.message }) };
+  } finally {
+    client.release();
+  }
+};

--- a/netlify/functions/flash-glass.js
+++ b/netlify/functions/flash-glass.js
@@ -85,8 +85,10 @@ exports.handler = async (event) => {
 
       if (action === 'current') {
         const weekStart = getCurrentWeekStart();
+        // Find the contest for this week, or the next upcoming one (so admin can create ahead of time)
         const contestRes = await client.query(
-          'SELECT * FROM flash_glass_contests WHERE week_start = $1', [weekStart]
+          'SELECT * FROM flash_glass_contests WHERE week_start >= $1 ORDER BY week_start ASC LIMIT 1',
+          [weekStart]
         );
         if (!contestRes.rows.length) {
           return { statusCode: 200, headers, body: JSON.stringify({ success: true, contest: null }) };


### PR DESCRIPTION
## Flash Glass 📸 — O lado divertido da estrada

Implementação completa do concurso semanal de fotografia para técnicos.

### O que foi feito

**Backend** — `netlify/functions/flash-glass.js`
- Auto-migração de 3 tabelas PostgreSQL (`flash_glass_contests`, `flash_glass_submissions`, `flash_glass_votes`)
- Endpoints: concurso atual, submeter foto, votar, mural publicado, ranking, gestão admin

**Frontend técnicos** — `flash-glass.js` + `flash-glass.css`
- Botão 📸 na agenda (desktop no header, mobile na barra de navegação) — só aparece se houver concurso ativo
- Modal principal: tema da semana + botão "Tirar Foto" + botão "Ver Mural"
- Fluxo câmara: `getUserMedia` → preview → ✓ enviar / ↩ repetir
- Fotos comprimidas para JPEG/1200px antes de enviar (≈100-200KB)
- Uma foto por semana, substituível em qualquer dia
- Modal Mural: cards por semana com fotos, votação ⭐, medalhas 🥇🥈🥉
- Modal Ranking: leaderboard com total de votos e medalhas por técnico

**Painel Admin** — `flash-glass-admin.js` + tab "📸 Flash Glass" em `admin.html`
- Criar tema semanal (semana + tema + descrição)
- Ver todas as submissões de uma semana com preview das fotos
- Publicar mural (atribui medalhas automaticamente ao top 3 por votos)

### Fluxo semanal
1. Admin cria o tema da semana na segunda-feira
2. Técnicos vêem o botão Flash Glass na agenda e participam
3. Podem trocar a foto durante a semana
4. Admin publica o mural (idealmente na segunda-feira seguinte)
5. Técnicos votam nas fotos do mural publicado
6. Medalhas atribuídas automaticamente ao publicar

### Ficheiros novos
- `netlify/functions/flash-glass.js`
- `flash-glass.js`
- `flash-glass.css`
- `flash-glass-admin.js`

### Ficheiros modificados
- `index.html` — botão header/mobile + 4 modais (principal, câmara, mural, ranking)
- `admin.html` — tab Flash Glass + CSS

https://claude.ai/code/session_01HxaBLf4eazMgTRAKx6kJYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxaBLf4eazMgTRAKx6kJYa)_