### PR TITLE
fix: guias AT não apareciam nos cards de marcações

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
         </div>
       </div>
       <!-- Guia AT upload (coordinator/admin only) -->
-      <div id="guiaATUploadArea" style="padding:6px 14px 0; display:flex; flex-direction:column; gap:6px;">
+      <div id="guiaATUploadArea" style="padding:6px 14px 0; display:none; flex-direction:column; gap:6px;">
         <input type="file" id="guiaATFileInput" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
           <button id="guiaATUploadBtn" class="guia-at-upload-btn" onclick="guiaAT.triggerUpload()">

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -32,7 +32,7 @@
 
     document.querySelectorAll('.guia-at-badge').forEach(b => b.remove());
 
-    document.querySelectorAll('.m-card[data-id]').forEach(card => {
+    document.querySelectorAll('.m-card[data-id], .desk-card[data-id]').forEach(card => {
       const appt = appts.find(a => String(a.id) === card.dataset.id);
       if (!appt) return;
       const ec = getEurocode(appt);
@@ -165,7 +165,7 @@
     // Show upload button only for coordinators/admins
     if (isCoordinator()) {
       const uploadArea = document.getElementById('guiaATUploadArea');
-      if (uploadArea) uploadArea.style.display = '';
+      if (uploadArea) uploadArea.style.display = 'flex';
       const uploadAreaDesk = document.getElementById('guiaATUploadAreaDesk');
       if (uploadAreaDesk) uploadAreaDesk.style.display = 'flex';
     }
@@ -178,6 +178,7 @@
       if (data.success && data.guide) {
         todayGuide = data.guide;
         updateUploadBtn();
+        injectBadges();
       }
     } catch (e) { console.error('Transport guide init:', e); }
 
@@ -185,6 +186,12 @@
     const target = document.getElementById('mobileDayList');
     if (target) {
       new MutationObserver(scheduleInject).observe(target, { childList: true, subtree: false });
+    }
+
+    // Observe desktop schedule table for re-renders
+    const scheduleEl = document.getElementById('schedule');
+    if (scheduleEl) {
+      new MutationObserver(scheduleInject).observe(scheduleEl, { childList: true, subtree: false });
     }
 
     // Initial inject (appointments may already be loaded)


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

- **Race condition no carregamento**: `injectBadges()` não era chamado após o fetch do guia no `init()`. Se os cards já estavam renderizados quando o fetch terminava, os crachás nunca apareciam.
- **Desktop ignorado**: `injectBadges()` só procurava `.m-card[data-id]` (mobile). Os cards desktop `.desk-card[data-id]` eram completamente ignorados.
- **MutationObserver só no mobile**: O observer só observava `#mobileDayList`. O `#schedule` (desktop) não tinha observer, logo re-renders do desktop não acionavam a injeção de crachás.
- **Upload area sempre visível**: O `guiaATUploadArea` (mobile) tinha `display:flex` no HTML, aparecendo para todos os utilizadores em vez de só para coordenadores/admins.

## Alterações

- `transport-guide.js`: `injectBadges()` passa a usar `.m-card[data-id], .desk-card[data-id]`
- `transport-guide.js`: Adicionado MutationObserver no `#schedule` (desktop)
- `transport-guide.js`: Chamada a `injectBadges()` imediatamente após o guia ser carregado no `init()`
- `transport-guide.js`: `uploadArea.style.display = 'flex'` (era `''`) para coordenadores
- `index.html`: `guiaATUploadArea` começa como `display:none`

## Plano de testes

- [ ] Carregar um guia AT como coordenador e verificar que os crachás aparecem nos cards mobile e desktop
- [ ] Recarregar a página e verificar que os crachás aparecem automaticamente (sem novo upload)
- [ ] Verificar que utilizadores não-coordenadores não veem o botão de upload

https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q)_