### PR TITLE
fix: crachás Guia AT com startsWith para códigos concatenados pelo pdf-parse

### DIFF
--- a/netlify/functions/transport-guide.js
+++ b/netlify/functions/transport-guide.js
@@ -13,7 +13,7 @@ function getUserFromToken(event) {
 
 function extractEurocodes(text) {
   const upper = text.toUpperCase();
-  const matches = upper.match(/\b\d{4}-?[A-Z]{2,}[0-9A-Z]*\b/g) || [];
+  const matches = upper.match(/\b\d{4}-?[A-Z]{3,}[0-9A-Z]*\b/g) || [];
   return [...new Set(matches.map(m => m.replace(/-/g, '')))];
 }
 

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -36,7 +36,8 @@
       const appt = appts.find(a => String(a.id) === card.dataset.id);
       if (!appt) return;
       const ec = getEurocode(appt);
-      if (!ec || !eurocodes.includes(ec)) return;
+      // Guide codes may have extra suffix (e.g. "6564AGNVZPBL" from pdf-parse table concat)
+      if (!ec || !eurocodes.some(g => g === ec || g.startsWith(ec) || ec.startsWith(g))) return;
 
       const badge = document.createElement('button');
       badge.className = 'guia-at-badge';


### PR DESCRIPTION
## Problema
Os crachás continuavam sem aparecer. O toast mostrava `4 Eurocodes: 2026BO864, 8547AGNGYV1VPBL, 6564AGNVZPBL, 8573BGSHW1JOCL` — o `pdf-parse` concatena as colunas da tabela sem espaços, colando o tipo de vidro (PBL/OCL) ao código. A comparação exata `includes("6564AGNVZ")` falha contra `"6564AGNVZPBL"`.

## Correções
- **Client**: comparação passa a usar `startsWith` — `"6564AGNVZPBL".startsWith("6564AGNVZ")` = true, o crachá aparece
- **Server**: regex usa `[A-Z]{3,}` (era `{2,}`) para eliminar o falso positivo `2026BO864` extraído do número do documento GT

https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q)_