### PR TITLE
Fix PDF viewer on Android (skip iframe, open directly)

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@
     <iframe id="guiaATIframe" title="Guia AT"></iframe>
   </div>
 
-  <script src="transport-guide.js?v=2026-05-19e"></script>
+  <script src="transport-guide.js?v=2026-05-19f"></script>
 
 </body>
 </html>

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -55,22 +55,40 @@
 
   // ── PDF Viewer ───────────────────────────────────────────
 
-  function openViewer() {
-    if (!todayGuide?.pdf_data) return;
-    const modal = document.getElementById('guiaATModal');
-    if (!modal) return;
+  function isMobile() {
+    return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  }
 
-    // Create blob URL for better cross-browser support
+  function makeBlobUrl() {
     const bytes = atob(todayGuide.pdf_data);
     const arr = new Uint8Array(bytes.length);
     for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
-    const blob = new Blob([arr], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
+    return URL.createObjectURL(new Blob([arr], { type: 'application/pdf' }));
+  }
+
+  function openViewer() {
+    if (!todayGuide?.pdf_data) return;
+    const url = makeBlobUrl();
+
+    // Android/iOS can't render PDFs in iframes — open directly in the system viewer
+    if (isMobile()) {
+      const a = document.createElement('a');
+      a.href = url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(() => URL.revokeObjectURL(url), 30000);
+      return;
+    }
+
+    const modal = document.getElementById('guiaATModal');
+    if (!modal) return;
 
     const iframe = document.getElementById('guiaATIframe');
     if (iframe) iframe.src = url;
 
-    // Fallback link for iOS
     const link = document.getElementById('guiaATDownload');
     if (link) { link.href = url; link.download = 'guia-AT.pdf'; }
 


### PR DESCRIPTION
## Summary

- Android Chrome cannot render PDF blob URLs inside `<iframe>` elements — it shows a native "Abrir" prompt that does nothing
- Added `isMobile()` detection (Android/iOS user agent)
- On mobile: creates the blob URL and opens it directly via a programmatic anchor click (`target="_blank"`), which hands off to the system PDF viewer — no modal shown
- On desktop: behaviour unchanged (modal with embedded iframe)

## Test plan

- [ ] Android: tap a "Guia AT" badge — PDF should open directly in the system PDF viewer (no modal, no broken "Abrir" button)
- [ ] iOS: same behaviour — PDF opens in Safari's PDF viewer
- [ ] Desktop (Chrome/Firefox/Safari): modal still opens with embedded iframe as before
- [ ] Blob URL is revoked after 30 s to avoid memory leaks

https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q)_