### PR TITLE
fix: aguardar portalReady antes de carregar guia AT (badges desaparecem no refresh)

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@
     <iframe id="guiaATIframe" title="Guia AT"></iframe>
   </div>
 
-  <script src="transport-guide.js?v=2026-05-19f"></script>
+  <script src="transport-guide.js?v=2026-05-19g"></script>
 
 </body>
 </html>

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -236,9 +236,26 @@
 
   window.guiaAT = { init, openViewer, closeViewer, triggerUpload, handleFileSelected, injectBadges };
 
+  let _initDone = false;
+  function _runInit() {
+    if (_initDone) return;
+    _initDone = true;
+    init();
+  }
+
+  function _waitForPortal() {
+    if (window._portalReadyFired) {
+      _runInit();
+    } else {
+      window.addEventListener('portalReady', _runInit, { once: true });
+      // Fallback: if portalReady never fires (e.g. single-portal user path), run after 3s
+      setTimeout(_runInit, 3000);
+    }
+  }
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => setTimeout(init, 700));
+    document.addEventListener('DOMContentLoaded', _waitForPortal);
   } else {
-    setTimeout(init, 700);
+    _waitForPortal();
   }
 })();


### PR DESCRIPTION
## Problema

Após um refresh, os badges "Guia AT" não apareciam nos cards.

**Causa raiz:** `init()` corria com um timer fixo de 700ms. Em mobile (Android), a sequência de inicialização do portal (`verifyAuth` + fetch de dados do portal) demora mais de 700ms, por isso `window.activePortalId` ainda não estava definido quando o guia era pedido ao servidor. O backend devolvia `guide: null` e os badges não apareciam.

## Fix

Em vez do timer fixo de 700ms, o módulo agora aguarda o evento `portalReady` já disparado pelo `portal-init.js` — que só é emitido depois de `window.activePortalId` estar definido. Fallback de 3s para casos em que o evento não dispare.

## Test plan

- [ ] Fazer refresh da página com guia AT já carregada — badges devem aparecer automaticamente
- [ ] Testar em Android/mobile (conexão lenta) — badges devem aparecer após render dos cards
- [ ] Upload de nova guia continua a funcionar e badges aparecem imediatamente

https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q)_