### PR TITLE
fix: badge Guia AT inline na linha dos km com ícone fiscal

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@600;700;800;900&family=Figtree:wght@400;500;600;700;800&family=Roboto:wght@400;500&family=Rajdhani:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css?v=2026-05-15b"/>
   <link rel="stylesheet" href="flash-glass.css?v=2026-05-18d"/>
-  <link rel="stylesheet" href="transport-guide.css?v=2026-05-19e"/>
+  <link rel="stylesheet" href="transport-guide.css?v=2026-05-19h"/>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png">
@@ -848,7 +848,7 @@
     <iframe id="guiaATIframe" title="Guia AT"></iframe>
   </div>
 
-  <script src="transport-guide.js?v=2026-05-19g"></script>
+  <script src="transport-guide.js?v=2026-05-19h"></script>
 
 </body>
 </html>

--- a/transport-guide.css
+++ b/transport-guide.css
@@ -45,26 +45,30 @@
 
 /* ── Badge on appointment cards ── */
 .guia-at-badge {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 8px;
-  background: #1e40af;
+  padding: 4px 9px;
+  background: rgba(255,255,255,0.18);
   color: #fff;
-  border: none;
+  border: 1px solid rgba(255,255,255,0.3);
   border-radius: 20px;
   font-size: 10px;
   font-weight: 800;
   cursor: pointer;
   letter-spacing: 0.3px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  z-index: 5;
   transition: background 0.15s, transform 0.1s;
+  white-space: nowrap;
 }
-.guia-at-badge:hover { background: #1d4ed8; transform: scale(1.05); }
+.guia-at-badge--inline { margin-left: auto; }
+.guia-at-badge--abs {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  z-index: 5;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+.guia-at-badge:hover { background: rgba(255,255,255,0.28); transform: scale(1.05); }
 .guia-at-badge:active { transform: scale(0.95); }
 
 /* ── Full-screen PDF viewer modal ── */

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -41,10 +41,17 @@
 
       const badge = document.createElement('button');
       badge.className = 'guia-at-badge';
-      badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg> Guia AT';
+      badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg> Guia AT';
       badge.onclick = (e) => { e.stopPropagation(); openViewer(); };
-      card.style.position = 'relative';
-      card.appendChild(badge);
+      const kmRow = card.querySelector('[data-km-row]');
+      if (kmRow) {
+        badge.classList.add('guia-at-badge--inline');
+        kmRow.appendChild(badge);
+      } else {
+        badge.classList.add('guia-at-badge--abs');
+        card.style.position = 'relative';
+        card.appendChild(badge);
+      }
     });
   }
 


### PR DESCRIPTION
## O quê

O badge "Guia AT" aparecia no canto inferior direito do card, sobreposto ao FAB e cortado.

## Fix

- Badge injetado inline dentro da linha dos km (`[data-km-row]`), alinhado à direita via `margin-left: auto`
- Resultado: `🚚 → 34 km ............... 🧾 Guia AT`
- Ícone trocado de documento genérico para recibo fiscal (traços horizontais = linhas de recibo)
- Estilo adaptado: fundo semi-transparente com borda, integra-se na cor do card
- Fallback absoluto mantido para cards sem linha de km (lojas)

https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDdGx7KPuq8RwMXJ8Xa8q)_