### PR TITLE
fix: lembrete Eurocodes filtra apenas portais SM (exclui lojas)

### DIFF
--- a/netlify/functions/tomorrow-eurocodes.js
+++ b/netlify/functions/tomorrow-eurocodes.js
@@ -47,6 +47,7 @@ exports.handler = async (event) => {
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
+          AND COALESCE(p.portal_type, 'sm') = 'sm'
           AND a.extra IS NOT NULL AND a.extra != ''
         ORDER BY p.name, a.id
       `);
@@ -58,6 +59,7 @@ exports.handler = async (event) => {
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
           AND a.portal_id = $1
+          AND COALESCE(p.portal_type, 'sm') = 'sm'
           AND a.extra IS NOT NULL AND a.extra != ''
         ORDER BY a.id
       `, [user.portalId]);


### PR DESCRIPTION
Filtra `portal_type = 'sm'` na query do `tomorrow-eurocodes`, para que o popup de lembrete das 17h e o botão "Amanhã" mostrem apenas Eurocodes de portais SM — excluindo agendas de loja.

---
_Generated by [Claude Code](https://claude.ai/code/session_01512Vjnh3PBKiQ9DF5tUsph)_