### PR TITLE
fix: portal activo tem prioridade sobre portalId do JWT no lembrete de eurocodes

### DIFF
--- a/netlify/functions/tomorrow-eurocodes.js
+++ b/netlify/functions/tomorrow-eurocodes.js
@@ -40,8 +40,8 @@ exports.handler = async (event) => {
     }
 
     const p = event.queryStringParameters || {};
-    // portalId: prefer JWT claim, fall back to query param (admin viewing a specific SM)
-    const portalId = user.portalId || (p.portal_id ? parseInt(p.portal_id) : null);
+    // Prefer active portal from frontend; fall back to JWT portalId
+    const portalId = (p.portal_id ? parseInt(p.portal_id) : null) || user.portalId;
 
     let rows;
     if (user.role === 'admin' && !portalId) {


### PR DESCRIPTION
O backend usava `user.portalId` do JWT com prioridade sobre o `portal_id` enviado pelo frontend — se o coordenador tivesse o JWT de Braga SM mas estivesse a ver Famalicão SM, a query ignorava Famalicão.\n\nInvertida a prioridade: o `portal_id` activo do frontend tem precedência, com fallback para o portalId do JWT.

---
_Generated by [Claude Code](https://claude.ai/code/session_01512Vjnh3PBKiQ9DF5tUsph)_