### PR TITLE
feat: guia AT pode ser carregada para hoje ou amanhã (toggle no menu)

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,6 +859,11 @@
 
   <!-- Guia AT upload menu (shared, coordinator only) -->
   <div id="guiaATMenu" class="guia-at-menu" style="display:none" onclick="event.stopPropagation()">
+    <div class="guia-at-date-toggle">
+      <button id="guiaATDate_hoje" class="guia-at-date-opt active" onclick="guiaAT.setUploadDate('today')">Hoje</button>
+      <button id="guiaATDate_amanha" class="guia-at-date-opt" onclick="guiaAT.setUploadDate('tomorrow')">Amanhã</button>
+    </div>
+    <div class="guia-at-menu-divider"></div>
     <button class="guia-at-menu-item" onclick="guiaAT.triggerFileInput()">
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
       Selecionar PDF

--- a/netlify/functions/transport-guide.js
+++ b/netlify/functions/transport-guide.js
@@ -120,12 +120,20 @@ exports.handler = async (event) => {
         return { statusCode: 403, headers, body: JSON.stringify({ error: 'Sem permissão' }) };
       }
       const body = JSON.parse(event.body || '{}');
-      const { pdf_data, file_type, manual_eurocodes, _portalId } = body;
+      const { pdf_data, file_type, manual_eurocodes, _portalId, guide_date: rawGuideDate } = body;
       if (!pdf_data) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Ficheiro em falta' }) };
 
       let portalId = user.portalId;
       if (!portalId && _portalId) portalId = parseInt(_portalId);
       if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Portal não identificado' }) };
+
+      // guide_date: accept 'today', 'tomorrow', or ISO date string; default today
+      const todayIso = new Date().toISOString().split('T')[0];
+      const tomorrowDate = new Date(); tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+      const tomorrowIso = tomorrowDate.toISOString().split('T')[0];
+      let guideDate = todayIso;
+      if (rawGuideDate === 'tomorrow') guideDate = tomorrowIso;
+      else if (rawGuideDate && /^\d{4}-\d{2}-\d{2}$/.test(rawGuideDate)) guideDate = rawGuideDate;
 
       const fileBuffer = Buffer.from(pdf_data, 'base64');
       let autoEurocodes = [];
@@ -156,16 +164,16 @@ exports.handler = async (event) => {
       const eurocodes = [...new Set([...autoEurocodes, ...manualList])];
       const storedFileType = file_type || 'application/pdf';
 
-      const today = new Date().toISOString().split('T')[0];
+      // Delete existing guide for same date + cleanup guides older than 2 days
       await client.query(
         "DELETE FROM transport_guides WHERE portal_id = $1 AND (guide_date = $2 OR guide_date < CURRENT_DATE - INTERVAL '1 day')",
-        [portalId, today]
+        [portalId, guideDate]
       );
       const res = await client.query(
         `INSERT INTO transport_guides (portal_id, guide_date, pdf_data, eurocodes, uploaded_by, file_type)
          VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING id, guide_date, eurocodes, uploaded_at, file_type`,
-        [portalId, today, pdf_data, eurocodes, user.userId, storedFileType]
+        [portalId, guideDate, pdf_data, eurocodes, user.userId, storedFileType]
       );
       return {
         statusCode: 200, headers,

--- a/transport-guide.css
+++ b/transport-guide.css
@@ -167,6 +167,31 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
+.guia-at-date-toggle {
+  display: flex;
+  gap: 4px;
+  padding: 2px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 8px;
+}
+.guia-at-date-opt {
+  flex: 1;
+  padding: 6px 0;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.guia-at-date-opt.active {
+  background: #1e40af;
+  color: #fff;
+}
+.guia-at-date-opt:not(.active):hover { color: #e2e8f0; }
+
 .guia-at-menu-item {
   display: flex;
   align-items: center;

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -2,7 +2,9 @@
   'use strict';
 
   const API = '/.netlify/functions/transport-guide';
-  let todayGuide = null;
+  let guides = { today: null, tomorrow: null }; // guides indexed by target date
+  let todayGuide = null; // kept for viewer (today's guide)
+  let uploadDate = 'today'; // 'today' | 'tomorrow'
   let injectTimer = null;
 
   async function authFetch(url, opts) {
@@ -25,9 +27,17 @@
 
   // ── Badge injection ──────────────────────────────────────
 
+  function allEurocodes() {
+    const set = new Set();
+    ['today', 'tomorrow'].forEach(k => {
+      (guides[k]?.eurocodes || []).forEach(e => set.add(e.toUpperCase()));
+    });
+    return [...set];
+  }
+
   function injectBadges() {
-    if (!todayGuide?.eurocodes?.length) return;
-    const eurocodes = todayGuide.eurocodes.map(e => e.toUpperCase());
+    const eurocodes = allEurocodes();
+    if (!eurocodes.length) return;
     const appts = window.appointments || [];
 
     document.querySelectorAll('.guia-at-badge').forEach(b => b.remove());
@@ -75,6 +85,8 @@
   }
 
   function openViewer() {
+    // Prefer today's guide for viewing; fall back to tomorrow's
+    todayGuide = guides.today || guides.tomorrow;
     if (!todayGuide?.pdf_data) return;
     const { url, type } = makeGuideUrl();
 
@@ -127,6 +139,14 @@
   }
 
   // ── Upload menu ──────────────────────────────────────────
+
+  function setUploadDate(val) {
+    uploadDate = val;
+    ['hoje', 'amanha'].forEach(id => {
+      const el = document.getElementById('guiaATDate_' + id);
+      if (el) el.classList.toggle('active', (id === 'hoje') === (val === 'today'));
+    });
+  }
 
   let _menuBtn = null;
 
@@ -199,12 +219,13 @@
     try {
       const base64 = await fileToBase64(file);
       const manual_eurocodes = getManualCodes();
-      const payload = { pdf_data: base64, file_type: file.type, manual_eurocodes };
+      const payload = { pdf_data: base64, file_type: file.type, manual_eurocodes, guide_date: uploadDate };
       if (window.activePortalId) payload._portalId = window.activePortalId;
       const res = await authFetch(API, { method: 'POST', body: JSON.stringify(payload) });
       const data = await res.json();
       if (data.success) {
-        todayGuide = data.guide;
+        guides[uploadDate === 'tomorrow' ? 'tomorrow' : 'today'] = data.guide;
+        todayGuide = guides.today || guides.tomorrow;
         injectBadges();
         updateUploadBtn();
         const n = data.eurocodes_found.length;
@@ -241,16 +262,21 @@
   }
 
   function updateUploadBtn() {
+    const hasToday = !!guides.today;
+    const hasTomorrow = !!guides.tomorrow;
+    const loaded = hasToday || hasTomorrow;
+    const label = hasToday && hasTomorrow ? 'Guia AT ✓✓'
+                : hasToday ? 'Guia AT ✓'
+                : hasTomorrow ? 'Guia AT +1 ✓'
+                : 'Guia AT';
+    const icon = loaded
+      ? '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
+      : '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>';
     const btns = [document.getElementById('guiaATUploadBtn'), document.getElementById('guiaATUploadBtnDesk')];
     btns.forEach(btn => {
       if (!btn) return;
-      if (todayGuide) {
-        btn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg> Guia AT ✓';
-        btn.classList.add('guia-at-loaded');
-      } else {
-        btn.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg> Guia AT';
-        btn.classList.remove('guia-at-loaded');
-      }
+      btn.innerHTML = `${icon} ${label}`;
+      btn.classList.toggle('guia-at-loaded', loaded);
     });
   }
 
@@ -277,16 +303,20 @@
       new MutationObserver(scheduleInject).observe(scheduleEl, { childList: true, subtree: false });
     }
 
-    // Load today's guide
+    // Load today's and tomorrow's guides
     try {
-      const portalParam = window.activePortalId ? `?portal_id=${window.activePortalId}` : '';
-      const res = await authFetch(API + portalParam);
-      const data = await res.json();
-      if (data.success && data.guide) {
-        todayGuide = data.guide;
-        updateUploadBtn();
-        scheduleInject();
-      }
+      const portalParam = window.activePortalId ? `&portal_id=${window.activePortalId}` : '';
+      const tomorrow = new Date(); tomorrow.setDate(tomorrow.getDate() + 1);
+      const tomorrowIso = tomorrow.toISOString().split('T')[0];
+      const [resToday, resTomorrow] = await Promise.all([
+        authFetch(`${API}?date=${new Date().toISOString().split('T')[0]}${portalParam}`),
+        authFetch(`${API}?date=${tomorrowIso}${portalParam}`)
+      ]);
+      const [dToday, dTomorrow] = await Promise.all([resToday.json(), resTomorrow.json()]);
+      if (dToday.success && dToday.guide) guides.today = dToday.guide;
+      if (dTomorrow.success && dTomorrow.guide) guides.tomorrow = dTomorrow.guide;
+      todayGuide = guides.today || guides.tomorrow;
+      if (guides.today || guides.tomorrow) { updateUploadBtn(); scheduleInject(); }
     } catch (e) { console.error('Transport guide init:', e); }
 
     // Safety-net inject for slow connections
@@ -307,7 +337,7 @@
     setTimeout(() => t.remove(), 3500);
   }
 
-  window.guiaAT = { init, openViewer, closeViewer, toggleMenu, closeMenu, triggerFileInput, handleFileSelected, handlePasteZone, injectBadges };
+  window.guiaAT = { init, openViewer, closeViewer, toggleMenu, closeMenu, triggerFileInput, handleFileSelected, handlePasteZone, injectBadges, setUploadDate };
 
   let _initDone = false;
   function _runInit() {


### PR DESCRIPTION
## Resumo\n\n- Menu de upload tem toggle **Hoje / Amanhã** — o coordenador escolhe para que dia é a guia antes de fazer o upload\n- Backend guarda a guia com a `guide_date` correcta (hoje ou amanhã)\n- Frontend carrega as guias de hoje E amanhã em paralelo no arranque\n- Badge injection usa eurocodes combinados de ambas — aparecem nos cards de qualquer dia que tenha uma guia carregada\n- Botão mostra estado: `✓` (só hoje), `+1 ✓` (só amanhã), `✓✓` (ambas)\n\n## Test plan\n- [ ] Abrir menu Guia AT → confirmar toggle Hoje/Amanhã\n- [ ] Seleccionar Amanhã → upload PDF/screenshot → confirmar toast com eurocodes\n- [ ] Navegar para amanhã na agenda → badges aparecem nos cards correspondentes\n- [ ] Upload de guia para hoje continua a funcionar normalmente\n- [ ] Botão mostra estado correcto em cada combinação

---
_Generated by [Claude Code](https://claude.ai/code/session_01512Vjnh3PBKiQ9DF5tUsph)_