### PR TITLE
fix: eurocode com JSON malformado — texto cru no card e badge Guia AT

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -31,6 +31,12 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS glass_removed_date DATE`);
   } catch(migErr) { console.warn('Migration warning:', migErr.message); }
 
+  // Migração: actualizar constraint de service para incluir RV e OUT
+  try {
+    await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
+    await pool.query(`ALTER TABLE appointments ADD CONSTRAINT appointments_service_check CHECK (service IS NULL OR service IN ('PB', 'LT', 'OC', 'REP', 'POL', 'RV', 'OUT'))`);
+  } catch(migErr) { console.warn('Migration service_check warning:', migErr.message); }
+
   try {
     const user = getUserFromToken(event);
     let portalId = user.portalId;

--- a/script-tail.js
+++ b/script-tail.js
@@ -60,8 +60,8 @@ const telBtn = phone ? `
     a.calibration ? `<span class="m-chip m-chip-calib">⊕ CALIB</span>` : '',
     a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
   ].filter(Boolean).join('');
-  let _extraDisp = a.extra || '';
-  if (_extraDisp) { try { const _p = JSON.parse(_extraDisp); _extraDisp = _p.eurocode || ''; } catch(e) {} }
+  let _extraDisp = '';
+  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : ''; } }
   const notes = [a.client_name, _extraDisp, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -45,6 +45,16 @@
     return d.getHours() * 60 + d.getMinutes();
   }
 
+  function mesmoLocalQue(a, b) {
+    if (!a || !b) return false;
+    const addrA = (a.address || '').trim().toLowerCase();
+    const addrB = (b.address || '').trim().toLowerCase();
+    if (addrA && addrB) return addrA === addrB;
+    const locA = (a.locality || '').trim().toLowerCase();
+    const locB = (b.locality || '').trim().toLowerCase();
+    return locA && locB && locA === locB && !(a.km > 0) && !(b.km > 0);
+  }
+
   // Valida tempo de viagem contra km: descarta valores impossíveis (< mín. a 120 km/h)
   function validarTempoViagem(minutos, km, fallbackVelocidade) {
     if (!km || km <= 0) return minutos > 0 ? minutos : 15;
@@ -74,7 +84,7 @@
     let simCursor = cursor;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
-      const mesmoLocal = prev && a.address && prev.address && a.address.trim() === prev.address.trim();
+      const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const rawTravel = mesmoLocal ? 0 : (a.travelTime || a.travel_time || 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(rawTravel, km);
@@ -125,7 +135,7 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
-      const mesmoLocal = prev && a.address && prev.address && a.address.trim() === prev.address.trim();
+      const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);
       if (travel > 0) events.push({

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -73,9 +73,11 @@
     const STEPS = [];
     let simCursor = cursor;
     items.forEach((a, i) => {
-      const km = a.km ?? a.kms ?? 0;
-      const rawTravel = a.travelTime || a.travel_time || 0;
-      const travel = validarTempoViagem(rawTravel, km);
+      const prev = i > 0 ? items[i - 1] : null;
+      const mesmoLocal = prev && a.address && prev.address && a.address.trim() === prev.address.trim();
+      const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
+      const rawTravel = mesmoLocal ? 0 : (a.travelTime || a.travel_time || 0);
+      const travel = mesmoLocal ? 0 : validarTempoViagem(rawTravel, km);
       simCursor += travel;
       STEPS.push({ idx: i, type: 'viagem', start: simCursor - travel, end: simCursor, travel });
       // Tempo de execução
@@ -122,9 +124,11 @@
     // Construir eventos reais com almoço na posição certa
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
-      const km = a.km ?? a.kms ?? 0;
-      const travel = validarTempoViagem(a.travelTime || a.travel_time || 0, km);
-      events.push({
+      const prev = i > 0 ? items[i - 1] : null;
+      const mesmoLocal = prev && a.address && prev.address && a.address.trim() === prev.address.trim();
+      const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
+      const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);
+      if (travel > 0) events.push({
         type: 'viagem',
         label: 'Viagem para ' + (a.locality || a.plate),
         time: cursor,

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -22,7 +22,10 @@
 
   function getEurocode(appt) {
     if (!appt.extra) return '';
-    try { return (JSON.parse(appt.extra).eurocode || '').trim().toUpperCase(); } catch (e) { return appt.extra.trim().toUpperCase(); }
+    try { return (JSON.parse(appt.extra).eurocode || '').trim().toUpperCase(); } catch (e) {
+      const m = appt.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
+      return m ? m[1].trim().toUpperCase() : '';
+    }
   }
 
   // ── Badge injection ──────────────────────────────────────


### PR DESCRIPTION
## Problema

Alguns agendamentos têm o campo `extra` com JSON malformado (corrompido por uma versão anterior do código). Isso causava dois bugs:

1. **Texto garbled no card** — o card mostrava o JSON cru (`{"eurocode":"...","photo_url"...}`) em vez de apenas o eurocode
2. **Badge Guia AT não aparecia** — `getEurocode()` devolvia o JSON inteiro quando `JSON.parse` falhava, nunca fazendo match com os eurocodes da guia

## Causa

Quando `JSON.parse(appt.extra)` falha:
- Em `script-tail.js`: o catch não limpava `_extraDisp`, deixando o JSON cru visível
- Em `transport-guide.js`: o catch devolvia `appt.extra.trim()` (o JSON inteiro) em vez do eurocode

## Solução

Usa regex como fallback em ambos os sítios para extrair o eurocode do campo `extra` mesmo quando o JSON está malformado:
```js
const m = appt.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
return m ? m[1].trim() : '';
```

## Test plan
- [ ] Card de agendamento com `extra` malformado mostra só o eurocode (não o JSON cru)
- [ ] Badge "Guia AT" aparece no card quando a guia carregada contém o eurocode do agendamento
- [ ] Agendamentos com `extra` válido continuam a funcionar normalmente

https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV)_