### PR TITLE
fix: limpar eurocode antes do matching (ignorar texto após o código)

### DIFF
--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,6 +135,7 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
+<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,7 +135,6 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
-<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -21,19 +21,23 @@
   }
 
   function getEurocode(appt) {
+    // Extrai apenas o código puro (4 dígitos + letras), ignorando texto extra
+    function cleanEc(raw) {
+      if (!raw) return '';
+      const m = String(raw).trim().toUpperCase().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
+      return m ? m[1] : '';
+    }
     if (appt.extra) {
       try {
-        const ec = (JSON.parse(appt.extra).eurocode || '').trim().toUpperCase();
+        const ec = cleanEc(JSON.parse(appt.extra).eurocode);
         if (ec) return ec;
       } catch (e) {
         const m = appt.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
-        if (m) return m[1].trim().toUpperCase();
-        // plain text extra (formato antigo)
-        const plain = appt.extra.trim().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
-        if (plain) return plain[1].toUpperCase();
+        if (m) return cleanEc(m[1]);
+        return cleanEc(appt.extra);
       }
     }
-    // fallback: extrair eurocode do campo notes (formato muito antigo)
+    // fallback: campo notes (formato antigo)
     if (appt.notes) {
       const m = appt.notes.match(/\b(\d{4}[A-Z]{3,}[0-9A-Z]*)\b/);
       if (m) return m[1].toUpperCase();


### PR DESCRIPTION
## Problema

Badge Guia AT ainda não aparecia em CF-33-QJ mesmo após o fix anterior.

## Causa Raiz

O `extra.eurocode` deste agendamento contém `"5385AGACMVZ // CALIBRAGEM ESTATICA"` — o eurocode com texto de notas colado. O fix anterior devolvia esse valor completo, e o matching falhava quando o guia tinha `"5385AGACMVZPBL"` (código concatenado com início da descrição pelo PDF parser):
- `"5385AGACMVZ // CALIBRAGEM ESTATICA".startsWith("5385AGACMVZPBL")` → FALSE ✗

## Solução

`cleanEc()` extrai apenas a parte pura do eurocode (`^\d{4}[A-Z]{3+}[0-9A-Z]*`) antes de qualquer texto extra. Agora devolve `"5385AGACMVZ"` em vez de `"5385AGACMVZ // CALIBRAGEM ESTATICA"`.

https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV)_