### PR TITLE
feat: fix transfer bugs + second service of day

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,17 @@
             </label>
           </div>
 
+          <!-- LINHA 5b: Segundo serviço do dia (só aparece se houver um 1.º nesse dia) -->
+          <div id="secondOfDayRow" style="display:none;margin-bottom:16px;">
+            <label class="toggle-card toggle-card--star" for="appointmentSecondOfDay" style="width:100%;box-sizing:border-box;">
+              <input type="checkbox" id="appointmentSecondOfDay" />
+              <span class="toggle-card-ui">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+              </span>
+              <span class="toggle-card-label">⭐ Segundo serviço do dia</span>
+            </label>
+          </div>
+
           <!-- LINHA 6: Encaminhado por comercial -->
           <div id="commercialSection" style="margin-bottom:12px;">
             <label class="toggle-card toggle-card--commercial" for="hasCommercial" style="width:100%;box-sizing:border-box;">

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -31,6 +31,10 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS glass_removed_date DATE`);
   } catch(migErr) { console.warn('Migration warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS second_of_day BOOLEAN DEFAULT FALSE`);
+  } catch(migErr) { console.warn('Migration second_of_day warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -69,7 +73,7 @@ exports.handler = async (event) => {
         SELECT id, date, period, plate, car, service, locality, status,
                notes, address, extra, phone, km, sortIndex, "glassOrdered",
                vehicle_type, travel_time, auto_imported, executed, confirmed,
-               calibration, first_of_day, not_done_reason, commercial_user_id,
+               calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
                custom_service_time, foreign_plate, extra_services, created_at, updated_at
         FROM appointments
@@ -104,11 +108,11 @@ exports.handler = async (event) => {
         INSERT INTO appointments (
           date, period, plate, car, service, locality, status,
           notes, address, extra, phone, km, sortIndex, "glassOrdered",
-          vehicle_type, travel_time, confirmed, calibration, first_of_day,
+          vehicle_type, travel_time, confirmed, calibration, first_of_day, second_of_day,
           not_done_reason, commercial_user_id, return_km, return_time, client_name, damage_details,
           glass_removed_date, custom_service_time, foreign_plate, extra_services, portal_id, created_at, updated_at
         ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
         ) RETURNING *
       `;
       const v = [
@@ -121,7 +125,7 @@ exports.handler = async (event) => {
         data.vehicleType || data.vehicle_type || 'L',
         data.travelTime || data.travel_time || null,
         data.confirmed !== undefined ? data.confirmed : true,
-        data.calibration || false, data.first_of_day || false,
+        data.calibration || false, data.first_of_day || false, data.second_of_day || false,
         data.not_done_reason || null,
         data.commercial_user_id ? parseInt(data.commercial_user_id) : null,
         data.return_km != null ? parseInt(data.return_km) : null,
@@ -176,10 +180,10 @@ exports.handler = async (event) => {
           km = $12, sortIndex = $13, "glassOrdered" = $14,
           vehicle_type = $15, travel_time = $16, auto_imported = $17,
           executed = $18, confirmed = $19, calibration = $20,
-          first_of_day = $21, not_done_reason = $22, commercial_user_id = $23,
-          return_km = $24, return_time = $25, client_name = $26, damage_details = $27, glass_removed = $28, extra_services = $29,
-          glass_removed_date = $30, updated_at = $31
-        WHERE id = $32 AND portal_id = $33
+          first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
+          return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
+          glass_removed_date = $31, updated_at = $32
+        WHERE id = $33 AND portal_id = $34
         RETURNING *
       `;
       const v = [
@@ -197,6 +201,7 @@ exports.handler = async (event) => {
         data.confirmed !== undefined ? data.confirmed : true,
         data.calibration === true,
         data.first_of_day === true,
+        data.second_of_day === true,
         notDoneReasonVal,
         data.commercial_user_id !== undefined ? (data.commercial_user_id || null) : existing.commercial_user_id,
         data.return_km != null ? parseInt(data.return_km) : null,

--- a/script-tail.js
+++ b/script-tail.js
@@ -61,7 +61,7 @@ const telBtn = phone ? `
     a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
   ].filter(Boolean).join('');
   let _extraDisp = '';
-  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : ''; } }
+  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
   const notes = [a.client_name, _extraDisp, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE

--- a/script-tail.js
+++ b/script-tail.js
@@ -58,7 +58,8 @@ const telBtn = phone ? `
     ..._allSvcs.map(function(s) { return `<span class="m-chip">${s}</span>`; }),
     !isLoja() && a.locality ? `<span class="m-chip">${a.locality}</span>` : '',
     a.calibration ? `<span class="m-chip m-chip-calib">⊕ CALIB</span>` : '',
-    a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
+    a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : '',
+    a.second_of_day ? `<span class="m-chip" style="background:#f97316;color:#fff;font-weight:700;">⭐ 2.º</span>` : ''
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
@@ -189,9 +190,11 @@ async function renderMobileDay(){
         if (isLoja()) {
           return (a.period||'').localeCompare(b.period||'') || (a.sortIndex||0)-(b.sortIndex||0);
         }
-        // first_of_day sempre no topo
+        // first_of_day e second_of_day sempre no topo, por esta ordem
         if (a.first_of_day && !b.first_of_day) return -1;
         if (!a.first_of_day && b.first_of_day) return 1;
+        if (a.second_of_day && !b.second_of_day) return -1;
+        if (!a.second_of_day && b.second_of_day) return 1;
         return (a.sortIndex||0) - (b.sortIndex||0);
       })
   );
@@ -209,10 +212,11 @@ async function renderMobileDay(){
     console.log('🔄 MOBILE - Aplicando ordenação automática');
     items = await ordenarSeNecessario(itemsRaw);
   }
-  // Garantir sempre: first_of_day no topo, independente do caminho
+  // Garantir sempre: first_of_day no topo, depois second_of_day, independente do caminho
   items = [
     ...items.filter(a => a.first_of_day),
-    ...items.filter(a => !a.first_of_day)
+    ...items.filter(a => a.second_of_day && !a.first_of_day),
+    ...items.filter(a => !a.first_of_day && !a.second_of_day)
   ];
 
   var _bmBlocked = isDayBlocked(iso);
@@ -982,6 +986,7 @@ function bootApp() {
       vehicleType: (document.getElementById('appointmentVehicleType')?.value || localStorage.getItem('eg_last_vehicleType') || 'L'),
       calibration: document.getElementById('appointmentCalibration')?.checked || false,
       first_of_day: document.getElementById('appointmentFirstOfDay')?.checked || false,
+      second_of_day: document.getElementById('appointmentSecondOfDay')?.checked || false,
       // ===== ADICIONAR OS QUILÓMETROS CALCULADOS =====
       km: calculatedKm,
       confirmed: document.getElementById('appointmentConfirmed')?.value !== 'false',
@@ -1026,6 +1031,7 @@ function bootApp() {
         if (idx >= 0) appointments[idx] = { ...appointments[idx], ...updated, ...payload };
         showToast('Agendamento atualizado', 'success');
         if (payload.first_of_day && payload.date) await enforceSingleFirstOfDay(editingId, payload.date);
+        if (payload.second_of_day && payload.date) await enforceSingleSecondOfDay(editingId, payload.date);
         // Notificar comercial apenas se mudou data OU confirmação
         if (payload.commercial_user_id && prevAppt) {
           const dateChanged = payload.date && prevAppt.date !== payload.date;
@@ -1089,6 +1095,7 @@ cancelEdit?.();
         appointments.push(item);
         showToast('Agendamento criado', 'success');
         if (payload.first_of_day && payload.date) await enforceSingleFirstOfDay(item.id, payload.date);
+        if (payload.second_of_day && payload.date) await enforceSingleSecondOfDay(item.id, payload.date);
         // Notificar comercial ao criar (sempre que tem comercial e data)
         if (payload.commercial_user_id && payload.date) {
           const apptId = created?.id || item.id;
@@ -1246,6 +1253,43 @@ if (window._portalReadyFired) {
 } else {
   window.addEventListener('portalReady', bootApp, { once: true });
 }
+
+// === SEGUNDO SERVIÇO DO DIA: visibilidade do checkbox no formulário ===
+window.updateSecondOfDayVisibility = function() {
+  var row = document.getElementById('secondOfDayRow');
+  if (!row) return;
+
+  var dateVal = document.getElementById('appointmentDate')?.value;
+  var isFirstOfDay = document.getElementById('appointmentFirstOfDay')?.checked;
+
+  // Não mostrar na mesma linha que é o 1.º serviço
+  if (isFirstOfDay || !dateVal) {
+    row.style.display = 'none';
+    var cb = document.getElementById('appointmentSecondOfDay');
+    if (cb) cb.checked = false;
+    return;
+  }
+
+  // Contar quantos 1.º serviço existem nesse dia (excluindo o agendamento em edição)
+  var editingId = window._currentEditingId;
+  var firstCount = (window.appointments || []).filter(function(a) {
+    return a.date === dateVal && a.first_of_day && String(a.id) !== String(editingId);
+  }).length;
+
+  row.style.display = firstCount === 1 ? '' : 'none';
+  if (firstCount !== 1) {
+    var cb2 = document.getElementById('appointmentSecondOfDay');
+    if (cb2) cb2.checked = false;
+  }
+};
+
+// Ligar eventos de data e 1.º serviço ao updateSecondOfDayVisibility
+document.addEventListener('DOMContentLoaded', function() {
+  var dateField = document.getElementById('appointmentDate');
+  if (dateField) dateField.addEventListener('change', window.updateSecondOfDayVisibility);
+  var firstCb = document.getElementById('appointmentFirstOfDay');
+  if (firstCb) firstCb.addEventListener('change', window.updateSecondOfDayVisibility);
+});
 
 // === PRINT: Preenche secções de impressão (Hoje, Amanhã, Por Agendar) ===
 (function(){

--- a/script.js
+++ b/script.js
@@ -205,9 +205,9 @@ const ORDER_ROUTE_SM_BRAGA = true;
 async function ordenarSeNecessario(lista) {
   if (!ORDER_ROUTE_SM_BRAGA) return lista;
 
-  // Pinnar first_of_day: sai da ordenação geográfica e vai sempre ao topo
-  const pinned = lista.filter(i => i.first_of_day);
-  const semPin  = lista.filter(i => !i.first_of_day);
+  // Pinnar first_of_day e second_of_day: saem da ordenação geográfica
+  const pinned = lista.filter(i => i.first_of_day || i.second_of_day);
+  const semPin  = lista.filter(i => !i.first_of_day && !i.second_of_day);
 
   const comMorada = semPin.filter(i => getAddressFromItem(i));
   if (!comMorada.length) return [...pinned, ...semPin];
@@ -1108,6 +1108,8 @@ function buildDaySummary(dayDate, isMobile) {
     .sort((a,b) => {
       if (a.first_of_day && !b.first_of_day) return -1;
       if (!a.first_of_day && b.first_of_day) return 1;
+      if (a.second_of_day && !b.second_of_day) return -1;
+      if (!a.second_of_day && b.second_of_day) return 1;
       return (a.sortIndex||0) - (b.sortIndex||0);
     });
   // Resumo: só contar serviços com localidade (confirmados e prontos para rota)
@@ -1820,7 +1822,6 @@ window.fireVidroRetiradoEmojis = fireVidroRetiradoEmojis;
 // ===== PRIMEIRO SERVIÇO DO DIA — só um por dia =====
 async function enforceSingleFirstOfDay(newId, date) {
   if (!date) return;
-  // Encontrar outros agendamentos do mesmo dia com first_of_day=true
   const others = appointments.filter(a =>
     String(a.id) !== String(newId) &&
     a.date === date &&
@@ -1831,6 +1832,22 @@ async function enforceSingleFirstOfDay(newId, date) {
       a.first_of_day = false;
       await window.apiClient.updateAppointment(a.id, { ...a, first_of_day: false });
     } catch(e) { console.warn('Erro ao limpar first_of_day:', e); }
+  }
+  if (others.length > 0) renderAll();
+}
+
+async function enforceSingleSecondOfDay(newId, date) {
+  if (!date) return;
+  const others = appointments.filter(a =>
+    String(a.id) !== String(newId) &&
+    a.date === date &&
+    a.second_of_day === true
+  );
+  for (const a of others) {
+    try {
+      a.second_of_day = false;
+      await window.apiClient.updateAppointment(a.id, { ...a, second_of_day: false });
+    } catch(e) { console.warn('Erro ao limpar second_of_day:', e); }
   }
   if (others.length > 0) renderAll();
 }
@@ -2142,6 +2159,9 @@ function editAppointment(id) {
   if (calibCb) calibCb.checked = !!(appointment.calibration);
   const firstCb = document.getElementById('appointmentFirstOfDay');
   if (firstCb) firstCb.checked = !!(appointment.first_of_day);
+  const secondCb = document.getElementById('appointmentSecondOfDay');
+  if (secondCb) secondCb.checked = !!(appointment.second_of_day);
+  setTimeout(function() { if (typeof window.updateSecondOfDayVisibility === 'function') window.updateSecondOfDayVisibility(); }, 50);
   document.getElementById('appointmentLocality').value = appointment.locality || '';
   if (document.getElementById('appointmentPeriod')) {
     document.getElementById('appointmentPeriod').value = appointment.period || 'Manhã';
@@ -2451,6 +2471,7 @@ function buildDesktopCard(a){
         ${getAllServices(a).map(s => `<span class="dc-badge">${s.service||''}</span>`).join('')}
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}
         ${a.first_of_day ? '<span class="dc-calib-badge" style="background:#f59e0b;color:#fff;">⭐ 1.º SERVIÇO</span>' : ''}
+        ${a.second_of_day ? '<span class="dc-calib-badge" style="background:#f97316;color:#fff;">⭐ 2.º SERVIÇO</span>' : ''}
         ${a.commercial_user_id ? '<span class="dc-calib-badge" style="background:#7c3aed !important;color:#fff !important;animation:blink 1.5s infinite;">🤝 COMERCIAL</span>' : ''}
         ${car ? `<span class="dc-car">${car}</span>` : ''}
       </div>

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,6 +135,7 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
+<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,7 +135,6 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
-<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/transfer-sm-patch.js
+++ b/transfer-sm-patch.js
@@ -129,11 +129,14 @@
     try {
       var currentPortalId = window.activePortalId;
       var sourceName = (window.portalConfig && window.portalConfig.name) || 'SM';
+      var targetName = _selectedPortalName; // save before cancelEdit clears it
 
       // ── 1. Criar no portal DESTINO primeiro (seguro: se falhar, original intacto) ──
       var payload = Object.assign({}, appt, {
         _portalId: _selectedPortalId,          // campo reconhecido pelo backend
-        notes: (appt.notes ? appt.notes + ' | ' : '') + 'Transferido de ' + sourceName
+        notes: (appt.notes ? appt.notes + ' | ' : '') + 'Transferido de ' + sourceName,
+        confirmed: false,  // deve aparecer como pendente no portal destino
+        status: 'NE'
       });
       // Limpar campos que não devem ser copiados
       ['id', 'created_at', 'updated_at', '_targetPortalId'].forEach(function (k) { delete payload[k]; });
@@ -180,7 +183,7 @@
         if (modal) modal.classList.remove('show');
       }
 
-      if (typeof showToast === 'function') showToast('✅ Transferido para ' + _selectedPortalName, 'success');
+      if (typeof showToast === 'function') showToast('✅ Transferido para ' + targetName, 'success');
       if (typeof renderAll === 'function') renderAll();
       if (typeof window.reloadAppointments === 'function') window.reloadAppointments();
 

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -21,19 +21,23 @@
   }
 
   function getEurocode(appt) {
+    // Extrai apenas o código puro (4 dígitos + letras), ignorando texto extra
+    function cleanEc(raw) {
+      if (!raw) return '';
+      const m = String(raw).trim().toUpperCase().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
+      return m ? m[1] : '';
+    }
     if (appt.extra) {
       try {
-        const ec = (JSON.parse(appt.extra).eurocode || '').trim().toUpperCase();
+        const ec = cleanEc(JSON.parse(appt.extra).eurocode);
         if (ec) return ec;
       } catch (e) {
         const m = appt.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
-        if (m) return m[1].trim().toUpperCase();
-        // plain text extra (formato antigo)
-        const plain = appt.extra.trim().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
-        if (plain) return plain[1].toUpperCase();
+        if (m) return cleanEc(m[1]);
+        return cleanEc(appt.extra);
       }
     }
-    // fallback: extrair eurocode do campo notes (formato muito antigo)
+    // fallback: campo notes (formato antigo)
     if (appt.notes) {
       const m = appt.notes.match(/\b(\d{4}[A-Z]{3,}[0-9A-Z]*)\b/);
       if (m) return m[1].toUpperCase();


### PR DESCRIPTION
## Summary

**Transfer fixes:**
- Fix "Transferido para null": `cancelEdit()` was clearing `_selectedPortalName` before the success toast ran — save to local `targetName` first
- Transferred appointments now arrive as pending (`confirmed: false`, `status: 'NE'`) at the destination portal

**Second service of day:**
- New `second_of_day` boolean column (auto-migration, no manual SQL needed)
- Checkbox appears in form **only** when exactly one `first_of_day` appointment exists for the selected date (hides automatically for the first-of-day appointment itself)
- Sorting: first_of_day → second_of_day → rest
- Orange badge `⭐ 2.º` on mobile and desktop cards
- Enforcement: only one second_of_day allowed per day (clears others on save)

https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV)_