### PR TITLE
feat: bloquear rota por dia (coord/admin only)

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,17 @@
             </label>
           </div>
 
+          <!-- LINHA 5b: Segundo serviço do dia (só aparece se houver um 1.º nesse dia) -->
+          <div id="secondOfDayRow" style="display:none;margin-bottom:16px;">
+            <label class="toggle-card toggle-card--star" for="appointmentSecondOfDay" style="width:100%;box-sizing:border-box;">
+              <input type="checkbox" id="appointmentSecondOfDay" />
+              <span class="toggle-card-ui">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+              </span>
+              <span class="toggle-card-label">⭐ Segundo serviço do dia</span>
+            </label>
+          </div>
+
           <!-- LINHA 6: Encaminhado por comercial -->
           <div id="commercialSection" style="margin-bottom:12px;">
             <label class="toggle-card toggle-card--commercial" for="hasCommercial" style="width:100%;box-sizing:border-box;">

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -31,6 +31,10 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS glass_removed_date DATE`);
   } catch(migErr) { console.warn('Migration warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS second_of_day BOOLEAN DEFAULT FALSE`);
+  } catch(migErr) { console.warn('Migration second_of_day warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -69,7 +73,7 @@ exports.handler = async (event) => {
         SELECT id, date, period, plate, car, service, locality, status,
                notes, address, extra, phone, km, sortIndex, "glassOrdered",
                vehicle_type, travel_time, auto_imported, executed, confirmed,
-               calibration, first_of_day, not_done_reason, commercial_user_id,
+               calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
                custom_service_time, foreign_plate, extra_services, created_at, updated_at
         FROM appointments
@@ -104,11 +108,11 @@ exports.handler = async (event) => {
         INSERT INTO appointments (
           date, period, plate, car, service, locality, status,
           notes, address, extra, phone, km, sortIndex, "glassOrdered",
-          vehicle_type, travel_time, confirmed, calibration, first_of_day,
+          vehicle_type, travel_time, confirmed, calibration, first_of_day, second_of_day,
           not_done_reason, commercial_user_id, return_km, return_time, client_name, damage_details,
           glass_removed_date, custom_service_time, foreign_plate, extra_services, portal_id, created_at, updated_at
         ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
         ) RETURNING *
       `;
       const v = [
@@ -121,7 +125,7 @@ exports.handler = async (event) => {
         data.vehicleType || data.vehicle_type || 'L',
         data.travelTime || data.travel_time || null,
         data.confirmed !== undefined ? data.confirmed : true,
-        data.calibration || false, data.first_of_day || false,
+        data.calibration || false, data.first_of_day || false, data.second_of_day || false,
         data.not_done_reason || null,
         data.commercial_user_id ? parseInt(data.commercial_user_id) : null,
         data.return_km != null ? parseInt(data.return_km) : null,
@@ -176,10 +180,10 @@ exports.handler = async (event) => {
           km = $12, sortIndex = $13, "glassOrdered" = $14,
           vehicle_type = $15, travel_time = $16, auto_imported = $17,
           executed = $18, confirmed = $19, calibration = $20,
-          first_of_day = $21, not_done_reason = $22, commercial_user_id = $23,
-          return_km = $24, return_time = $25, client_name = $26, damage_details = $27, glass_removed = $28, extra_services = $29,
-          glass_removed_date = $30, updated_at = $31
-        WHERE id = $32 AND portal_id = $33
+          first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
+          return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
+          glass_removed_date = $31, updated_at = $32
+        WHERE id = $33 AND portal_id = $34
         RETURNING *
       `;
       const v = [
@@ -197,6 +201,7 @@ exports.handler = async (event) => {
         data.confirmed !== undefined ? data.confirmed : true,
         data.calibration === true,
         data.first_of_day === true,
+        data.second_of_day === true,
         notDoneReasonVal,
         data.commercial_user_id !== undefined ? (data.commercial_user_id || null) : existing.commercial_user_id,
         data.return_km != null ? parseInt(data.return_km) : null,

--- a/netlify/functions/route-locks.js
+++ b/netlify/functions/route-locks.js
@@ -1,0 +1,92 @@
+// netlify/functions/route-locks.js
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+function getUserFromToken(event) {
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
+  const token = authHeader.substring(7);
+  return jwt.verify(token, JWT_SECRET);
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS route_locks (
+        id SERIAL PRIMARY KEY,
+        date DATE NOT NULL,
+        portal_id INTEGER,
+        created_at TIMESTAMP DEFAULT NOW(),
+        UNIQUE(date, portal_id)
+      )
+    `);
+  } catch (e) { console.warn('route_locks migration:', e.message); }
+
+  try {
+    const user = getUserFromToken(event);
+    const isAdmin = user.role === 'admin';
+    const isCoord = user.role === 'coordenador' || user.role === 'pesados_coord';
+
+    const params = event.queryStringParameters || {};
+    let portalId = user.portalId;
+    if (isAdmin && params.portal_id) portalId = parseInt(params.portal_id);
+    else if (isCoord && params.portal_id) {
+      const allowed = user.portalIds || (user.portalId ? [user.portalId] : []);
+      const req = parseInt(params.portal_id);
+      if (allowed.includes(req)) portalId = req;
+    }
+
+    if (event.httpMethod === 'GET') {
+      const { rows } = await pool.query(
+        'SELECT date::text, portal_id, created_at FROM route_locks WHERE portal_id = $1 ORDER BY date',
+        [portalId]
+      );
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
+    }
+
+    if (!isAdmin && !isCoord) {
+      return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Sem permissão' }) };
+    }
+
+    if (event.httpMethod === 'POST') {
+      const { date } = JSON.parse(event.body || '{}');
+      if (!date) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'date obrigatório' }) };
+      await pool.query(
+        'INSERT INTO route_locks (date, portal_id) VALUES ($1, $2) ON CONFLICT (date, portal_id) DO NOTHING',
+        [date, portalId]
+      );
+      return { statusCode: 201, headers, body: JSON.stringify({ success: true }) };
+    }
+
+    if (event.httpMethod === 'DELETE') {
+      const date = params.date;
+      if (!date) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'date obrigatório' }) };
+      await pool.query('DELETE FROM route_locks WHERE date = $1 AND portal_id = $2', [date, portalId]);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };
+  } catch (err) {
+    console.error('route-locks error:', err);
+    if (err.message === 'Não autenticado' || err.name === 'JsonWebTokenError' || err.name === 'TokenExpiredError') {
+      return { statusCode: 401, headers, body: JSON.stringify({ success: false, error: 'Não autenticado' }) };
+    }
+    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  }
+};

--- a/script-tail.js
+++ b/script-tail.js
@@ -61,7 +61,7 @@ const telBtn = phone ? `
     a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
   ].filter(Boolean).join('');
   let _extraDisp = '';
-  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : ''; } }
+  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
   const notes = [a.client_name, _extraDisp, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE

--- a/script-tail.js
+++ b/script-tail.js
@@ -58,7 +58,8 @@ const telBtn = phone ? `
     ..._allSvcs.map(function(s) { return `<span class="m-chip">${s}</span>`; }),
     !isLoja() && a.locality ? `<span class="m-chip">${a.locality}</span>` : '',
     a.calibration ? `<span class="m-chip m-chip-calib">⊕ CALIB</span>` : '',
-    a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : ''
+    a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : '',
+    a.second_of_day ? `<span class="m-chip" style="background:#f97316;color:#fff;font-weight:700;">⭐ 2.º</span>` : ''
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
@@ -189,9 +190,11 @@ async function renderMobileDay(){
         if (isLoja()) {
           return (a.period||'').localeCompare(b.period||'') || (a.sortIndex||0)-(b.sortIndex||0);
         }
-        // first_of_day sempre no topo
+        // first_of_day e second_of_day sempre no topo, por esta ordem
         if (a.first_of_day && !b.first_of_day) return -1;
         if (!a.first_of_day && b.first_of_day) return 1;
+        if (a.second_of_day && !b.second_of_day) return -1;
+        if (!a.second_of_day && b.second_of_day) return 1;
         return (a.sortIndex||0) - (b.sortIndex||0);
       })
   );
@@ -209,10 +212,11 @@ async function renderMobileDay(){
     console.log('🔄 MOBILE - Aplicando ordenação automática');
     items = await ordenarSeNecessario(itemsRaw);
   }
-  // Garantir sempre: first_of_day no topo, independente do caminho
+  // Garantir sempre: first_of_day no topo, depois second_of_day, independente do caminho
   items = [
     ...items.filter(a => a.first_of_day),
-    ...items.filter(a => !a.first_of_day)
+    ...items.filter(a => a.second_of_day && !a.first_of_day),
+    ...items.filter(a => !a.first_of_day && !a.second_of_day)
   ];
 
   var _bmBlocked = isDayBlocked(iso);
@@ -982,6 +986,7 @@ function bootApp() {
       vehicleType: (document.getElementById('appointmentVehicleType')?.value || localStorage.getItem('eg_last_vehicleType') || 'L'),
       calibration: document.getElementById('appointmentCalibration')?.checked || false,
       first_of_day: document.getElementById('appointmentFirstOfDay')?.checked || false,
+      second_of_day: document.getElementById('appointmentSecondOfDay')?.checked || false,
       // ===== ADICIONAR OS QUILÓMETROS CALCULADOS =====
       km: calculatedKm,
       confirmed: document.getElementById('appointmentConfirmed')?.value !== 'false',
@@ -1026,6 +1031,7 @@ function bootApp() {
         if (idx >= 0) appointments[idx] = { ...appointments[idx], ...updated, ...payload };
         showToast('Agendamento atualizado', 'success');
         if (payload.first_of_day && payload.date) await enforceSingleFirstOfDay(editingId, payload.date);
+        if (payload.second_of_day && payload.date) await enforceSingleSecondOfDay(editingId, payload.date);
         // Notificar comercial apenas se mudou data OU confirmação
         if (payload.commercial_user_id && prevAppt) {
           const dateChanged = payload.date && prevAppt.date !== payload.date;
@@ -1089,6 +1095,7 @@ cancelEdit?.();
         appointments.push(item);
         showToast('Agendamento criado', 'success');
         if (payload.first_of_day && payload.date) await enforceSingleFirstOfDay(item.id, payload.date);
+        if (payload.second_of_day && payload.date) await enforceSingleSecondOfDay(item.id, payload.date);
         // Notificar comercial ao criar (sempre que tem comercial e data)
         if (payload.commercial_user_id && payload.date) {
           const apptId = created?.id || item.id;
@@ -1246,6 +1253,43 @@ if (window._portalReadyFired) {
 } else {
   window.addEventListener('portalReady', bootApp, { once: true });
 }
+
+// === SEGUNDO SERVIÇO DO DIA: visibilidade do checkbox no formulário ===
+window.updateSecondOfDayVisibility = function() {
+  var row = document.getElementById('secondOfDayRow');
+  if (!row) return;
+
+  var dateVal = document.getElementById('appointmentDate')?.value;
+  var isFirstOfDay = document.getElementById('appointmentFirstOfDay')?.checked;
+
+  // Não mostrar na mesma linha que é o 1.º serviço
+  if (isFirstOfDay || !dateVal) {
+    row.style.display = 'none';
+    var cb = document.getElementById('appointmentSecondOfDay');
+    if (cb) cb.checked = false;
+    return;
+  }
+
+  // Contar quantos 1.º serviço existem nesse dia (excluindo o agendamento em edição)
+  var editingId = window._currentEditingId;
+  var firstCount = (window.appointments || []).filter(function(a) {
+    return a.date === dateVal && a.first_of_day && String(a.id) !== String(editingId);
+  }).length;
+
+  row.style.display = firstCount === 1 ? '' : 'none';
+  if (firstCount !== 1) {
+    var cb2 = document.getElementById('appointmentSecondOfDay');
+    if (cb2) cb2.checked = false;
+  }
+};
+
+// Ligar eventos de data e 1.º serviço ao updateSecondOfDayVisibility
+document.addEventListener('DOMContentLoaded', function() {
+  var dateField = document.getElementById('appointmentDate');
+  if (dateField) dateField.addEventListener('change', window.updateSecondOfDayVisibility);
+  var firstCb = document.getElementById('appointmentFirstOfDay');
+  if (firstCb) firstCb.addEventListener('change', window.updateSecondOfDayVisibility);
+});
 
 // === PRINT: Preenche secções de impressão (Hoje, Amanhã, Por Agendar) ===
 (function(){

--- a/script-tail.js
+++ b/script-tail.js
@@ -222,6 +222,7 @@ async function renderMobileDay(){
   var _bmBlocked = isDayBlocked(iso);
   var _bmRole = window.authClient?.getUser?.()?.role;
   var _bmCanToggle = _bmRole === 'admin' || _bmRole === 'coordenador';
+  var _bmCanToggleRL = _bmRole === 'admin' || _bmRole === 'coordenador' || _bmRole === 'pesados_coord';
   var _bmBanner = '';
   if (_bmBlocked) {
     var _desbtn = _bmCanToggle ? '<button onclick="toggleBlockedDay(&quot;' + iso + '&quot;)" style="margin-left:auto;background:#ef4444;color:#fff;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:700;cursor:pointer;">Desbloquear</button>' : '';
@@ -230,8 +231,20 @@ async function renderMobileDay(){
     _bmBanner = '<div style="text-align:right;margin-bottom:6px;"><button onclick="toggleBlockedDay(&quot;' + iso + '&quot;)" style="background:#f1f5f9;color:#64748b;border:1px solid #e2e8f0;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:600;cursor:pointer;">🔓 Bloquear este dia</button></div>';
   }
 
+  // Rota bloqueada
+  var _rlLocked = typeof isDayRouteLocked === 'function' && isDayRouteLocked(iso);
+  var _rlBanner = '';
+  if (_rlLocked) {
+    var _rlDesbtn = _bmCanToggleRL
+      ? '<button onclick="toggleRouteLock(&quot;' + iso + '&quot;)" style="margin-left:auto;background:#f59e0b;color:#fff;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:700;cursor:pointer;">🔓 Desbloquear Rota</button>'
+      : '';
+    _rlBanner = '<div style="background:#fffbeb;border:1.5px solid #f59e0b;border-radius:10px;padding:10px 14px;margin-bottom:10px;display:flex;align-items:center;gap:8px;font-size:13px;font-weight:700;color:#92400e;">🔒 Rota bloqueada ' + _rlDesbtn + '</div>';
+  } else if (_bmCanToggleRL) {
+    _rlBanner = '<div style="text-align:right;margin-bottom:6px;"><button onclick="toggleRouteLock(&quot;' + iso + '&quot;)" style="background:#fffbeb;color:#92400e;border:1px solid #f59e0b;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:600;cursor:pointer;">🔒 Bloquear Rota</button></div>';
+  }
+
   if(items.length === 0){
-    list.innerHTML = _bmBanner + '<div class="m-card" style="--c1:#9ca3af;--c2:#6b7280;">Sem serviços para este dia.</div>';
+    list.innerHTML = _bmBanner + _rlBanner + '<div class="m-card" style="--c1:#9ca3af;--c2:#6b7280;">Sem serviços para este dia.</div>';
     return;
   }
 
@@ -263,7 +276,7 @@ async function renderMobileDay(){
       🗺️ Ver Rota do Dia
     </button>` : '';
 
-  list.innerHTML = _bmBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
+  list.innerHTML = _bmBanner + _rlBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
   highlightSearchResults();
   window.guiaAT?.injectBadges();
 }
@@ -276,6 +289,7 @@ function renderAll(){
   try { if (typeof renderServicesTable === 'function') renderServicesTable(); } catch(e){ console.error('Erro renderServicesTable:', e); }
   try { renderMobileDay(); } catch(e){ console.error('Erro renderMobileDay:', e); }
   try { applyBlockedDayOverlays(); } catch(e){ console.warn('applyBlockedDayOverlays:', e); }
+  try { applyRouteLockOverlays(); } catch(e){ console.warn('applyRouteLockOverlays:', e); }
 }
 
 // Função global para recarregar appointments (usada pelo switcher do coordenador)
@@ -832,6 +846,7 @@ function bootApp() {
     try { await loadRouteSettings(); } catch(e){ console.warn('loadRouteSettings falhou', e); }
     try { await load(); } catch(e){ console.error('load() falhou', e); }
     try { await loadBlockedDays(); } catch(e){ console.warn('loadBlockedDays falhou', e); }
+    try { await loadRouteLocks(); } catch(e){ console.warn('loadRouteLocks falhou', e); }
     try { await loadPoweringKpis(); } catch(e){ console.warn('PoweringEG falhou', e); }
     // Arrancar polling de pedidos comerciais após tudo carregado
     try { if (typeof window.crStartPolling === 'function') window.crStartPolling(); } catch(e){}

--- a/script.js
+++ b/script.js
@@ -282,6 +282,18 @@ async function calculateAllRoutesFromToday() {
       return;
     }
 
+    // Filtrar dias com rota bloqueada para técnicos
+    if (!canOverrideRouteLock()) {
+      const locked = daysWithServices.filter(d => isDayRouteLocked(d));
+      daysWithServices.splice(0, daysWithServices.length, ...daysWithServices.filter(d => !isDayRouteLocked(d)));
+      if (daysWithServices.length === 0) {
+        hideProgressModal();
+        showToast('🔒 Rota bloqueada pelo coordenador — não é possível calcular rotas.', 'warning');
+        return;
+      }
+      if (locked.length > 0) showToast('⚠️ ' + locked.length + ' dia(s) com rota bloqueada foram ignorados.', 'info');
+    }
+
     let totalOptimized = 0;
 
     for (let i = 0; i < daysWithServices.length; i++) {
@@ -1321,6 +1333,7 @@ function buildLocalityOptions() {
 // ---------- Estado ----------
 let appointments = [];
 let blockedDays = [];
+let routeLockedDays = [];
 
 function isDayBlocked(isoDate) {
   if (!isoDate) return null;
@@ -1384,6 +1397,108 @@ async function toggleBlockedDay(isoDate) {
     await loadBlockedDays();
     if (typeof renderAll === 'function') renderAll(); else applyBlockedDayOverlays();
   } catch(e) { showToast('Erro: ' + e.message, 'error'); }
+}
+
+// ===== BLOQUEIO DE ROTA =====
+
+function isDayRouteLocked(isoDate) {
+  if (!isoDate) return false;
+  const pid = String(window.activePortalId || window.portalConfig?.id || '');
+  return routeLockedDays.some(function(r) {
+    return r.date === isoDate && String(r.portal_id) === pid;
+  });
+}
+
+function canOverrideRouteLock() {
+  var role = window.authClient?.getUser?.()?.role;
+  return role === 'admin' || role === 'coordenador' || role === 'pesados_coord';
+}
+
+async function loadRouteLocks() {
+  try {
+    const pid = window.activePortalId || window.portalConfig?.id;
+    const url = '/.netlify/functions/route-locks' + (pid ? '?portal_id=' + pid : '');
+    const resp = await window.authClient.authenticatedFetch(url);
+    const data = await resp.json();
+    if (data.success) routeLockedDays = data.data || [];
+  } catch(e) { console.warn('loadRouteLocks:', e.message); }
+}
+
+async function toggleRouteLock(isoDate) {
+  if (!canOverrideRouteLock()) return;
+  const pid = window.activePortalId || window.portalConfig?.id;
+  const locked = isDayRouteLocked(isoDate);
+  try {
+    if (locked) {
+      await window.authClient.authenticatedFetch(
+        '/.netlify/functions/route-locks?date=' + isoDate + (pid ? '&portal_id=' + pid : ''),
+        { method: 'DELETE' }
+      );
+      routeLockedDays = routeLockedDays.filter(function(r) {
+        return !(r.date === isoDate && String(r.portal_id) === String(pid));
+      });
+      showToast('🔓 Rota desbloqueada', 'success');
+    } else {
+      await window.authClient.authenticatedFetch(
+        '/.netlify/functions/route-locks' + (pid ? '?portal_id=' + pid : ''),
+        { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ date: isoDate }) }
+      );
+      routeLockedDays.push({ date: isoDate, portal_id: pid });
+      showToast('🔒 Rota bloqueada', 'success');
+    }
+    renderAll();
+  } catch(e) { showToast('❌ Erro: ' + e.message, 'error'); }
+}
+
+function applyRouteLockOverlays() {
+  var role = window.authClient?.getUser?.()?.role;
+  var canToggle = canOverrideRouteLock();
+
+  if (!document.getElementById('_rlStyles')) {
+    var s = document.createElement('style');
+    s.id = '_rlStyles';
+    s.textContent = [
+      '.th-rl{background:repeating-linear-gradient(45deg,#fffbeb,#fffbeb 6px,#fef3c7 6px,#fef3c7 12px)!important;}',
+      '.th-rl .day{color:#92400e!important;}.th-rl .date{color:#b45309!important;}',
+      '.rl-badge{font-size:10px;font-weight:700;color:#92400e;background:#fef3c7;border-radius:4px;padding:2px 5px;margin-top:2px;display:block;}',
+      '.rl-btn{background:none;border:none;cursor:pointer;font-size:12px;padding:0 2px;opacity:.55;vertical-align:middle;}',
+      '.rl-btn:hover{opacity:1;}'
+    ].join('');
+    document.head.appendChild(s);
+  }
+
+  document.querySelectorAll('.rl-btn,.rl-badge').forEach(function(el) { el.remove(); });
+  document.querySelectorAll('.th-rl').forEach(function(el) { el.classList.remove('th-rl'); });
+
+  var table = document.getElementById('schedule');
+  if (!table) return;
+  var headers = table.querySelectorAll('thead th');
+  var week = [...Array(6)].map(function(_, i) { return addDays(currentMonday, i); });
+
+  week.forEach(function(d, i) {
+    var iso = localISO(d);
+    var locked = isDayRouteLocked(iso);
+    var th = headers[i + 1];
+    if (!th) return;
+
+    if (canToggle) {
+      var btn = document.createElement('button');
+      btn.className = 'rl-btn';
+      btn.title = locked ? 'Desbloquear rota' : 'Bloquear rota';
+      btn.textContent = locked ? '🔒' : '🔓';
+      btn.setAttribute('onclick', 'toggleRouteLock("' + iso + '")');
+      var dayDiv = th.querySelector('.day');
+      if (dayDiv) dayDiv.appendChild(btn);
+    }
+
+    if (locked) {
+      th.classList.add('th-rl');
+      var badge = document.createElement('span');
+      badge.className = 'rl-badge';
+      badge.textContent = '🔒 Rota';
+      th.appendChild(badge);
+    }
+  });
 }
 
 // Aplicar overlays visuais APÓS o render (não toca no renderSchedule interno)
@@ -2012,6 +2127,9 @@ async function onDropAppointment(id, targetBucket, targetIndex){
     var _dateDrop = targetBucket.split('|')[0];
     var _blockedDrop = isDayBlocked(_dateDrop);
     if (_blockedDrop) { showToast('🔒 ' + (_blockedDrop.reason || 'Dia bloqueado'), 'error'); return; }
+    if (isDayRouteLocked(_dateDrop) && !canOverrideRouteLock()) {
+      showToast('🔒 Rota bloqueada pelo coordenador — não pode alterar a ordem', 'error'); return;
+    }
   }
   const i = appointments.findIndex(a => String(a.id) === String(id));
   if (i < 0) return;

--- a/script.js
+++ b/script.js
@@ -205,9 +205,9 @@ const ORDER_ROUTE_SM_BRAGA = true;
 async function ordenarSeNecessario(lista) {
   if (!ORDER_ROUTE_SM_BRAGA) return lista;
 
-  // Pinnar first_of_day: sai da ordenação geográfica e vai sempre ao topo
-  const pinned = lista.filter(i => i.first_of_day);
-  const semPin  = lista.filter(i => !i.first_of_day);
+  // Pinnar first_of_day e second_of_day: saem da ordenação geográfica
+  const pinned = lista.filter(i => i.first_of_day || i.second_of_day);
+  const semPin  = lista.filter(i => !i.first_of_day && !i.second_of_day);
 
   const comMorada = semPin.filter(i => getAddressFromItem(i));
   if (!comMorada.length) return [...pinned, ...semPin];
@@ -1108,6 +1108,8 @@ function buildDaySummary(dayDate, isMobile) {
     .sort((a,b) => {
       if (a.first_of_day && !b.first_of_day) return -1;
       if (!a.first_of_day && b.first_of_day) return 1;
+      if (a.second_of_day && !b.second_of_day) return -1;
+      if (!a.second_of_day && b.second_of_day) return 1;
       return (a.sortIndex||0) - (b.sortIndex||0);
     });
   // Resumo: só contar serviços com localidade (confirmados e prontos para rota)
@@ -1820,7 +1822,6 @@ window.fireVidroRetiradoEmojis = fireVidroRetiradoEmojis;
 // ===== PRIMEIRO SERVIÇO DO DIA — só um por dia =====
 async function enforceSingleFirstOfDay(newId, date) {
   if (!date) return;
-  // Encontrar outros agendamentos do mesmo dia com first_of_day=true
   const others = appointments.filter(a =>
     String(a.id) !== String(newId) &&
     a.date === date &&
@@ -1831,6 +1832,22 @@ async function enforceSingleFirstOfDay(newId, date) {
       a.first_of_day = false;
       await window.apiClient.updateAppointment(a.id, { ...a, first_of_day: false });
     } catch(e) { console.warn('Erro ao limpar first_of_day:', e); }
+  }
+  if (others.length > 0) renderAll();
+}
+
+async function enforceSingleSecondOfDay(newId, date) {
+  if (!date) return;
+  const others = appointments.filter(a =>
+    String(a.id) !== String(newId) &&
+    a.date === date &&
+    a.second_of_day === true
+  );
+  for (const a of others) {
+    try {
+      a.second_of_day = false;
+      await window.apiClient.updateAppointment(a.id, { ...a, second_of_day: false });
+    } catch(e) { console.warn('Erro ao limpar second_of_day:', e); }
   }
   if (others.length > 0) renderAll();
 }
@@ -2142,6 +2159,9 @@ function editAppointment(id) {
   if (calibCb) calibCb.checked = !!(appointment.calibration);
   const firstCb = document.getElementById('appointmentFirstOfDay');
   if (firstCb) firstCb.checked = !!(appointment.first_of_day);
+  const secondCb = document.getElementById('appointmentSecondOfDay');
+  if (secondCb) secondCb.checked = !!(appointment.second_of_day);
+  setTimeout(function() { if (typeof window.updateSecondOfDayVisibility === 'function') window.updateSecondOfDayVisibility(); }, 50);
   document.getElementById('appointmentLocality').value = appointment.locality || '';
   if (document.getElementById('appointmentPeriod')) {
     document.getElementById('appointmentPeriod').value = appointment.period || 'Manhã';
@@ -2451,6 +2471,7 @@ function buildDesktopCard(a){
         ${getAllServices(a).map(s => `<span class="dc-badge">${s.service||''}</span>`).join('')}
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}
         ${a.first_of_day ? '<span class="dc-calib-badge" style="background:#f59e0b;color:#fff;">⭐ 1.º SERVIÇO</span>' : ''}
+        ${a.second_of_day ? '<span class="dc-calib-badge" style="background:#f97316;color:#fff;">⭐ 2.º SERVIÇO</span>' : ''}
         ${a.commercial_user_id ? '<span class="dc-calib-badge" style="background:#7c3aed !important;color:#fff !important;animation:blink 1.5s infinite;">🤝 COMERCIAL</span>' : ''}
         ${car ? `<span class="dc-car">${car}</span>` : ''}
       </div>

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,6 +135,7 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
+<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -135,7 +135,6 @@
     cursor = HORA_PARTIDA_H * 60 + HORA_PARTIDA_M;
     items.forEach((a, i) => {
       const prev = i > 0 ? items[i - 1] : null;
-<<<<<<< HEAD
       const mesmoLocal = mesmoLocalQue(a, prev);
       const km = mesmoLocal ? 0 : (a.km ?? a.kms ?? 0);
       const travel = mesmoLocal ? 0 : validarTempoViagem(a.travelTime || a.travel_time || 0, km);

--- a/transfer-sm-patch.js
+++ b/transfer-sm-patch.js
@@ -129,11 +129,14 @@
     try {
       var currentPortalId = window.activePortalId;
       var sourceName = (window.portalConfig && window.portalConfig.name) || 'SM';
+      var targetName = _selectedPortalName; // save before cancelEdit clears it
 
       // ── 1. Criar no portal DESTINO primeiro (seguro: se falhar, original intacto) ──
       var payload = Object.assign({}, appt, {
         _portalId: _selectedPortalId,          // campo reconhecido pelo backend
-        notes: (appt.notes ? appt.notes + ' | ' : '') + 'Transferido de ' + sourceName
+        notes: (appt.notes ? appt.notes + ' | ' : '') + 'Transferido de ' + sourceName,
+        confirmed: false,  // deve aparecer como pendente no portal destino
+        status: 'NE'
       });
       // Limpar campos que não devem ser copiados
       ['id', 'created_at', 'updated_at', '_targetPortalId'].forEach(function (k) { delete payload[k]; });
@@ -180,7 +183,7 @@
         if (modal) modal.classList.remove('show');
       }
 
-      if (typeof showToast === 'function') showToast('✅ Transferido para ' + _selectedPortalName, 'success');
+      if (typeof showToast === 'function') showToast('✅ Transferido para ' + targetName, 'success');
       if (typeof renderAll === 'function') renderAll();
       if (typeof window.reloadAppointments === 'function') window.reloadAppointments();
 

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -21,19 +21,23 @@
   }
 
   function getEurocode(appt) {
+    // Extrai apenas o código puro (4 dígitos + letras), ignorando texto extra
+    function cleanEc(raw) {
+      if (!raw) return '';
+      const m = String(raw).trim().toUpperCase().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
+      return m ? m[1] : '';
+    }
     if (appt.extra) {
       try {
-        const ec = (JSON.parse(appt.extra).eurocode || '').trim().toUpperCase();
+        const ec = cleanEc(JSON.parse(appt.extra).eurocode);
         if (ec) return ec;
       } catch (e) {
         const m = appt.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
-        if (m) return m[1].trim().toUpperCase();
-        // plain text extra (formato antigo)
-        const plain = appt.extra.trim().match(/^(\d{4}[A-Z]{3,}[0-9A-Z]*)/);
-        if (plain) return plain[1].toUpperCase();
+        if (m) return cleanEc(m[1]);
+        return cleanEc(appt.extra);
       }
     }
-    // fallback: extrair eurocode do campo notes (formato muito antigo)
+    // fallback: campo notes (formato antigo)
     if (appt.notes) {
       const m = appt.notes.match(/\b(\d{4}[A-Z]{3,}[0-9A-Z]*)\b/);
       if (m) return m[1].toUpperCase();


### PR DESCRIPTION
## Summary

- **Novo Netlify function** `route-locks.js` — cria a tabela `route_locks` automaticamente (PostgreSQL), GET/POST/DELETE por portal e data
- **Mobile**: banner âmbar por dia com botão "🔒 Bloquear Rota" / "🔓 Desbloquear Rota" (só visível para coordenador e admin)
- **Desktop**: overlay âmbar no cabeçalho da coluna do dia com botão de toggle
- **Técnicos**: drag-and-drop bloqueado em dias com rota bloqueada; cálculo de rota ignora dias bloqueados (ou bloqueia totalmente se todos estiverem bloqueados)
- **Coord/Admin**: pode sempre recalcular e reordenar, independentemente do estado do bloqueio

https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV

---
_Generated by [Claude Code](https://claude.ai/code/session_0119JXSwumhq5LeVfE5qy7vV)_