### PR TITLE
Fix: upgrade Node.js to 20 (mailparser/undici File error)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   functions = "netlify/functions"
 
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "20"
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
## Problema

A função `mycar-gmail-poller` crashava ao iniciar com:
```
ReferenceError: File is not defined
at node_modules/undici/lib/web/webidl/index.js
```

O `mailparser` depende do `undici` (versão recente) que usa a API global `File` — só disponível no Node.js 20+. O projeto estava configurado para Node 18.

## Fix

`NODE_VERSION = "18"` → `NODE_VERSION = "20"` em `netlify.toml`.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_