### PR TITLE
Fix: set AWS_LAMBDA_JS_RUNTIME=nodejs20.x for function runtime

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  AWS_LAMBDA_JS_RUNTIME = "nodejs20.x"
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
## Problema

`NODE_VERSION = "20"` no `netlify.toml` apenas afeta o processo de build — o runtime Lambda das funções continua a ser Node 18, causando `ReferenceError: File is not defined` no `undici`.

## Fix

Adicionar `AWS_LAMBDA_JS_RUNTIME = "nodejs20.x"` em `[build.environment]` para forçar o runtime das funções para Node 20.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_