### PR TITLE
Fix: polyfill File global for Node 18 (undici crash on init)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  AWS_LAMBDA_JS_RUNTIME = "nodejs20.x"
 
 [functions]
   node_bundler = "esbuild"

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -1,6 +1,17 @@
 // netlify/functions/mycar-gmail-poller.js
 // Corre a cada 15 min — lê emails não lidos no Gmail e importa serviços por matrícula
 // Também aceita POST autenticado para trigger manual via UI
+
+// Polyfill: undici (dep do mailparser) usa File global disponível só no Node 20+
+// Em Node 18 o File não é global mas existe em require('buffer')
+if (typeof File === 'undefined') {
+  try { global.File = require('buffer').File; } catch (_) {
+    global.File = class File extends Blob {
+      constructor(bits, name, opts = {}) { super(bits, opts); this.name = name; this.lastModified = opts.lastModified ?? Date.now(); }
+    };
+  }
+}
+
 const { Pool } = require('pg');
 const Imap = require('imap');
 const { simpleParser } = require('mailparser');


### PR DESCRIPTION
## Problema

`undici` (dependência transitiva de `mailparser`) referencia `File` durante o carregamento do módulo. `File` só existe como global no Node 20+; no Node 18 (runtime Netlify Lambda) não está definida globalmente → `ReferenceError: File is not defined` → função crasha na inicialização → 502.

`AWS_LAMBDA_JS_RUNTIME` e `NODE_VERSION` não resolveram porque o runtime Lambda ignora essas variáveis neste tier.

## Fix

Polyfill no topo do ficheiro, antes de qualquer `require`:
- Tenta `require('buffer').File` (disponível em Node 18.13+)
- Fallback para classe `File` simples que estende `Blob` (global em Node 18)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_