### PR TITLE
Add "Novo" indicator for unviewed services

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -222,6 +222,9 @@
     .badge-done    { background: var(--green-l);  color: var(--green); }
     .badge-reject  { background: var(--red-l);    color: var(--red); }
     .badge-neutral { background: var(--gray-l);   color: var(--gray); }
+    .badge-new     { background: #dbeafe; color: #1d4ed8; font-size:.65rem; padding:2px 6px; }
+    tr.row-new { background: #eff6ff; }
+    tr.row-new td { font-weight: 600; }
 
     .empty-state {
       text-align: center;
@@ -724,13 +727,15 @@ function buildGroups(services) {
   const map = {};
   for (const svc of services) {
     const key = svc.matricula.toUpperCase();
-    if (!map[key]) map[key] = { matricula: key, services: [], lastDate: null };
+    if (!map[key]) map[key] = { matricula: key, services: [], lastDate: null, isNew: false };
     map[key].services.push(svc);
     const d = svc.email_received_at || svc.created_at;
     if (d && (!map[key].lastDate || d > map[key].lastDate)) map[key].lastDate = d;
+    if (!svc.viewed_at) map[key].isNew = true;
   }
   return Object.values(map).sort((a, b) => {
-    // Ordenar: primeiro os que têm pendentes
+    // Ordenar: primeiro os novos, depois os que têm pendentes
+    if (b.isNew !== a.isNew) return b.isNew ? 1 : -1;
     const ap = a.services.filter(s => s.status === 'pendente').length;
     const bp = b.services.filter(s => s.status === 'pendente').length;
     if (bp !== ap) return bp - ap;
@@ -772,8 +777,11 @@ function renderTable(groups) {
     const rej  = g.services.filter(s => s.status === 'rejeitado').length;
     const last = g.lastDate ? fmtDate(g.lastDate) : '—';
     return `
-      <tr onclick="openDetail('${g.matricula}')">
-        <td class="plate-cell"><span class="plate-badge">${g.matricula}</span></td>
+      <tr class="${g.isNew ? 'row-new' : ''}" onclick="openDetail('${g.matricula}')">
+        <td class="plate-cell">
+          <span class="plate-badge">${g.matricula}</span>
+          ${g.isNew ? '<span class="count-badge badge-new" style="margin-left:6px">Novo</span>' : ''}
+        </td>
         <td class="col-total"><span class="count-badge badge-neutral">${g.services.length}</span></td>
         <td class="col-pend">${pend > 0 ? `<span class="count-badge badge-pending">${pend}</span>` : '<span style="color:#d1d5db">0</span>'}</td>
         <td class="col-trat">${trat > 0 ? `<span class="count-badge badge-done">${trat}</span>`    : '<span style="color:#d1d5db">0</span>'}</td>
@@ -802,6 +810,17 @@ function filterTable() {
 function openDetail(plate) {
   currentPlate = plate;
   const services = allServices.filter(s => s.matricula.toUpperCase() === plate);
+
+  // Marcar como visto (background, sem bloquear UI)
+  const token = localStorage.getItem('eg_auth_token');
+  services.filter(s => !s.viewed_at).forEach(s => {
+    s.viewed_at = new Date().toISOString(); // optimistic update local
+    fetch('/.netlify/functions/mycar-services', {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: s.id, viewed: true })
+    });
+  });
 
   document.getElementById('detail-title').textContent = `Matrícula: ${plate}`;
   document.getElementById('detail-subtitle').textContent = '';

--- a/netlify/functions/mycar-services.js
+++ b/netlify/functions/mycar-services.js
@@ -38,6 +38,7 @@ async function ensureTable(client) {
   `);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS obs_tecnico TEXT`);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS email_body TEXT`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMP`);
   await client.query(`ALTER TABLE mycar_services DROP CONSTRAINT IF EXISTS mycar_services_status_check`);
   await client.query(`UPDATE mycar_services SET status = 'realizado' WHERE status = 'tratado'`);
   await client.query(`ALTER TABLE mycar_services ADD CONSTRAINT mycar_services_status_check CHECK (status IN ('pendente', 'encomendado', 'realizado', 'faturado', 'rejeitado'))`);
@@ -100,9 +101,18 @@ exports.handler = async (event) => {
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
     }
 
-    // PATCH - atualizar status de um serviço
+    // PATCH - atualizar status de um serviço (ou marcar como visto)
     if (event.httpMethod === 'PATCH') {
-      const { id, status, notas, obs_tecnico } = JSON.parse(event.body || '{}');
+      const { id, status, notas, obs_tecnico, viewed } = JSON.parse(event.body || '{}');
+
+      // Marcar como visto (pode ser sem status)
+      if (id && viewed && !status) {
+        await client.query(
+          `UPDATE mycar_services SET viewed_at = COALESCE(viewed_at, NOW()) WHERE id = $1`,
+          [id]
+        );
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
 
       if (!id || !status) {
         return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'id e status são obrigatórios' }) };
@@ -111,7 +121,7 @@ exports.handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'Status inválido' }) };
       }
 
-      const setClauses = [`status = $1`, `updated_at = NOW()`];
+      const setClauses = [`status = $1`, `updated_at = NOW()`, `viewed_at = COALESCE(viewed_at, NOW())`];
       const params = [status];
       let idx = 2;
 


### PR DESCRIPTION
- Nova coluna `viewed_at TIMESTAMP` na DB
- Linhas não abertas → fundo azul claro + texto bold + badge **Novo** ao lado da matrícula
- Ao abrir o modal de detalhe, todos os serviços da matrícula ficam marcados como vistos (update optimista local + PATCH na DB)
- Linhas novas ordenam-se para o topo da tabela

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_