### PR TITLE
fix: add n_obra column migration to sync-portal

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -878,6 +878,7 @@ function analyzeDistribution() {
 
 async function startImport() {
   const nmdosCol = importHeaders.findIndex(h => h.toLowerCase() === 'nmdos');
+  const obraCol  = importHeaders.findIndex(h => h.toLowerCase() === 'obrano');
   const plateCol = importHeaders.findIndex(h => h.toLowerCase() === 'matricula');
   const marcaCol = importHeaders.findIndex(h => h.toLowerCase() === 'marca');
   const modeloCol = importHeaders.findIndex(h => h.toLowerCase() === 'modelo');
@@ -952,6 +953,7 @@ async function startImport() {
     const phone = phoneCol >= 0 && row[phoneCol] ? String(row[phoneCol]).trim() : '';
     const email = emailCol >= 0 && row[emailCol] ? String(row[emailCol]).trim() : '';
     const eurocode = eurocodeCol >= 0 && row[eurocodeCol] ? String(row[eurocodeCol]).trim() : '';
+    const n_obra = obraCol >= 0 && row[obraCol] ? String(row[obraCol]).trim() : null;
 
     // ✅ MAPEAMENTO CORRECTO (confirmado com utilizador):
     // Nome do cliente (DB: client_name) → col K - Segurado
@@ -991,7 +993,8 @@ async function startImport() {
       createdAt,
       date: scheduleDate || null,
       period: schedulePeriod || null,
-      confirmed: false  // sempre pré-agendamento ao importar do Excel
+      confirmed: false,  // sempre pré-agendamento ao importar do Excel
+      n_obra: n_obra || null
     });
   });
 

--- a/admin-script.js
+++ b/admin-script.js
@@ -1066,6 +1066,7 @@ async function startSync() {
   if (!confirm('🔄 SINCRONIZAR COM EXCEL\n\nO que vai acontecer:\n✅ Cria os serviços que faltam\n✅ Move para agenda os que têm hora\n🗑️ Apaga os pendentes (sem data) que não estão no Excel\n🔒 Nunca toca nos já agendados (com data)\n\nTens a certeza?')) return;
 
   const nmdosCol = importHeaders.findIndex(h => h.toLowerCase() === 'nmdos');
+  const obraCol  = importHeaders.findIndex(h => h.toLowerCase() === 'obrano');
   const plateCol = importHeaders.findIndex(h => h.toLowerCase() === 'matricula');
   const marcaCol = importHeaders.findIndex(h => h.toLowerCase() === 'marca');
   const modeloCol = importHeaders.findIndex(h => h.toLowerCase() === 'modelo');
@@ -1120,6 +1121,7 @@ async function startSync() {
     const segurado = seguradoCol >= 0 && row[seguradoCol] ? String(row[seguradoCol]).trim() : '';
     const obs = obsCol >= 0 && row[obsCol] ? String(row[obsCol]).trim() : '';
     const phone = phoneCol >= 0 && row[phoneCol] ? String(row[phoneCol]).trim() : '';
+    const n_obra = obraCol >= 0 && row[obraCol] ? String(row[obraCol]).trim() : null;
     const createdAt = dataObraCol >= 0 ? excelDateToISO(row[dataObraCol]) : null;
 
     // ✅ MAPEAMENTO CORRECTO (confirmado com utilizador):
@@ -1146,7 +1148,8 @@ async function startSync() {
       portal_id: portalInfo.id, plate, car, service: 'PB',
       notes, extra, client_name, phone, status: 'NE', createdAt,
       date: scheduleDate || null, period: schedulePeriod || null,
-      confirmed: false  // sempre pré-agendamento ao importar do Excel
+      confirmed: false,  // sempre pré-agendamento ao importar do Excel
+      n_obra: n_obra || null
     });
   });
 

--- a/index.html
+++ b/index.html
@@ -511,13 +511,16 @@
             </div>
           </div>
 
-          <!-- LINHA 8b: Eurocode + Outros dados -->
+          <!-- LINHA 8b: Eurocode + Nº Ficha -->
           <div class="form-row">
             <div class="form-group">
               <label for="appointmentExtra">Eurocode</label>
               <textarea id="appointmentExtra" placeholder="Ex: 3556AGSVW" rows="2"></textarea>
             </div>
-            <div class="form-group"></div>
+            <div class="form-group">
+              <label for="appointmentNObra">Nº de Ficha (opcional)</label>
+              <input type="text" id="appointmentNObra" placeholder="Ex: 12345" autocomplete="off" />
+            </div>
           </div>
 
           <!-- Foto URL -->

--- a/mycar.html
+++ b/mycar.html
@@ -202,14 +202,37 @@
       color: var(--text);
     }
     .plate-badge {
-      display: inline-block;
-      background: #1e3a8a;
-      color: white;
-      padding: 3px 10px;
-      border-radius: 5px;
-      font-family: monospace;
-      font-size: .92rem;
-      letter-spacing: 1.5px;
+      display: inline-flex;
+      align-items: stretch;
+      border: 2px solid #222;
+      border-radius: 4px;
+      overflow: hidden;
+      font-family: 'Arial Black', 'Arial Bold', sans-serif;
+      font-size: .88rem;
+      font-weight: 900;
+      letter-spacing: 2px;
+      line-height: 1;
+      box-shadow: 0 1px 3px rgba(0,0,0,.18);
+    }
+    .plate-badge::before {
+      content: 'P';
+      background: #003399;
+      color: #fff;
+      font-size: .62rem;
+      font-weight: 700;
+      letter-spacing: 0;
+      padding: 2px 5px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+    }
+    .plate-badge-text {
+      background: #fff;
+      color: #111;
+      padding: 3px 8px;
+      display: flex;
+      align-items: center;
     }
     .count-badge {
       display: inline-block;
@@ -474,7 +497,7 @@
       /* Tabela */
       .table-card { overflow-x: hidden; }
       td, thead th { padding: 10px 10px; font-size: .82rem; }
-      .plate-badge { font-size: .82rem; padding: 3px 7px; letter-spacing: .8px; }
+      .plate-badge { font-size: .78rem; } .plate-badge-text { padding: 2px 5px; letter-spacing: 1px; }
       /* Empty state */
       .empty-state { padding: 40px 16px; }
       .empty-state p { font-size: .88rem; word-break: break-word; }
@@ -779,7 +802,7 @@ function renderTable(groups) {
     return `
       <tr class="${g.isNew ? 'row-new' : ''}" onclick="openDetail('${g.matricula}')">
         <td class="plate-cell">
-          <span class="plate-badge">${g.matricula}</span>
+          <span class="plate-badge"><span class="plate-badge-text">${g.matricula}</span></span>
           ${g.isNew ? '<span class="count-badge badge-new" style="margin-left:6px">Novo</span>' : ''}
         </td>
         <td class="col-total"><span class="count-badge badge-neutral">${g.services.length}</span></td>
@@ -822,7 +845,7 @@ function openDetail(plate) {
     });
   });
 
-  document.getElementById('detail-title').textContent = `Matrícula: ${plate}`;
+  document.getElementById('detail-title').innerHTML = `<span class="plate-badge"><span class="plate-badge-text">${plate}</span></span>`;
   document.getElementById('detail-subtitle').textContent = '';
 
   renderDetailBody(plate);

--- a/mycar.html
+++ b/mycar.html
@@ -750,11 +750,13 @@ function buildGroups(services) {
   const map = {};
   for (const svc of services) {
     const key = svc.matricula.toUpperCase();
-    if (!map[key]) map[key] = { matricula: key, services: [], lastDate: null, isNew: false };
+    if (!map[key]) map[key] = { matricula: key, services: [], lastDate: null, isNew: false, car: null, n_obra: null };
     map[key].services.push(svc);
     const d = svc.email_received_at || svc.created_at;
     if (d && (!map[key].lastDate || d > map[key].lastDate)) map[key].lastDate = d;
     if (!svc.viewed_at) map[key].isNew = true;
+    if (svc.car && !map[key].car) map[key].car = svc.car;
+    if (svc.n_obra && !map[key].n_obra) map[key].n_obra = svc.n_obra;
   }
   return Object.values(map).sort((a, b) => {
     // Ordenar: primeiro os novos, depois os que têm pendentes
@@ -804,6 +806,7 @@ function renderTable(groups) {
         <td class="plate-cell">
           <span class="plate-badge"><span class="plate-badge-text">${g.matricula}</span></span>
           ${g.isNew ? '<span class="count-badge badge-new" style="margin-left:6px">Novo</span>' : ''}
+          ${g.car ? `<div style="font-size:.75rem;color:#6b7280;margin-top:3px">${g.car}</div>` : ''}
         </td>
         <td class="col-total"><span class="count-badge badge-neutral">${g.services.length}</span></td>
         <td class="col-pend">${pend > 0 ? `<span class="count-badge badge-pending">${pend}</span>` : '<span style="color:#d1d5db">0</span>'}</td>
@@ -880,6 +883,14 @@ function renderDetailBody(plate) {
           <div class="meta-label">Descrição</div>
           <div class="meta-value">${svc.descricao || '—'}</div>
         </div>
+        ${svc.car ? `<div class="meta-item">
+          <div class="meta-label">Viatura</div>
+          <div class="meta-value">${svc.car}</div>
+        </div>` : ''}
+        ${svc.n_obra ? `<div class="meta-item">
+          <div class="meta-label">Nº Ficha</div>
+          <div class="meta-value" style="font-weight:700">${svc.n_obra}</div>
+        </div>` : ''}
         <div class="meta-item" style="grid-column:1/-1">
           <div class="meta-label">Eurocode</div>
           <div class="meta-value" style="font-family:monospace">${svc.eurocode || '—'}</div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,4 +14,7 @@
 
 [functions."mycar-gmail-poller"]
   node_bundler = "zisi"
+
+[functions."mycar-poller-cron"]
+  node_bundler = "zisi"
   schedule = "*/15 * * * *"

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -35,6 +35,10 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS second_of_day BOOLEAN DEFAULT FALSE`);
   } catch(migErr) { console.warn('Migration second_of_day warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+  } catch(migErr) { console.warn('Migration n_obra warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -75,7 +79,7 @@ exports.handler = async (event) => {
                vehicle_type, travel_time, auto_imported, executed, confirmed,
                calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
-               custom_service_time, foreign_plate, extra_services, created_at, updated_at
+               custom_service_time, foreign_plate, extra_services, n_obra, created_at, updated_at
         FROM appointments
         WHERE portal_id = $1
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
@@ -110,9 +114,9 @@ exports.handler = async (event) => {
           notes, address, extra, phone, km, sortIndex, "glassOrdered",
           vehicle_type, travel_time, confirmed, calibration, first_of_day, second_of_day,
           not_done_reason, commercial_user_id, return_km, return_time, client_name, damage_details,
-          glass_removed_date, custom_service_time, foreign_plate, extra_services, portal_id, created_at, updated_at
+          glass_removed_date, custom_service_time, foreign_plate, extra_services, n_obra, portal_id, created_at, updated_at
         ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34
         ) RETURNING *
       `;
       const v = [
@@ -136,6 +140,7 @@ exports.handler = async (event) => {
         data.custom_service_time ? parseInt(data.custom_service_time) : null,
         data.foreign_plate === true,
         data.extra_services ? JSON.stringify(data.extra_services) : null,
+        data.n_obra || null,
         portalId, createdAt, new Date().toISOString()
       ];
       const { rows } = await pool.query(q, v);
@@ -182,8 +187,8 @@ exports.handler = async (event) => {
           executed = $18, confirmed = $19, calibration = $20,
           first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
-          glass_removed_date = $31, updated_at = $32
-        WHERE id = $33 AND portal_id = $34
+          glass_removed_date = $31, n_obra = $32, updated_at = $33
+        WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
       const v = [
@@ -211,6 +216,7 @@ exports.handler = async (event) => {
         data.glass_removed !== undefined ? (!!data.glass_removed) : (existing.glass_removed || false),
         JSON.stringify(data.extra_services !== undefined ? (data.extra_services || []) : (existing.extra_services || [])),
         data.glass_removed_date !== undefined ? (data.glass_removed_date || null) : (existing.glass_removed_date || null),
+        data.n_obra !== undefined ? (data.n_obra || null) : null,
         new Date().toISOString(), id, effectivePortalId
       ];
       const { rows } = await pool.query(q, v);

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -41,6 +41,12 @@ exports.handler = async (event) => {
 
     const results = { created: 0, updated: 0, skipped: 0, errors: 0, details: [] };
 
+    // Garantir colunas car e n_obra em mycar_services
+    try {
+      await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
+      await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+    } catch(e) { console.warn('Migration mycar_services warning:', e.message); }
+
     for (const svc of services) {
       try {
         if (!svc.portal_id || !svc.plate) {
@@ -93,6 +99,11 @@ exports.handler = async (event) => {
           if (svc.damage_details) {
             updateFields.push(`damage_details = $${idx++}`);
             updateVals.push(svc.damage_details);
+          }
+          // Actualizar n_obra se Excel tem valor
+          if (svc.n_obra) {
+            updateFields.push(`n_obra = $${idx++}`);
+            updateVals.push(svc.n_obra);
           }
 
           // Se NÃO está na agenda mas Excel tem data → colocar na agenda
@@ -167,6 +178,26 @@ exports.handler = async (event) => {
 
           results.created++;
           results.details.push({ plate: svc.plate, portal_id: svc.portal_id, status: 'created' });
+        }
+
+        // Atualizar mycar_services com car e n_obra se a matrícula constar no mural
+        if (svc.car || svc.n_obra) {
+          const myCols = [];
+          const myVals = [];
+          let myIdx = 1;
+          if (svc.car) { myCols.push(`car = $${myIdx++}`); myVals.push(svc.car); }
+          if (svc.n_obra) { myCols.push(`n_obra = $${myIdx++}`); myVals.push(svc.n_obra); }
+          myCols.push(`updated_at = $${myIdx++}`);
+          myVals.push(new Date().toISOString());
+          myVals.push(String(svc.plate).replace(/[^A-Z0-9]/gi, '').toUpperCase());
+          try {
+            await pool.query(
+              `UPDATE mycar_services
+               SET ${myCols.join(', ')}
+               WHERE UPPER(REGEXP_REPLACE(matricula, '[^A-Z0-9]', '', 'g')) = $${myIdx}`,
+              myVals
+            );
+          } catch(e) { console.warn('mycar_services update warning:', e.message); }
         }
 
       } catch (err) {

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -136,9 +136,9 @@ exports.handler = async (event) => {
             `INSERT INTO appointments (
               date, period, plate, car, service, locality, status,
               notes, address, extra, phone, km, sortIndex, "glassOrdered",
-              auto_imported, confirmed, damage_details, portal_id, created_at, updated_at
+              auto_imported, confirmed, damage_details, n_obra, portal_id, created_at, updated_at
             ) VALUES (
-              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20
+              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
             ) RETURNING id`,
             [
               svc.date || null,
@@ -158,6 +158,7 @@ exports.handler = async (event) => {
               hasAutoDate,    // auto_imported
               false,          // confirmed
               svc.damage_details || null,
+              svc.n_obra || null,
               svc.portal_id,
               svc.createdAt || new Date().toISOString(),
               new Date().toISOString()

--- a/netlify/functions/mycar-poller-cron.js
+++ b/netlify/functions/mycar-poller-cron.js
@@ -1,0 +1,284 @@
+// netlify/functions/mycar-poller-cron.js
+// Pure scheduled function — runs every 15 min via Netlify Scheduled Functions
+// No HTTP handling to avoid any method-check conflicts
+
+if (typeof File === 'undefined') {
+  try { global.File = require('buffer').File; } catch (_) {
+    global.File = class File extends Blob {
+      constructor(bits, name, opts = {}) { super(bits, opts); this.name = name; this.lastModified = opts.lastModified ?? Date.now(); }
+    };
+  }
+}
+
+const { Pool } = require('pg');
+const Imap = require('imap');
+const { simpleParser } = require('mailparser');
+const cheerio = require('cheerio');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+const GMAIL_USER     = process.env.MYCAR_GMAIL_USER;
+const GMAIL_PASSWORD = process.env.MYCAR_GMAIL_PASSWORD;
+
+function extractWip(subject) {
+  const m = subject.match(/WIP[:\s]+(\w+)/i);
+  return m ? `WIP: ${m[1]}` : null;
+}
+
+function parseValor(str) {
+  if (!str) return null;
+  const v = parseFloat(str.replace(/[^\d,.-]/g, '').replace(',', '.'));
+  return isNaN(v) ? null : v;
+}
+
+function parseTableHtml(html) {
+  if (!html) return [];
+  const $ = cheerio.load(html);
+  const services = [];
+
+  $('table').each((_, table) => {
+    const $rows = $(table).find('tr');
+    let headerRowIdx = -1;
+    let headers = [];
+
+    $rows.each((rowIdx, row) => {
+      const cells = $(row).find('th, td').map((_, c) => $(c).text().trim().toLowerCase()).get();
+      if (cells.some(h => /matr[ií]cula/i.test(h))) {
+        headerRowIdx = rowIdx;
+        headers = cells;
+        return false;
+      }
+    });
+
+    if (headerRowIdx < 0) return;
+
+    const matIdx = headers.findIndex(h => /matr[ií]cula/i.test(h));
+    const svcIdx = headers.findIndex(h => /servi[çc]o|descri[çc][aã]o/i.test(h));
+    const valIdx = headers.findIndex(h => /valor/i.test(h));
+    const neIdx  = headers.findIndex(h => /^ne$/i.test(h));
+    const notIdx = headers.findIndex(h => /notas?/i.test(h));
+
+    $rows.slice(headerRowIdx + 1).each((_, row) => {
+      const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
+      if (cells.length < 2) return;
+      const mat = cells[matIdx]?.replace(/\s/g, '').toUpperCase();
+      if (!mat || mat.length < 4) return;
+
+      services.push({
+        matricula: mat,
+        descricao: svcIdx >= 0 ? (cells[svcIdx] || null) : null,
+        valor:     valIdx >= 0 ? parseValor(cells[valIdx]) : null,
+        eurocode:  notIdx >= 0 ? (cells[notIdx] || null) : null,
+        ne:        neIdx  >= 0 ? (cells[neIdx]  || null) : null,
+      });
+    });
+  });
+
+  return services;
+}
+
+function cleanEmailBody(text) {
+  if (!text) return null;
+
+  const fwdRx = /[-]{4,}\s*(Forwarded message|Mensagem encaminhada|Original Message)/i;
+  const fwdIdx = text.search(fwdRx);
+  if (fwdIdx >= 0) {
+    const after = text.slice(fwdIdx);
+    const lines = after.split('\n');
+    let bodyStart = 0;
+    let inHeaders = false;
+    for (let i = 0; i < lines.length; i++) {
+      if (/^(From|De|Date|Data|Subject|Assunto|To|Para|Cc):/i.test(lines[i].trim())) { inHeaders = true; continue; }
+      if (inHeaders && lines[i].trim() === '') { bodyStart = i + 1; break; }
+    }
+    text = lines.slice(bodyStart).join('\n');
+  }
+
+  const cleaned = text.split('\n').filter(line => {
+    const t = line.trim();
+    if (!t) return false;
+    if (/^[-=_*>]{3,}$/.test(t)) return false;
+    if (/^(From|De|Date|Data|Subject|Assunto|To|Para|Cc|Sent|Enviado):/i.test(t)) return false;
+    if (/^\[?(image|imagem|cid:)/i.test(t)) return false;
+    if ((t.match(/\t/g) || []).length >= 2) return false;
+    return true;
+  }).join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+  return cleaned.slice(0, 600) || null;
+}
+
+async function getMycaPortalId(client) {
+  const { rows } = await client.query(
+    `SELECT id FROM portals WHERE name = 'Mycar Center' LIMIT 1`
+  );
+  return rows.length > 0 ? rows[0].id : null;
+}
+
+async function ensureTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS mycar_services (
+      id SERIAL PRIMARY KEY,
+      matricula VARCHAR(20) NOT NULL,
+      data_servico DATE,
+      descricao TEXT,
+      valor DECIMAL(10,2),
+      eurocode VARCHAR(100),
+      status VARCHAR(20) DEFAULT 'pendente',
+      email_from VARCHAR(255),
+      email_subject VARCHAR(500),
+      email_received_at TIMESTAMP,
+      portal_id INTEGER,
+      notas TEXT,
+      obs_tecnico TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS obs_tecnico TEXT`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS email_body TEXT`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMP`);
+  await client.query(`ALTER TABLE mycar_services DROP CONSTRAINT IF EXISTS mycar_services_status_check`);
+  await client.query(`UPDATE mycar_services SET status = 'realizado' WHERE status = 'tratado'`);
+  await client.query(`ALTER TABLE mycar_services ADD CONSTRAINT mycar_services_status_check CHECK (status IN ('pendente', 'encomendado', 'realizado', 'faturado', 'rejeitado'))`);
+}
+
+function fetchUnseenEmails() {
+  return new Promise((resolve, reject) => {
+    if (!GMAIL_USER || !GMAIL_PASSWORD) {
+      reject(new Error('MYCAR_GMAIL_USER ou MYCAR_GMAIL_PASSWORD não configurados'));
+      return;
+    }
+
+    const imap = new Imap({
+      user: GMAIL_USER,
+      password: GMAIL_PASSWORD,
+      host: 'imap.gmail.com',
+      port: 993,
+      tls: true,
+      tlsOptions: { rejectUnauthorized: false },
+      connTimeout: 20000,
+      authTimeout: 10000
+    });
+
+    const emails = [];
+
+    imap.once('ready', () => {
+      imap.openBox('INBOX', false, (err) => {
+        if (err) { imap.end(); reject(err); return; }
+
+        const since = new Date();
+        since.setDate(since.getDate() - 3);
+        imap.search([['SINCE', since]], (err, uids) => {
+          if (err) { imap.end(); reject(err); return; }
+          if (!uids || uids.length === 0) { imap.end(); resolve([]); return; }
+
+          console.log(`📬 ${uids.length} email(s) encontrado(s) nos últimos 3 dias`);
+
+          const fetch = imap.fetch(uids, { bodies: '', markSeen: false });
+          const pending = [];
+
+          fetch.on('message', (msg) => {
+            const p = new Promise((res) => {
+              const chunks = [];
+              msg.on('body', (stream) => {
+                stream.on('data', chunk => chunks.push(chunk));
+                stream.once('end', () => res(Buffer.concat(chunks)));
+              });
+              msg.once('attributes', () => {});
+            });
+            pending.push(p);
+          });
+
+          fetch.once('end', async () => {
+            for (const raw of await Promise.all(pending)) {
+              const parsed = await simpleParser(raw);
+              emails.push(parsed);
+            }
+            imap.end();
+            resolve(emails);
+          });
+
+          fetch.once('error', (err) => { imap.end(); reject(err); });
+        });
+      });
+    });
+
+    imap.once('error', reject);
+    imap.connect();
+  });
+}
+
+exports.handler = async () => {
+  console.log('⏰ mycar-poller-cron: início');
+
+  const client = await pool.connect();
+  try {
+    await ensureTable(client);
+    const portalId = await getMycaPortalId(client);
+
+    let emails;
+    try {
+      emails = await fetchUnseenEmails();
+    } catch (err) {
+      console.error('❌ Erro IMAP:', err.message);
+      return { statusCode: 500, body: JSON.stringify({ success: false, error: err.message }) };
+    }
+
+    if (emails.length === 0) {
+      console.log('📭 Sem emails');
+      return { statusCode: 200, body: JSON.stringify({ success: true, processed: 0, emails: 0 }) };
+    }
+
+    let totalImported = 0;
+
+    for (const email of emails) {
+      const subject  = email.subject || '';
+      const from     = email.from?.text || '';
+      const date     = email.date || new Date();
+      const html     = email.html || '';
+      const wip      = extractWip(subject);
+      const body     = cleanEmailBody(email.text || '');
+
+      const tableCount = html ? cheerio.load(html)('table').length : 0;
+      console.log(`📧 "${subject}" | html:${!!html} | tabelas:${tableCount}`);
+
+      const services = html ? parseTableHtml(html) : [];
+
+      if (services.length === 0) {
+        console.log(`⏭️ Sem tabela: "${subject}"`);
+        continue;
+      }
+
+      for (const svc of services) {
+        const { rows: existing } = await client.query(
+          `SELECT id FROM mycar_services WHERE matricula = $1 AND email_subject = $2 LIMIT 1`,
+          [svc.matricula, subject]
+        );
+        if (existing.length > 0) {
+          console.log(`⏭️ Duplicado: ${svc.matricula}`);
+          continue;
+        }
+
+        await client.query(
+          `INSERT INTO mycar_services
+             (matricula, descricao, valor, eurocode, status,
+              email_from, email_subject, email_received_at, portal_id, notas, email_body)
+           VALUES ($1,$2,$3,$4,'pendente',$5,$6,$7,$8,$9,$10)`,
+          [svc.matricula, svc.descricao, svc.valor, svc.eurocode,
+           from, subject, date, portalId, wip, body || null]
+        );
+        totalImported++;
+        console.log(`✅ ${svc.matricula} | ${svc.descricao} | €${svc.valor}`);
+      }
+    }
+
+    console.log(`📊 Total: ${totalImported} serviço(s) de ${emails.length} email(s)`);
+    return { statusCode: 200, body: JSON.stringify({ success: true, processed: totalImported, emails: emails.length }) };
+
+  } finally {
+    client.release();
+  }
+};

--- a/netlify/functions/mycar-services.js
+++ b/netlify/functions/mycar-services.js
@@ -39,6 +39,8 @@ async function ensureTable(client) {
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS obs_tecnico TEXT`);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS email_body TEXT`);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMP`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
   await client.query(`ALTER TABLE mycar_services DROP CONSTRAINT IF EXISTS mycar_services_status_check`);
   await client.query(`UPDATE mycar_services SET status = 'realizado' WHERE status = 'tratado'`);
   await client.query(`ALTER TABLE mycar_services ADD CONSTRAINT mycar_services_status_check CHECK (status IN ('pendente', 'encomendado', 'realizado', 'faturado', 'rejeitado'))`);

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -34,6 +34,11 @@ exports.handler = async (event) => {
   }
 
   try {
+    // Ensure n_obra column exists (migration guard)
+    try {
+      await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+    } catch(e) { console.warn('Migration n_obra warning:', e.message); }
+
     const { portal_id, services } = JSON.parse(event.body || '{}');
 
     if (!portal_id || !Array.isArray(services)) {

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -85,13 +85,13 @@ exports.handler = async (event) => {
 
           if (shouldUpdateDate) {
             await pool.query(
-              `UPDATE appointments SET date=$1, period=$2, car=$3, notes=$4, extra=$5, phone=$6, client_name=$7, auto_imported=true, confirmed=false, updated_at=$8 WHERE id=$9`,
-              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id]
+              `UPDATE appointments SET date=$1, period=$2, car=$3, notes=$4, extra=$5, phone=$6, client_name=$7, n_obra=COALESCE($10,n_obra), auto_imported=true, confirmed=false, updated_at=$8 WHERE id=$9`,
+              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null]
             );
           } else {
             await pool.query(
-              `UPDATE appointments SET car=$1, notes=$2, extra=$3, phone=$4, client_name=$5, updated_at=$6 WHERE id=$7`,
-              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id]
+              `UPDATE appointments SET car=$1, notes=$2, extra=$3, phone=$4, client_name=$5, n_obra=COALESCE($7,n_obra), updated_at=$6 WHERE id=$8`,
+              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id]
             );
           }
           results.updated++;
@@ -102,14 +102,14 @@ exports.handler = async (event) => {
         await pool.query(
           `INSERT INTO appointments (
              date, period, plate, car, service, locality, status,
-             notes, extra, phone, client_name, km, sortIndex, "glassOrdered",
+             notes, extra, phone, client_name, n_obra, km, sortIndex, "glassOrdered",
              auto_imported, confirmed, portal_id, created_at, updated_at
-           ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,null,1,false,$11,false,$12,$13,$14)`,
+           ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,$11,null,1,false,$12,false,$13,$14,$15)`,
           [
             svc.date||null, svc.period||null,
             String(svc.plate).trim(), svc.car||null, svc.service||null,
             svc.status||'NE', svc.notes||null, svc.extra||null, svc.phone||null,
-            svc.client_name||null,
+            svc.client_name||null, svc.n_obra||null,
             !!svc.date, portal_id,
             svc.createdAt||now, now
           ]

--- a/script-tail.js
+++ b/script-tail.js
@@ -1010,6 +1010,7 @@ function bootApp() {
         : null,
       client_name: (document.getElementById('appointmentClientName')?.value || '').trim() || null,
       damage_details: (document.getElementById('appointmentDamageDetails')?.value || '').trim() || null,
+      n_obra: (document.getElementById('appointmentNObra')?.value || '').trim() || null,
       custom_service_time: document.getElementById('appointmentService')?.value === 'OUT'
         ? (parseInt(document.getElementById('appointmentCustomTime')?.value) || null)
         : null,

--- a/script-tail.js
+++ b/script-tail.js
@@ -146,7 +146,7 @@ const telBtn = phone ? `
         ${wazeBtn}${mapsBtn}${telBtn}
       </div>
       <div style="${iconPadding}">
-        <div class="m-title"><span class="m-title-text">${plate}</span></div>
+        <div class="m-title"><span class="m-title-text">${plate}</span>${a.n_obra ? `<span style="font-size:11px;font-weight:600;color:rgba(255,255,255,0.75);margin-left:6px;">📋 ${a.n_obra}</span>` : ''}</div>
         ${car ? `<div class="m-car">${car}</div>` : ''}
         ${chips ? `<div class="m-chips" data-ms-patched="1">${chips}</div>` : ''}
         ${a.commercial_user_id ? `<div style="display:inline-block;background:#7c3aed !important;color:#fff !important;font-size:11px;font-weight:800;padding:3px 10px;border-radius:12px;margin-bottom:4px;animation:blink 1.5s infinite;">🤝 COMERCIAL</div>` : ''}

--- a/script.js
+++ b/script.js
@@ -2288,6 +2288,7 @@ function editAppointment(id) {
   document.getElementById('appointmentAddress').value = appointment.address || '';
   document.getElementById('appointmentPhone').value = appointment.phone || '';
   if (document.getElementById('appointmentClientName')) document.getElementById('appointmentClientName').value = appointment.client_name || '';
+  if (document.getElementById('appointmentNObra')) document.getElementById('appointmentNObra').value = appointment.n_obra || '';
   // Parse extra field (may be JSON with eurocode + photo_url + history)
   let _extraParsed = null;
   if (appointment.extra) {
@@ -2584,7 +2585,7 @@ function buildDesktopCard(a){
     <div class="appointment desk-card${needsLoc}${isPreAgendado ? ' pre-agendado' : ''}" data-id="${a.id}" draggable="true"
          data-locality="${a.locality||''}" data-loccolor="${base}"
          style="--c1:${g.c1}; --c2:${g.c2}; --tc:${textColor}; ${bar} ${glassRemovedBorderStyle}">
-      <div class="dc-title"><span class="dc-title-text">${plate}</span></div>
+      <div class="dc-title"><span class="dc-title-text">${plate}</span>${a.n_obra ? `<span style="font-size:11px;font-weight:600;color:#6b7280;margin-left:6px;">📋 ${a.n_obra}</span>` : ''}</div>
       <div class="dc-meta" data-ms-patched="1">
         ${getAllServices(a).map(s => `<span class="dc-badge">${s.service||''}</span>`).join('')}
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}

--- a/template-expressglass-completo.js
+++ b/template-expressglass-completo.js
@@ -69,6 +69,9 @@ class ExpressglassFileProcessor {
     
     // Matrícula (coluna 8)
     result.plate = this.formatPlate(row[8] || '');
+
+    // Nº de obra/ficha (coluna 2)
+    result.n_obra = (row[2] || '').toString().trim() || null;
     
     // Carro - combinar Marca + Modelo (colunas 11 e 12)
     const marca = (row[11] || '').trim();

--- a/template-personalizado.js
+++ b/template-personalizado.js
@@ -75,6 +75,7 @@ class ProcessadorPersonalizado {
 
   async processarLinha(row, numeroLinha) {
     const matricula   = row[8]  || '';
+    const nObra       = (row[2]  || '').toString().trim() || null;
     const marca       = (row[11] || '').trim();
     const modelo      = (row[12] || '').trim();
     // ✅ CORRECÇÃO: Obs (col J, índice 9) → Eurocode; Segurado (col K, índice 10) → Observações
@@ -161,6 +162,7 @@ class ProcessadorPersonalizado {
       confirmed:     false,
       km:            null,
       sortIndex:     1,
+      n_obra:        nObra,
       createdAt:     dataCriacao,
       importedAt:    new Date().toISOString(),
       importedFrom:  'excel_personalizado'


### PR DESCRIPTION
## Summary
- `sync-portal.js` had no migration guard for the `n_obra` column
- The SQL `n_obra=COALESCE($7,n_obra)` references the column, which fails silently if the column doesn't exist in the DB
- Added `ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)` at the start of the handler so the column is always present before any query runs

## Root cause
`appointments.js` creates the column via its own migration, but `sync-portal.js` runs independently and never triggered that migration — so the first Excel import after deploy would fail to save n_obra on any appointment row.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_