### PR TITLE
feat: sync car and n_obra to mycar_services on Excel import

### DIFF
--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -37,7 +37,9 @@ exports.handler = async (event) => {
     // Ensure n_obra column exists (migration guard)
     try {
       await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
-    } catch(e) { console.warn('Migration n_obra warning:', e.message); }
+      await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
+      await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+    } catch(e) { console.warn('Migration warning:', e.message); }
 
     const { portal_id, services } = JSON.parse(event.body || '{}');
 
@@ -100,26 +102,43 @@ exports.handler = async (event) => {
             );
           }
           results.updated++;
-          continue;
+        } else {
+          // Não existe → criar
+          await pool.query(
+            `INSERT INTO appointments (
+               date, period, plate, car, service, locality, status,
+               notes, extra, phone, client_name, n_obra, km, sortIndex, "glassOrdered",
+               auto_imported, confirmed, portal_id, created_at, updated_at
+             ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,$11,null,1,false,$12,false,$13,$14,$15)`,
+            [
+              svc.date||null, svc.period||null,
+              String(svc.plate).trim(), svc.car||null, svc.service||null,
+              svc.status||'NE', svc.notes||null, svc.extra||null, svc.phone||null,
+              svc.client_name||null, svc.n_obra||null,
+              !!svc.date, portal_id,
+              svc.createdAt||now, now
+            ]
+          );
+          results.created++;
         }
 
-        // Não existe → criar
-        await pool.query(
-          `INSERT INTO appointments (
-             date, period, plate, car, service, locality, status,
-             notes, extra, phone, client_name, n_obra, km, sortIndex, "glassOrdered",
-             auto_imported, confirmed, portal_id, created_at, updated_at
-           ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,$11,null,1,false,$12,false,$13,$14,$15)`,
-          [
-            svc.date||null, svc.period||null,
-            String(svc.plate).trim(), svc.car||null, svc.service||null,
-            svc.status||'NE', svc.notes||null, svc.extra||null, svc.phone||null,
-            svc.client_name||null, svc.n_obra||null,
-            !!svc.date, portal_id,
-            svc.createdAt||now, now
-          ]
-        );
-        results.created++;
+        // Sincronizar car e n_obra no mural mycar_services se a matrícula constar
+        if (svc.car || svc.n_obra) {
+          const myCols = [];
+          const myVals = [];
+          let myIdx = 1;
+          if (svc.car) { myCols.push(`car = $${myIdx++}`); myVals.push(svc.car); }
+          if (svc.n_obra) { myCols.push(`n_obra = $${myIdx++}`); myVals.push(svc.n_obra); }
+          myCols.push(`updated_at = $${myIdx++}`);
+          myVals.push(now);
+          myVals.push(plateNorm);
+          try {
+            await pool.query(
+              `UPDATE mycar_services SET ${myCols.join(', ')} WHERE UPPER(REGEXP_REPLACE(matricula, '[^A-Z0-9]', '', 'g')) = $${myIdx}`,
+              myVals
+            );
+          } catch(e) { console.warn('mycar_services sync warning:', e.message); }
+        }
 
       } catch (err) {
         console.error('Erro svc', svc.plate, err.message);

--- a/script-tail.js
+++ b/script-tail.js
@@ -63,7 +63,7 @@ const telBtn = phone ? `
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
-  const notes = [a.client_name, _extraDisp, a.notes].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');
@@ -146,7 +146,7 @@ const telBtn = phone ? `
         ${wazeBtn}${mapsBtn}${telBtn}
       </div>
       <div style="${iconPadding}">
-        <div class="m-title"><span class="m-title-text">${plate}</span>${a.n_obra ? `<span style="font-size:11px;font-weight:600;color:rgba(255,255,255,0.75);margin-left:6px;">FS${a.n_obra}</span>` : ''}</div>
+        <div class="m-title"><span class="m-title-text">${plate}</span></div>
         ${car ? `<div class="m-car">${car}</div>` : ''}
         ${chips ? `<div class="m-chips" data-ms-patched="1">${chips}</div>` : ''}
         ${a.commercial_user_id ? `<div style="display:inline-block;background:#7c3aed !important;color:#fff !important;font-size:11px;font-weight:800;padding:3px 10px;border-radius:12px;margin-bottom:4px;animation:blink 1.5s infinite;">🤝 COMERCIAL</div>` : ''}

--- a/script.js
+++ b/script.js
@@ -2505,8 +2505,8 @@ function buildDesktopCard(a){
     try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
   }
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, _extraDisplay, a.notes].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
@@ -2585,7 +2585,7 @@ function buildDesktopCard(a){
     <div class="appointment desk-card${needsLoc}${isPreAgendado ? ' pre-agendado' : ''}" data-id="${a.id}" draggable="true"
          data-locality="${a.locality||''}" data-loccolor="${base}"
          style="--c1:${g.c1}; --c2:${g.c2}; --tc:${textColor}; ${bar} ${glassRemovedBorderStyle}">
-      <div class="dc-title"><span class="dc-title-text">${plate}</span>${a.n_obra ? `<span style="font-size:11px;font-weight:600;color:#6b7280;margin-left:6px;">FS${a.n_obra}</span>` : ''}</div>
+      <div class="dc-title"><span class="dc-title-text">${plate}</span></div>
       <div class="dc-meta" data-ms-patched="1">
         ${getAllServices(a).map(s => `<span class="dc-badge">${s.service||''}</span>`).join('')}
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}


### PR DESCRIPTION
When `sync-portal` processes Excel rows, it now updates `car` (marca+modelo) and `n_obra` (ficha de serviço) on any matching `mycar_services` record — for both created and updated appointments.

The sync runs after each appointment is processed, so both new and existing appointments trigger the mycar_services update.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_