### PR TITLE
fix: move guia AT badge to chips row on mobile cards

### DIFF
--- a/transport-guide.js
+++ b/transport-guide.js
@@ -82,22 +82,22 @@
       badge.className = 'guia-at-badge';
       badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg> Guia AT';
       badge.onclick = (e) => { e.stopPropagation(); openViewer(); };
+      badge.classList.add('guia-at-badge--inline');
+      const chipsRow = card.querySelector('.m-chips');
       const kmRow = card.querySelector('[data-km-row]');
-      if (kmRow) {
-        badge.classList.add('guia-at-badge--inline');
+      const statusRow = card.querySelector('.m-status-row');
+      if (chipsRow) {
+        chipsRow.appendChild(badge);
+      } else if (kmRow) {
         kmRow.appendChild(badge);
+      } else if (statusRow) {
+        badge.style.margin = '6px 0 4px';
+        statusRow.parentNode.insertBefore(badge, statusRow);
       } else {
-        // No km row (e.g. card without distance): inject inline before status buttons
-        const statusRow = card.querySelector('.m-status-row');
-        if (statusRow) {
-          badge.classList.add('guia-at-badge--inline');
-          badge.style.margin = '6px 0 4px';
-          statusRow.parentNode.insertBefore(badge, statusRow);
-        } else {
-          badge.classList.add('guia-at-badge--abs');
-          card.style.position = 'relative';
-          card.appendChild(badge);
-        }
+        badge.classList.remove('guia-at-badge--inline');
+        badge.classList.add('guia-at-badge--abs');
+        card.style.position = 'relative';
+        card.appendChild(badge);
       }
     });
   }


### PR DESCRIPTION
Move the Guia AT badge to the chips row (`.m-chips`) on mobile cards, grouping it with PB, Azambuja, CALIB and other service chips — instead of the km/distance row at the bottom.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_