### PR TITLE
fix: guia AT badge amber color + align in chips row

### DIFF
--- a/transport-guide.css
+++ b/transport-guide.css
@@ -67,9 +67,9 @@
   align-items: center;
   gap: 4px;
   padding: 4px 9px;
-  background: rgba(255,255,255,0.18);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.3);
+  background: #f59e0b;
+  color: #1a1a1a;
+  border: none;
   border-radius: 20px;
   font-size: 10px;
   font-weight: 800;
@@ -78,7 +78,8 @@
   transition: background 0.15s, transform 0.1s;
   white-space: nowrap;
 }
-.guia-at-badge--inline { margin-left: auto; }
+.guia-at-badge--inline { }
+.guia-at-badge--km { margin-left: auto; }
 .guia-at-badge--abs {
   position: absolute;
   bottom: 10px;

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -89,6 +89,7 @@
       if (chipsRow) {
         chipsRow.appendChild(badge);
       } else if (kmRow) {
+        badge.classList.add('guia-at-badge--km');
         kmRow.appendChild(badge);
       } else if (statusRow) {
         badge.style.margin = '6px 0 4px';


### PR DESCRIPTION
- Badge color changed to amber (`#f59e0b`) with dark text for clear contrast against colored card backgrounds
- `margin-left: auto` moved to a new `--km` class, only applied when the badge is in the km row (desktop cards). In the chips row it now aligns naturally left with the other chips.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_