### PR TITLE
fix: mycar-poller parse headerless table emails (BR-42-XN format)

### DIFF
--- a/netlify/functions/mycar-poller-cron.js
+++ b/netlify/functions/mycar-poller-cron.js
@@ -34,6 +34,10 @@ function parseValor(str) {
   return isNaN(v) ? null : v;
 }
 
+// Portuguese plate: AA-##-AA (current), ##-AA-## or ##-##-AA (older)
+const PLATE_RX = /^[A-Z]{2}-\d{2}-[A-Z]{2}$|^\d{2}-[A-Z]{2}-\d{2}$|^\d{2}-\d{2}-[A-Z]{2}$/i;
+const EUROCODE_RX = /\b\d{4}[A-Z]{3,}[0-9A-Z]*\b/i;
+
 function parseTableHtml(html) {
   if (!html) return [];
   const $ = cheerio.load(html);
@@ -53,28 +57,53 @@ function parseTableHtml(html) {
       }
     });
 
-    if (headerRowIdx < 0) return;
+    if (headerRowIdx >= 0) {
+      // Standard parsing with header row
+      const matIdx = headers.findIndex(h => /matr[ií]cula/i.test(h));
+      const svcIdx = headers.findIndex(h => /servi[çc]o|descri[çc][aã]o/i.test(h));
+      const valIdx = headers.findIndex(h => /valor/i.test(h));
+      const neIdx  = headers.findIndex(h => /^ne$/i.test(h));
+      const notIdx = headers.findIndex(h => /notas?/i.test(h));
 
-    const matIdx = headers.findIndex(h => /matr[ií]cula/i.test(h));
-    const svcIdx = headers.findIndex(h => /servi[çc]o|descri[çc][aã]o/i.test(h));
-    const valIdx = headers.findIndex(h => /valor/i.test(h));
-    const neIdx  = headers.findIndex(h => /^ne$/i.test(h));
-    const notIdx = headers.findIndex(h => /notas?/i.test(h));
+      $rows.slice(headerRowIdx + 1).each((_, row) => {
+        const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
+        if (cells.length < 2) return;
+        const mat = cells[matIdx]?.replace(/\s/g, '').toUpperCase();
+        if (!mat || mat.length < 4) return;
 
-    $rows.slice(headerRowIdx + 1).each((_, row) => {
-      const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
-      if (cells.length < 2) return;
-      const mat = cells[matIdx]?.replace(/\s/g, '').toUpperCase();
-      if (!mat || mat.length < 4) return;
-
-      services.push({
-        matricula: mat,
-        descricao: svcIdx >= 0 ? (cells[svcIdx] || null) : null,
-        valor:     valIdx >= 0 ? parseValor(cells[valIdx]) : null,
-        eurocode:  notIdx >= 0 ? (cells[notIdx] || null) : null,
-        ne:        neIdx  >= 0 ? (cells[neIdx]  || null) : null,
+        services.push({
+          matricula: mat,
+          descricao: svcIdx >= 0 ? (cells[svcIdx] || null) : null,
+          valor:     valIdx >= 0 ? parseValor(cells[valIdx]) : null,
+          eurocode:  notIdx >= 0 ? (cells[notIdx] || null) : null,
+          ne:        neIdx  >= 0 ? (cells[neIdx]  || null) : null,
+        });
       });
-    });
+    } else {
+      // Fallback: headerless table — detect plate pattern in first column
+      // Handles emails like BR-42-XN that go straight to data rows without headers
+      $rows.each((_, row) => {
+        const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
+        if (cells.length < 2) return;
+        const mat = cells[0]?.replace(/\s/g, '').toUpperCase();
+        if (!mat || !PLATE_RX.test(mat)) return;
+
+        // Columns: [0]=plate, [1]=description, [2]=value, [3..n]=scan for eurocode
+        let eurocode = null;
+        for (let i = 2; i < cells.length; i++) {
+          const m = cells[i]?.toUpperCase().match(EUROCODE_RX);
+          if (m) { eurocode = m[0]; break; }
+        }
+
+        services.push({
+          matricula: mat,
+          descricao: cells[1] || null,
+          valor:     cells.length > 2 ? parseValor(cells[2]) : null,
+          eurocode,
+          ne: null,
+        });
+      });
+    }
   });
 
   return services;

--- a/transport-guide.css
+++ b/transport-guide.css
@@ -67,9 +67,9 @@
   align-items: center;
   gap: 4px;
   padding: 4px 9px;
-  background: rgba(255,255,255,0.18);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.3);
+  background: #f59e0b;
+  color: #1a1a1a;
+  border: none;
   border-radius: 20px;
   font-size: 10px;
   font-weight: 800;
@@ -78,7 +78,8 @@
   transition: background 0.15s, transform 0.1s;
   white-space: nowrap;
 }
-.guia-at-badge--inline { margin-left: auto; }
+.guia-at-badge--inline { }
+.guia-at-badge--km { margin-left: auto; }
 .guia-at-badge--abs {
   position: absolute;
   bottom: 10px;

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -89,6 +89,7 @@
       if (chipsRow) {
         chipsRow.appendChild(badge);
       } else if (kmRow) {
+        badge.classList.add('guia-at-badge--km');
         kmRow.appendChild(badge);
       } else if (statusRow) {
         badge.style.margin = '6px 0 4px';


### PR DESCRIPTION
## Resumo

- Fix parser de emails no `mycar-poller-cron` para emails sem linha de cabeçalho na tabela
- Emails como `FW: BR-42-XN | ...` enviam a tabela diretamente com dados (sem linha de cabeçalho com "Matrícula"), causando `⏭️ Sem tabela` em cada ciclo
- Adicionado fallback que deteta matrícula portuguesa (AA-##-AA, ##-AA-##, ##-##-AA) na primeira coluna e extrai dados por posição fixa: coluna 0=matrícula, 1=descrição, 2=valor, restantes=eurocode

## Outras correções incluídas neste PR

- **n_obra (FS)**: aparece no card de agendamento na zona de texto (`FS{n}` junto a notas/eurocode)
- **sync-portal**: migração de colunas `n_obra` e `mycar_services.car/n_obra`; sincroniza ao importar Excel
- **Guia AT badge**: z-index corrigido, cor âmbar com texto escuro, alinhamento em chips row
- **mycar.html**: mostra marca/modelo e Nº Ficha (FS) no painel e modal de detalhe

## Test plan

- [ ] Verificar email BR-42-XN entra no Mycar Center após deploy
- [ ] Confirmar que emails com header "Matrícula" continuam a funcionar normalmente
- [ ] Verificar que FS{n} aparece nos cards de agendamento após import Excel

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_