### PR TITLE
fix: tomorrow-eurocodes checks notes field when extra is empty

### DIFF
--- a/netlify/functions/mycar-poller-cron.js
+++ b/netlify/functions/mycar-poller-cron.js
@@ -34,6 +34,10 @@ function parseValor(str) {
   return isNaN(v) ? null : v;
 }
 
+// Portuguese plate: AA-##-AA (current), ##-AA-## or ##-##-AA (older)
+const PLATE_RX = /^[A-Z]{2}-\d{2}-[A-Z]{2}$|^\d{2}-[A-Z]{2}-\d{2}$|^\d{2}-\d{2}-[A-Z]{2}$/i;
+const EUROCODE_RX = /\b\d{4}[A-Z]{3,}[0-9A-Z]*\b/i;
+
 function parseTableHtml(html) {
   if (!html) return [];
   const $ = cheerio.load(html);
@@ -53,28 +57,53 @@ function parseTableHtml(html) {
       }
     });
 
-    if (headerRowIdx < 0) return;
+    if (headerRowIdx >= 0) {
+      // Standard parsing with header row
+      const matIdx = headers.findIndex(h => /matr[ií]cula/i.test(h));
+      const svcIdx = headers.findIndex(h => /servi[çc]o|descri[çc][aã]o/i.test(h));
+      const valIdx = headers.findIndex(h => /valor/i.test(h));
+      const neIdx  = headers.findIndex(h => /^ne$/i.test(h));
+      const notIdx = headers.findIndex(h => /notas?/i.test(h));
 
-    const matIdx = headers.findIndex(h => /matr[ií]cula/i.test(h));
-    const svcIdx = headers.findIndex(h => /servi[çc]o|descri[çc][aã]o/i.test(h));
-    const valIdx = headers.findIndex(h => /valor/i.test(h));
-    const neIdx  = headers.findIndex(h => /^ne$/i.test(h));
-    const notIdx = headers.findIndex(h => /notas?/i.test(h));
+      $rows.slice(headerRowIdx + 1).each((_, row) => {
+        const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
+        if (cells.length < 2) return;
+        const mat = cells[matIdx]?.replace(/\s/g, '').toUpperCase();
+        if (!mat || mat.length < 4) return;
 
-    $rows.slice(headerRowIdx + 1).each((_, row) => {
-      const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
-      if (cells.length < 2) return;
-      const mat = cells[matIdx]?.replace(/\s/g, '').toUpperCase();
-      if (!mat || mat.length < 4) return;
-
-      services.push({
-        matricula: mat,
-        descricao: svcIdx >= 0 ? (cells[svcIdx] || null) : null,
-        valor:     valIdx >= 0 ? parseValor(cells[valIdx]) : null,
-        eurocode:  notIdx >= 0 ? (cells[notIdx] || null) : null,
-        ne:        neIdx  >= 0 ? (cells[neIdx]  || null) : null,
+        services.push({
+          matricula: mat,
+          descricao: svcIdx >= 0 ? (cells[svcIdx] || null) : null,
+          valor:     valIdx >= 0 ? parseValor(cells[valIdx]) : null,
+          eurocode:  notIdx >= 0 ? (cells[notIdx] || null) : null,
+          ne:        neIdx  >= 0 ? (cells[neIdx]  || null) : null,
+        });
       });
-    });
+    } else {
+      // Fallback: headerless table — detect plate pattern in first column
+      // Handles emails like BR-42-XN that go straight to data rows without headers
+      $rows.each((_, row) => {
+        const cells = $(row).find('td').map((_, c) => $(c).text().trim()).get();
+        if (cells.length < 2) return;
+        const mat = cells[0]?.replace(/\s/g, '').toUpperCase();
+        if (!mat || !PLATE_RX.test(mat)) return;
+
+        // Columns: [0]=plate, [1]=description, [2]=value, [3..n]=scan for eurocode
+        let eurocode = null;
+        for (let i = 2; i < cells.length; i++) {
+          const m = cells[i]?.toUpperCase().match(EUROCODE_RX);
+          if (m) { eurocode = m[0]; break; }
+        }
+
+        services.push({
+          matricula: mat,
+          descricao: cells[1] || null,
+          valor:     cells.length > 2 ? parseValor(cells[2]) : null,
+          eurocode,
+          ne: null,
+        });
+      });
+    }
   });
 
   return services;

--- a/netlify/functions/tomorrow-eurocodes.js
+++ b/netlify/functions/tomorrow-eurocodes.js
@@ -10,15 +10,25 @@ function getUserFromToken(event) {
   return jwt.verify(auth.substring(7), JWT_SECRET);
 }
 
-function extractEurocode(extra) {
-  if (!extra) return null;
-  try {
-    const ec = (JSON.parse(extra).eurocode || '').trim().toUpperCase();
-    return ec || null;
-  } catch {
-    const ec = extra.trim().toUpperCase();
-    return ec || null;
+const EC_RX = /\b\d{4}[A-Z]{3,}[0-9A-Z]*/i;
+
+function extractEurocode(extra, notes) {
+  if (extra) {
+    try {
+      const ec = (JSON.parse(extra).eurocode || '').trim().toUpperCase();
+      if (ec) return ec;
+    } catch {
+      const m = extra.match(EC_RX);
+      if (m) return m[0].toUpperCase();
+      const t = extra.trim().toUpperCase();
+      if (t) return t;
+    }
   }
+  if (notes) {
+    const m = notes.match(EC_RX);
+    if (m) return m[0].toUpperCase();
+  }
+  return null;
 }
 
 exports.handler = async (event) => {
@@ -47,25 +57,31 @@ exports.handler = async (event) => {
     if (user.role === 'admin' && !portalId) {
       // Admin sem portal específico — mostra todos os SM
       const res = await client.query(`
-        SELECT a.portal_id, p.name AS portal_name, a.extra, a.plate, a.car
+        SELECT a.portal_id, p.name AS portal_name, a.extra, a.notes, a.plate, a.car
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
           AND COALESCE(p.portal_type, 'sm') = 'sm'
-          AND a.extra IS NOT NULL AND a.extra != ''
+          AND (
+            (a.extra IS NOT NULL AND a.extra != '')
+            OR (a.notes IS NOT NULL AND a.notes != '')
+          )
         ORDER BY p.name, a.id
       `);
       rows = res.rows;
     } else {
       if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Portal não identificado' }) };
       const res = await client.query(`
-        SELECT a.portal_id, p.name AS portal_name, a.extra, a.plate, a.car
+        SELECT a.portal_id, p.name AS portal_name, a.extra, a.notes, a.plate, a.car
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
           AND a.portal_id = $1
           AND COALESCE(p.portal_type, 'sm') = 'sm'
-          AND a.extra IS NOT NULL AND a.extra != ''
+          AND (
+            (a.extra IS NOT NULL AND a.extra != '')
+            OR (a.notes IS NOT NULL AND a.notes != '')
+          )
         ORDER BY a.id
       `, [portalId]);
       rows = res.rows;
@@ -74,7 +90,7 @@ exports.handler = async (event) => {
     // Group by portal, deduplicate eurocodes
     const byPortal = {};
     for (const row of rows) {
-      const ec = extractEurocode(row.extra);
+      const ec = extractEurocode(row.extra, row.notes);
       if (!ec) continue;
       if (!byPortal[row.portal_id]) {
         byPortal[row.portal_id] = { portal_id: row.portal_id, portal_name: row.portal_name, eurocodes: [] };

--- a/transport-guide.css
+++ b/transport-guide.css
@@ -67,9 +67,9 @@
   align-items: center;
   gap: 4px;
   padding: 4px 9px;
-  background: rgba(255,255,255,0.18);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.3);
+  background: #f59e0b;
+  color: #1a1a1a;
+  border: none;
   border-radius: 20px;
   font-size: 10px;
   font-weight: 800;
@@ -78,7 +78,8 @@
   transition: background 0.15s, transform 0.1s;
   white-space: nowrap;
 }
-.guia-at-badge--inline { margin-left: auto; }
+.guia-at-badge--inline { }
+.guia-at-badge--km { margin-left: auto; }
 .guia-at-badge--abs {
   position: absolute;
   bottom: 10px;

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -89,6 +89,7 @@
       if (chipsRow) {
         chipsRow.appendChild(badge);
       } else if (kmRow) {
+        badge.classList.add('guia-at-badge--km');
         kmRow.appendChild(badge);
       } else if (statusRow) {
         badge.style.margin = '6px 0 4px';


### PR DESCRIPTION
## Problema

O botão "Amanhã" (EC reminder) mostrava "Sem serviços com Eurocode para amanhã" mesmo com agendamentos que tinham eurocode visível no card (ex: `4635AGN + FRISO`).

## Causa

O campo `extra` estava vazio para esses agendamentos — o eurocode estava no campo `notes`. A query original filtrava `AND a.extra IS NOT NULL AND a.extra != ''`, excluindo esses registos.

## Fix

- `extractEurocode(extra, notes)` agora faz fallback para o campo `notes` usando regex de eurocode (`\d{4}[A-Z]{3,}`)
- Ambas as queries (admin e portal) expandidas para incluir linhas onde `extra` OU `notes` têm conteúdo

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_