### PR TITLE
fix: include pesados portals in tomorrow-eurocodes query

### DIFF
--- a/netlify/functions/tomorrow-eurocodes.js
+++ b/netlify/functions/tomorrow-eurocodes.js
@@ -61,7 +61,7 @@ exports.handler = async (event) => {
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
-          AND COALESCE(p.portal_type, 'sm') = 'sm'
+          AND COALESCE(p.portal_type, '') NOT IN ('loja', 'mycar')
           AND (
             (a.extra IS NOT NULL AND a.extra != '')
             OR (a.notes IS NOT NULL AND a.notes != '')
@@ -77,7 +77,7 @@ exports.handler = async (event) => {
         JOIN portals p ON p.id = a.portal_id
         WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
           AND a.portal_id = $1
-          AND COALESCE(p.portal_type, 'sm') = 'sm'
+          AND COALESCE(p.portal_type, '') NOT IN ('loja', 'mycar')
           AND (
             (a.extra IS NOT NULL AND a.extra != '')
             OR (a.notes IS NOT NULL AND a.notes != '')


### PR DESCRIPTION
## Causa

O filtro `COALESCE(portal_type, 'sm') = 'sm'` excluía portais do tipo 'pesados' (ex: Pesados Norte), que são portais SM mas com tipo diferente.

## Fix

Substituído por `NOT IN ('loja', 'mycar')` — inclui todos os portais de agendamento (sm, pesados, etc.) e exclui apenas loja e mycar.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_