### PR TITLE
Remove global SM plate UI — each portal has its own vehicle plate

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -275,30 +275,6 @@ function populateNmdosSelect() {
   });
 }
 
-// Mostrar/esconder campos baseado no tipo de portal
-async function applyGlobalPlate() {
-  const plate = document.getElementById('globalVehiclePlate').value.trim().toUpperCase().replace(/\s/g,'');
-  if (!plate) { alert('Preenche a matrícula primeiro.'); return; }
-  const statusEl = document.getElementById('globalPlateStatus');
-  statusEl.style.display = 'none';
-  try {
-    const resp = await authClient.authenticatedFetch('/.netlify/functions/portals', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ vehicle_plate: plate })
-    });
-    const data = await resp.json();
-    if (data.success) {
-      statusEl.textContent = `✓ Aplicado a ${data.updated} portal(ais)`;
-      statusEl.style.display = '';
-      setTimeout(() => { statusEl.style.display = 'none'; }, 3000);
-      loadPortals();
-    } else {
-      alert('Erro: ' + (data.error || 'desconhecido'));
-    }
-  } catch(e) { alert('Erro de rede: ' + e.message); }
-}
-
 function togglePortalTypeFields() {
   const type = document.getElementById('portalType').value;
   const localitiesSection = document.getElementById('localitiesSection');

--- a/admin.html
+++ b/admin.html
@@ -41,15 +41,6 @@
         <h2>Gestão de Portais</h2>
         <button id="addPortalBtn" class="btn-primary">+ Novo Portal</button>
       </div>
-
-      <!-- Matrícula global SM -->
-      <div style="background:#eff6ff;border:1.5px solid #bfdbfe;border-radius:10px;padding:14px 18px;margin-bottom:18px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
-        <span style="font-size:.88rem;font-weight:700;color:#1e40af">🚐 Matrícula SM (todos os portais)</span>
-        <input type="text" id="globalVehiclePlate" placeholder="Ex: BR-42-XN" maxlength="10"
-          style="text-transform:uppercase;letter-spacing:2px;font-weight:700;font-family:monospace;padding:6px 10px;border:1.5px solid #93c5fd;border-radius:7px;font-size:.9rem;width:130px;outline:none">
-        <button onclick="applyGlobalPlate()" class="btn-primary" style="padding:6px 16px;font-size:.85rem">Aplicar a todos os SMs</button>
-        <span id="globalPlateStatus" style="font-size:.82rem;color:#16a34a;display:none">✓ Guardado</span>
-      </div>
       <div class="table-container">
         <table class="data-table">
           <thead>


### PR DESCRIPTION
## Summary

- Removes the "Matrícula SM (todos os portais)" section from `admin.html` — the global bulk-apply UI was added by mistake
- Removes `applyGlobalPlate()` function from `admin-script.js`
- Each SM portal already has its own individual `vehicle_plate` field (added in PR #76), which is the correct approach

## No behaviour changes

The per-portal vehicle plate field in the portal edit form remains intact. Only the erroneous global bulk-apply UI is removed.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_