### PR TITLE
Fix plate badge alignment — center inline with dropdown

### DIFF
--- a/portal-init.js
+++ b/portal-init.js
@@ -291,14 +291,14 @@ function buildPortalSwitcher(portals, activeId) {
   wrapper.appendChild(label);
   wrapper.appendChild(select);
 
-  // Move the plate badge into the blue switcher bar (right side)
+  // Add the plate badge into the blue switcher bar (inline, next to dropdown)
   let vpEl = document.getElementById('headerVehiclePlate');
   if (!vpEl) {
     vpEl = document.createElement('div');
     vpEl.id = 'headerVehiclePlate';
     vpEl.style.display = 'none';
   }
-  vpEl.style.marginLeft = 'auto';
+  vpEl.style.marginLeft = '12px';
   wrapper.appendChild(vpEl);
 
   const header = document.querySelector('.page-header');


### PR DESCRIPTION
The badge was pushed to the far right with `marginLeft: auto`, making the layout unbalanced. Now uses `marginLeft: 12px` so it sits inline next to the dropdown, all centered together in the blue bar.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_