### PR TITLE
Show blinking SEM GUIA badge on appointments missing transport guide

### DIFF
--- a/transport-guide.css
+++ b/transport-guide.css
@@ -89,6 +89,16 @@
 }
 .guia-at-badge:hover { background: rgba(255,255,255,0.28); transform: scale(1.05); }
 .guia-at-badge:active { transform: scale(0.95); }
+.guia-at-badge--sem-guia {
+  background: #dc2626;
+  color: #fff;
+  cursor: default;
+  animation: semGuiaBlink 1s ease-in-out infinite;
+}
+@keyframes semGuiaBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
 
 /* ── Full-screen PDF viewer modal ── */
 #guiaATModal {

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -58,10 +58,12 @@
 
   function injectBadges() {
     const eurocodes = allEurocodes();
-    if (!eurocodes.length) return;
     const appts = window.appointments || [];
 
     document.querySelectorAll('.guia-at-badge').forEach(b => b.remove());
+
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const tomorrowStr = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
 
     document.querySelectorAll('.m-card[data-id], .desk-card[data-id]').forEach(card => {
       const appt = appts.find(a => String(a.id) === card.dataset.id);
@@ -79,18 +81,29 @@
 
       // Determine which guide contains the matching eurocode
       let matchedGuideKey = null;
-      if (guides.today?.eurocodes?.map(e => e.toUpperCase()).some(matches)) {
-        matchedGuideKey = 'today';
-      } else if (guides.tomorrow?.eurocodes?.map(e => e.toUpperCase()).some(matches)) {
-        matchedGuideKey = 'tomorrow';
+      if (eurocodes.length) {
+        if (guides.today?.eurocodes?.map(e => e.toUpperCase()).some(matches)) {
+          matchedGuideKey = 'today';
+        } else if (guides.tomorrow?.eurocodes?.map(e => e.toUpperCase()).some(matches)) {
+          matchedGuideKey = 'tomorrow';
+        }
       }
-      if (!matchedGuideKey) return;
 
-      const badge = document.createElement('button');
-      badge.className = 'guia-at-badge';
-      badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg> Guia AT';
-      badge.onclick = (e) => { e.stopPropagation(); openViewer(matchedGuideKey); };
-      badge.classList.add('guia-at-badge--inline');
+      let badge;
+      if (matchedGuideKey) {
+        badge = document.createElement('button');
+        badge.className = 'guia-at-badge guia-at-badge--inline';
+        badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg> Guia AT';
+        badge.onclick = (e) => { e.stopPropagation(); openViewer(matchedGuideKey); };
+      } else {
+        // No guide loaded — show blinking red warning only for today and tomorrow
+        const apptDate = appt.date;
+        if (!apptDate || (apptDate !== todayStr && apptDate !== tomorrowStr)) return;
+        badge = document.createElement('span');
+        badge.className = 'guia-at-badge guia-at-badge--sem-guia guia-at-badge--inline';
+        badge.textContent = 'SEM GUIA';
+      }
+
       const chipsRow = card.querySelector('.m-chips');
       const kmRow = card.querySelector('[data-km-row]');
       const statusRow = card.querySelector('.m-status-row');


### PR DESCRIPTION
## Feature

For appointments with a eurocode but no matching transport guide uploaded, a blinking red **SEM GUIA** badge now appears in the same position as the normal orange "Guia AT" badge — but only for appointments happening today or tomorrow (within ~24 hours).

- Thursday and beyond: no badge shown (will appear from Wednesday onwards)
- Once a guide with the matching eurocode is uploaded, the "SEM GUIA" badge is replaced by the normal clickable "Guia AT" badge
- The badge pulses at 1s intervals to draw attention

Also removed the early `if (!eurocodes.length) return` guard so the loop always runs and can inject "SEM GUIA" badges even when no guides have been loaded yet.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_