### PR TITLE
Restrict SEM GUIA badge to SM/pesados portals only

### DIFF
--- a/transport-guide.js
+++ b/transport-guide.js
@@ -96,7 +96,9 @@
         badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="12" y2="17"/></svg> Guia AT';
         badge.onclick = (e) => { e.stopPropagation(); openViewer(matchedGuideKey); };
       } else {
-        // No guide loaded — show blinking red warning only for today and tomorrow
+        // No guide loaded — show blinking red warning only for SM/pesados portals, today and tomorrow
+        const portalType = window.portalConfig?.portalType || 'sm';
+        if (portalType === 'loja' || portalType === 'mycar') return;
         const apptDate = appt.date;
         if (!apptDate || (apptDate !== todayStr && apptDate !== tomorrowStr)) return;
         badge = document.createElement('span');


### PR DESCRIPTION
Lojas and Mycar don't use transport guides. The blinking "SEM GUIA" badge now only appears on SM and pesados portal appointment cards.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_