### PR TITLE
Fix missing 'Retirar Vidro' button on mobile day navigation

### DIFF
--- a/glass-alert.js
+++ b/glass-alert.js
@@ -3,6 +3,15 @@
 // Chave para localStorage
 const GLASS_ORDERS_KEY = 'glassOrders';
 
+function _getEurocodeFromAppt(a) {
+  if (a.extra) {
+    try { const ec = JSON.parse(a.extra).eurocode; if (ec) return String(ec).trim().toUpperCase(); } catch(e) {}
+    const m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/);
+    if (m) return m[1].trim().toUpperCase();
+  }
+  return '';
+}
+
 /// Obter estado de encomenda dos serviços (da base de dados)
 function getGlassOrders() {
   // Agora usa o campo glassOrdered de cada appointment
@@ -148,16 +157,19 @@ function renderGlassAlertList() {
     }
     
     // Item do serviço
-    const rowStyle = isOrdered 
-      ? 'background: #d1fae5; border-left: 4px solid #10b981;' 
+    const rowStyle = isOrdered
+      ? 'background: #d1fae5; border-left: 4px solid #10b981;'
       : 'background: #fee2e2; border-left: 4px solid #ef4444;';
-    
+
+    const eurocode = _getEurocodeFromAppt(service);
+
     html += `
       <div style="${rowStyle} padding: 12px; border-radius: 6px; margin-bottom: 8px;">
         <div style="display: flex; justify-content: space-between; align-items: start; gap: 16px;">
           <div style="flex: 1;">
             <div style="font-weight: 600; font-size: 15px; margin-bottom: 4px;">
               ${service.plate || '—'} • ${service.car || '—'}
+              ${eurocode ? `<span style="display:inline-block;margin-left:8px;background:#1e40af;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;letter-spacing:0.3px;">${eurocode}</span>` : ''}
             </div>
             <div style="font-size: 13px; color: #6b7280; display: flex; gap: 12px; flex-wrap: wrap;">
               <span>🔧 ${service.service || '—'}</span>
@@ -272,6 +284,7 @@ function printGlassAlert() {
       ? '<span style="display: inline-block; width: 18px; height: 18px; border: 2px solid #000; background: #000; color: #fff; text-align: center; line-height: 18px; vertical-align: middle;">✓</span>' 
       : '<span style="display: inline-block; width: 18px; height: 18px; border: 2px solid #000; vertical-align: middle;"></span>';
     
+    const printEc = _getEurocodeFromAppt(service);
     tableRows += `
       <tr>
         <td>${dateStr}</td>
@@ -279,6 +292,7 @@ function printGlassAlert() {
         <td>${service.car || '—'}</td>
         <td>${service.service || '—'}</td>
         <td>${service.locality || '—'}</td>
+        <td>${printEc || '—'}</td>
         <td>${service.notes || '—'}</td>
         <td style="text-align: center;">${checkboxHtml}</td>
       </tr>
@@ -374,6 +388,7 @@ function printGlassAlert() {
             <th>Carro</th>
             <th>Serviço</th>
             <th>Localidade</th>
+            <th>Eurocode</th>
             <th>Observações</th>
             <th style="width: 80px;">Encomendado</th>
           </tr>

--- a/glass-removed-patch.js
+++ b/glass-removed-patch.js
@@ -179,5 +179,7 @@
   style.textContent = `.m-status-active-gr{background:#2563eb!important;color:#fff!important;-webkit-text-fill-color:#fff!important;border-color:#2563eb!important;} .m-status-active-gr .m-status-dot{background:#fff!important;}`;
   document.head.appendChild(style);
 
+  window._injectGlassButtons = injectGlassButtons;
+
   console.log('🪟 Glass Removed Patch carregado');
 })();

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -124,6 +124,9 @@
         card.appendChild(badge);
       }
     });
+
+    // Re-inject glass buttons in case renderMobileDay() was called directly (bypassing the renderAll hook)
+    setTimeout(() => window._injectGlassButtons?.(), 60);
   }
 
   function scheduleInject() {


### PR DESCRIPTION
## Summary

- Exposes `injectGlassButtons` as `window._injectGlassButtons` in `glass-removed-patch.js`
- Calls `window._injectGlassButtons()` at the end of `injectBadges()` in `transport-guide.js` so glass buttons are always present after badge injection

## Root cause

Day navigation (prev/next day buttons) calls `renderMobileDay()` directly, which bypasses the `window.renderAll` wrapper that `glass-removed-patch.js` hooks into to schedule glass button injection. The MutationObserver in `transport-guide.js` watches `#mobileDayList` and still fires on day navigation, running `injectBadges()`. Previously `injectBadges` returned early when no guides were loaded, so the absence of glass buttons was not visible. Now that `injectBadges` injects SEM GUIA badges even without a guide, the missing glass buttons became apparent.

## Test plan

- [ ] Navigate to a day with SM appointments — "Retirar Vidro" button appears on mobile cards
- [ ] Navigate forward/back a day — "Retirar Vidro" button still appears on the new day's cards
- [ ] SEM GUIA badge (red, blinking) still appears for appointments without a transport guide
- [ ] Guia AT badge still appears when a guide is loaded and eurocode matches

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_