### PR TITLE
Show vehicle plate in admin portal list; fix plate save reliability

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -122,7 +122,7 @@ function renderPortals() {
   const tbody = document.getElementById('portalsTableBody');
   
   if (portals.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="6" class="loading">Nenhum portal criado</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7" class="loading">Nenhum portal criado</td></tr>';
     return;
   }
 
@@ -140,11 +140,15 @@ function renderPortals() {
     const poweringBadge = portal.powering_loja_id
       ? `<span title="PoweringEG #${portal.powering_loja_id}" style="background:#f5f3ff;color:#7c3aed;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:600;margin-left:4px;">⚡ EG</span>`
       : '';
+    const plateBadge = portal.vehicle_plate
+      ? `<span style="display:inline-flex;align-items:stretch;border:2px solid #374151;border-radius:4px;overflow:hidden;font-family:monospace;font-size:12px;font-weight:700;letter-spacing:1px;"><span style="background:#003399;color:#fff;font-size:10px;padding:2px 4px;display:flex;align-items:center;">P</span><span style="background:#fff;color:#111;padding:2px 6px;display:flex;align-items:center;">${portal.vehicle_plate}</span></span>`
+      : '<span style="color:#9ca3af">—</span>';
     return `
     <tr>
       <td><strong>${portal.name}</strong> ${typeLabel}${poweringBadge}</td>
       <td>${portal.departure_address}</td>
       <td>${portal.nmdos_code || '<span style="color:#9ca3af">—</span>'}</td>
+      <td>${plateBadge}</td>
       <td>${portal.service_count || 0}</td>
       <td>${lastImport}</td>
       <td class="table-actions">

--- a/admin.html
+++ b/admin.html
@@ -48,13 +48,14 @@
               <th>Nome</th>
               <th>Morada de Partida</th>
               <th>Código nmdos</th>
+              <th>Matrícula</th>
               <th>Serviços</th>
               <th>Última Importação</th>
               <th>Ações</th>
             </tr>
           </thead>
           <tbody id="portalsTableBody">
-            <tr><td colspan="6" class="loading">A carregar...</td></tr>
+            <tr><td colspan="7" class="loading">A carregar...</td></tr>
           </tbody>
         </table>
       </div>

--- a/historico.js
+++ b/historico.js
@@ -93,6 +93,17 @@
   }
 
   // ── Helpers ───────────────────────────────────────────────
+
+  // For Pesados portals, locality is stored as the first segment of notes
+  // e.g. "Matosinhos | Cliente | Código..." → "Matosinhos"
+  function getLocality(a) {
+    if (a.notes) {
+      const m = a.notes.match(/^([A-Za-zÀ-ÿ][A-Za-zÀ-ÿ\s\-\.]+?)\s*\|/);
+      if (m) return m[1].trim();
+    }
+    return a.locality || '—';
+  }
+
   function getStatus(a) {
     if (a.glass_removed) return 'vidro_retirado';
     if (a.executed === true) return 'realizado';
@@ -182,7 +193,7 @@
         <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;"><span style="font-family:monospace;font-weight:700;color:#1e293b;letter-spacing:0.5px;">${(a.plate||'—').toUpperCase()}</span></td>
         <td style="padding:10px 12px;color:#374151;border-bottom:1px solid #f1f5f9;">${a.car||'—'}</td>
         <td style="padding:10px 12px;color:#374151;border-bottom:1px solid #f1f5f9;">${a.service||'—'}</td>
-        <td style="padding:10px 12px;color:#64748b;border-bottom:1px solid #f1f5f9;">${a.locality||'—'}</td>
+        <td style="padding:10px 12px;color:#64748b;border-bottom:1px solid #f1f5f9;">${getLocality(a)}</td>
         <td style="padding:10px 12px;color:#64748b;border-bottom:1px solid #f1f5f9;">${a.client_name||'—'}</td>
         <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;">${statusBadge(a)}</td>
         <td style="padding:10px 12px;color:#64748b;font-size:12px;border-bottom:1px solid #f1f5f9;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${(a.notes||'').replace(/"/g,"'")}">
@@ -263,7 +274,7 @@
         <td><strong>${(a.plate||'—').toUpperCase()}</strong></td>
         <td>${a.car||'—'}</td>
         <td>${a.service||'—'}</td>
-        <td>${a.locality||'—'}</td>
+        <td>${getLocality(a)}</td>
         <td>${a.client_name||'—'}</td>
         <td><span style="display:inline-block;background:${statusColor[s]||'#6b7280'};color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;-webkit-print-color-adjust:exact;print-color-adjust:exact;">${statusLabel[s]||'—'}</span></td>
         <td>${nota}</td>

--- a/netlify/functions/portals.js
+++ b/netlify/functions/portals.js
@@ -142,6 +142,7 @@ exports.handler = async (event) => {
 
     // ---------- PUT - Atualizar portal ----------
     if (event.httpMethod === 'PUT') {
+      await pool.query(`ALTER TABLE portals ADD COLUMN IF NOT EXISTS vehicle_plate VARCHAR(20)`);
       const data = JSON.parse(event.body || '{}');
       // ID from body (reliable) or fallback to last path segment
       const pathId = (event.path || '').split('/').filter(Boolean).pop();


### PR DESCRIPTION
## Summary
- Admin portals table now has a **Matrícula** column showing the plate badge, so after saving a portal the plate is immediately visible in the list
- `portals.js` PUT handler now runs `ALTER TABLE ADD COLUMN IF NOT EXISTS vehicle_plate` before the UPDATE (defensive — GET already does this, but PUT can run independently)
- Fixed `colspan` in empty-state rows to match new 7-column table

## Test plan
- [ ] Open admin → Portais, confirm new "Matrícula" column appears
- [ ] Edit an SM portal, enter a plate (e.g. BS-66-SI), click Guardar
- [ ] Confirm the plate badge appears in the list immediately after save
- [ ] Reopen the Edit form and confirm the plate value is still there

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_