### PR TITLE
Fix not-done date clipped by overflow — use br instead of inline span

### DIFF
--- a/historico.js
+++ b/historico.js
@@ -206,7 +206,7 @@
         <td style="padding:10px 12px;color:#64748b;border-bottom:1px solid #f1f5f9;">${a.client_name||'—'}</td>
         <td style="padding:10px 12px;border-bottom:1px solid #f1f5f9;">${statusBadge(a)}</td>
         <td style="padding:10px 12px;color:#64748b;font-size:12px;border-bottom:1px solid #f1f5f9;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${(a.notes||'').replace(/"/g,"'")}">
-          ${a.not_done_reason ? `<em style="color:#dc2626;">Motivo: ${a.not_done_reason}</em><span style="color:#9ca3af;font-size:11px;margin-left:6px;">${fmtDate(a.date)}</span>` : (a.notes || '<span style="color:#cbd5e1;">—</span>')}
+          ${a.not_done_reason ? `<em style="color:#dc2626;">Motivo: ${a.not_done_reason}</em><br><span style="color:#9ca3af;font-size:11px;">${fmtDate(a.date)}</span>` : (a.notes || '<span style="color:#cbd5e1;">—</span>')}
         </td>
       </tr>`;
     }).join('');

--- a/index.html
+++ b/index.html
@@ -895,7 +895,7 @@
 
   <script src="transport-guide.js?v=2026-05-19j"></script>
   <script src="eurocode-reminder.js?v=2026-05-19a"></script>
-  <script src="historico.js?v=2026-05-26c"></script>
+  <script src="historico.js?v=2026-05-26d"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The date was hidden because `white-space:nowrap` + `overflow:hidden` on the notes cell clipped the inline span
- Fixed by using `<br>` so the date appears on a new line — `<br>` is not affected by `white-space:nowrap`
- Bumped version string to bust browser cache

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_