### PR TITLE
Histórico: show not-done date in Estado column below badge

### DIFF
--- a/historico.js
+++ b/historico.js
@@ -122,7 +122,11 @@
       pendente:        { bg: '#475569', color: '#cbd5e1', label: '— Pendente' },
     };
     const { bg, color, label } = map[s] || map.pendente;
-    return `<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:3px 9px;border-radius:20px;white-space:nowrap;">${label}</span>`;
+    const badge = `<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:3px 9px;border-radius:20px;white-space:nowrap;">${label}</span>`;
+    if (s === 'nao_realizado' && a.date) {
+      return badge + `<div style="font-size:11px;color:#64748b;margin-top:4px;">📅 ${fmtDate(a.date)}</div>`;
+    }
+    return badge;
   }
 
   function fmtDate(iso) {

--- a/index.html
+++ b/index.html
@@ -895,7 +895,8 @@
 
   <script src="transport-guide.js?v=2026-05-19j"></script>
   <script src="eurocode-reminder.js?v=2026-05-19a"></script>
-  <script src="historico.js?v=2026-05-26e"></script>
+  <script src="historico.js?v=2026-05-26f"></script>
+
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Moves the date from the notes cell (which has `overflow:hidden` and `white-space:nowrap`) to the **Estado** column via `statusBadge()`
- The Estado column has no overflow constraints so the date is guaranteed to be visible
- For "Não Realizado" rows the badge now shows two lines: `❌ Não Realizado` + `📅 DD/MM/YYYY`
- Bumped `historico.js` version to `?v=2026-05-26f`

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_