### PR TITLE
Show date on appointment card after Não Realizado motivo

### DIFF
--- a/script-tail.js
+++ b/script-tail.js
@@ -79,10 +79,13 @@ const telBtn = phone ? `
   const todayISO = localISO(new Date());
   const isPastOrToday = a.date && a.date <= todayISO;
 
-  const motivoBadge = isNaoRealizado && a.not_done_reason ? `
-    <div style="margin:6px 8px 0;padding:7px 12px;background:rgba(220,38,38,0.15);border-left:3px solid #dc2626;border-radius:6px;font-size:12px;font-weight:700;color:#dc2626;display:flex;align-items:center;gap:6px;">
-      ❌ <span style="color:inherit;">${a.not_done_reason}</span>
-    </div>` : '';
+  const motivoBadge = isNaoRealizado && a.not_done_reason ? (() => {
+    const _nd = a.not_done_reason;
+    const _ndDate = a.date ? (() => { const _d = new Date(a.date + 'T00:00:00'); return _d.toLocaleDateString('pt-PT', {day:'2-digit',month:'2-digit',year:'numeric'}); })() : null;
+    return `<div style="margin:6px 8px 0;padding:7px 12px;background:rgba(220,38,38,0.15);border-left:3px solid #dc2626;border-radius:6px;font-size:12px;font-weight:700;color:#dc2626;">
+      <div style="display:flex;align-items:center;gap:6px;">❌ <span style="color:inherit;">${_nd}</span></div>${_ndDate ? `<div style="font-size:11px;font-weight:400;color:#64748b;margin-top:3px;">📅 ${_ndDate}</div>` : ''}
+    </div>`;
+  })() : '';
 
   const statusToggle = a.date ? `
     <div class="m-status-row">

--- a/script.js
+++ b/script.js
@@ -2541,10 +2541,13 @@ function buildDesktopCard(a){
   const isPastOrToday = a.date && a.date <= todayISO2;
   const _roleDesk = window.authClient?.getUser?.()?.role || '';
   const canExecDesk = isPastOrToday || _roleDesk === 'admin' || _roleDesk === 'coordenador';
-  const motivoDesktop = (a.executed === false && a.not_done_reason) ? `
-    <div style="margin:4px 0 0;padding:5px 10px;background:rgba(220,38,38,0.12);border-left:3px solid #dc2626;border-radius:5px;font-size:11px;font-weight:700;color:#dc2626;">
-      ❌ ${a.not_done_reason}
-    </div>` : '';
+  const motivoDesktop = (a.executed === false && a.not_done_reason) ? (() => {
+    const _nd = a.not_done_reason;
+    const _ndDate = a.date ? (() => { const _d = new Date(a.date + 'T00:00:00'); return _d.toLocaleDateString('pt-PT', {day:'2-digit',month:'2-digit',year:'numeric'}); })() : null;
+    return `<div style="margin:4px 0 0;padding:5px 10px;background:rgba(220,38,38,0.12);border-left:3px solid #dc2626;border-radius:5px;font-size:11px;font-weight:700;color:#dc2626;">
+      ❌ ${_nd}${_ndDate ? `<span style="font-weight:400;color:#64748b;margin-left:8px;">📅 ${_ndDate}</span>` : ''}
+    </div>`;
+  })() : '';
 
   const execBadge = (canExecDesk && !isPreAgendado && a.date) ? `
     <div class="dc-exec-row" data-id="${a.id}">


### PR DESCRIPTION
## Summary

- Desktop card (`script.js`): shows `📅 dd/mm/yyyy` inline after the motivo text
- Mobile card (`script-tail.js`): shows `📅 dd/mm/yyyy` on a second line below the motivo

Result: ❌ Carro não disponível  📅 26/05/2026

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_