### PR TITLE
Fix Mycar Center TOTAL KPI to exclude rejected services

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -765,10 +765,10 @@ function buildGroups(services) {
 
 // ─── STATS ────────────────────────────────────────────────────────────────────
 function updateStats() {
-  const total = allServices.length;
+  const rej   = allServices.filter(s => s.status === 'rejeitado').length;
   const pend  = allServices.filter(s => s.status === 'pendente').length;
   const trat  = allServices.filter(s => s.status === 'realizado' || s.status === 'faturado').length;
-  const rej   = allServices.filter(s => s.status === 'rejeitado').length;
+  const total = pend + trat;
   document.getElementById('stat-total').textContent = total;
   document.getElementById('stat-pend').textContent  = pend;
   document.getElementById('stat-trat').textContent  = trat;


### PR DESCRIPTION
## Summary

TOTAL KPI was 13 (all services including 2 rejected) while the table only shows 11 (non-rejected), causing the mismatch the user noticed.

Now: **TOTAL = PENDENTES + REALIZADOS** (excludes rejected), so TOTAL (11) = PENDENTES (11) + REALIZADOS (0). REJEITADOS remains its own KPI tile separately.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_