### PR TITLE
Show plain-text passwords to admin in user management

### DIFF
--- a/netlify/functions/users.js
+++ b/netlify/functions/users.js
@@ -71,9 +71,11 @@ const headers = {
       }
 
       // Admin: query completa
+      await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS plain_password TEXT');
       const query = `
         SELECT u.id, u.username, u.portal_id, u.role, u.created_at, u.updated_at,
-               u.telegram_chat_id, u.telegram_chat_id_2, u.assigned_portal_ids, p.name as portal_name
+               u.telegram_chat_id, u.telegram_chat_id_2, u.assigned_portal_ids,
+               u.plain_password, p.name as portal_name
         FROM users u
         LEFT JOIN portals p ON u.portal_id = p.id
         ORDER BY u.username ASC
@@ -91,6 +93,7 @@ const headers = {
           telegramChatId: user.telegram_chat_id || null,
           telegramChatId2: user.telegram_chat_id_2 || null,
           assigned_portal_ids: user.assigned_portal_ids || [],
+          plain_password: user.plain_password || null,
           createdAt: user.created_at,
           updatedAt: user.updated_at
         };
@@ -164,14 +167,16 @@ const headers = {
       }
 
       const passwordHash = await bcrypt.hash(data.password, 10);
+      await pool.query('ALTER TABLE users ADD COLUMN IF NOT EXISTS plain_password TEXT');
       const query = `
-        INSERT INTO users (username, password_hash, portal_id, role, telegram_chat_id, telegram_chat_id_2, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        INSERT INTO users (username, password_hash, plain_password, portal_id, role, telegram_chat_id, telegram_chat_id_2, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         RETURNING id, username, portal_id, role
       `;
       const values = [
         data.username.trim(),
         passwordHash,
+        data.password,
         data.portal_id || null,
         data.role || 'user',
         data.telegram_chat_id || null,
@@ -225,7 +230,8 @@ const headers = {
       let paramIndex = 1;
 
       if (data.username)              { updates.push('username = $'          + paramIndex++); values.push(data.username.trim()); }
-      if (passwordHash)               { updates.push('password_hash = $'     + paramIndex++); values.push(passwordHash); }
+      if (passwordHash)               { updates.push('password_hash = $'     + paramIndex++); values.push(passwordHash);
+                                        updates.push('plain_password = $'    + paramIndex++); values.push(data.password); }
       if (data.portal_id !== undefined){ updates.push('portal_id = $'        + paramIndex++); values.push(data.portal_id || null); }
       if (data.role)                  { updates.push('role = $'              + paramIndex++); values.push(data.role); }
       if (data.telegram_chat_id !== undefined) { updates.push('telegram_chat_id = $' + paramIndex++); values.push(data.telegram_chat_id || null); }


### PR DESCRIPTION
## Summary

- Adds `plain_password TEXT` column to `users` table (defensive `ALTER TABLE IF NOT EXISTS`)
- Stores the plain-text password on `INSERT` (new user) and `UPDATE` (password change)
- `GET /users` now returns `plain_password` so the admin table shows the actual password instead of `••••••`

Note: only applies to passwords set/changed after this deploy. Existing users will still show `••••••` until their password is reset.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_