### PR TITLE
Mycar Center: default filter to Pendentes on page load

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -717,6 +717,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const token = getToken();
   if (!token) { location.href = 'login.html'; return; }
 
+  document.getElementById('filter-status').value = 'pendente';
+
   const user = getUser();
   if (user?.role === 'admin') {
     document.getElementById('nav-admin').style.display = '';


### PR DESCRIPTION
Set `filter-status` to `pendente` on `DOMContentLoaded` so the page opens showing only pending services by default.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_