### PR TITLE
Excel import: derive glass status from Encomenda/Receção columns

### DIFF
--- a/excel-import-ui.js
+++ b/excel-import-ui.js
@@ -174,6 +174,8 @@ function autoDetectColumns() {
     'mapPlate': ['matricula', 'matrícula', 'plate', 'placa'],
     'mapCar': ['carro', 'modelo', 'car', 'vehicle', 'veiculo', 'veículo'],
     'mapNotes': ['observacoes', 'observações', 'notes', 'obs', 'comentarios', 'comentários'],
+    'mapOrderRef': ['encomenda', 'enc', 'order', 'ordem', 'pedido_enc', 'data_enc'],
+    'mapReceptionRef': ['recep', 'receção', 'rececao', 'reception', 'stock', 'em_stock', 'data_rec'],
     'mapAddress': ['morada', 'endereco', 'endereço', 'address', 'rua'],
     'mapPhone': ['telefone', 'contacto', 'contato', 'phone', 'telemovel', 'telemóvel'],
     'mapExtra': ['extra', 'outros', 'adicional', 'dados'],

--- a/excel-import.js
+++ b/excel-import.js
@@ -253,8 +253,16 @@ class ExcelImporter {
     service.phone = service.phone || '';
     service.extra = service.extra || '';
     
-    // Campos padrão
-    service.status = 'NE'; // Não Executado
+    // Derivar status do vidro a partir das colunas de encomenda e receção
+    const _orderRef     = (service.order_ref     || '').trim();
+    const _receptionRef = (service.reception_ref || '').trim();
+    if (_receptionRef) {
+      service.status = 'ST'; // vidro em stock
+    } else if (_orderRef) {
+      service.status = 'VE'; // vidro encomendado
+    } else {
+      service.status = 'NE'; // não encomendado
+    }
     service.date = null; // Sem data (por agendar)
     service.period = null;
     service.km = null;
@@ -449,23 +457,21 @@ class ExcelImporter {
 
         // Verificar duplicado no mesmo lote (evita chamadas duplas ao backend)
         if (existingPlates.has(plateNormalized)) {
-          // Se tem damage_details, tentar atualizar registo existente
-          if (service.damage_details) {
-            const existing = existingAppointments.find(a =>
-              String(a.plate).toUpperCase().trim() === plateNormalized
-            );
-            if (existing?.id) {
-              try {
-                await window.apiClient.updateAppointment(existing.id, {
-                  ...existing,
-                  damage_details: service.damage_details
-                });
-                results.details.push({ plate: service.plate, status: 'updated', reason: 'damage_details atualizado' });
-              } catch (e) {
-                results.skipped++;
-                results.details.push({ plate: service.plate, status: 'skipped', reason: 'Duplicado no lote' });
-              }
-            } else {
+          const existing = existingAppointments.find(a =>
+            String(a.plate).toUpperCase().trim() === plateNormalized
+          );
+          // Atualizar status de vidro se mudou (encomenda/receção), ou damage_details
+          const statusChanged = existing && service.status && service.status !== existing.status;
+          const hasDamage = !!service.damage_details;
+          if (existing?.id && (statusChanged || hasDamage)) {
+            try {
+              await window.apiClient.updateAppointment(existing.id, {
+                ...existing,
+                ...(statusChanged ? { status: service.status } : {}),
+                ...(hasDamage ? { damage_details: service.damage_details } : {})
+              });
+              results.details.push({ plate: service.plate, status: 'updated', reason: statusChanged ? `Status → ${service.status}` : 'damage_details atualizado' });
+            } catch (e) {
               results.skipped++;
               results.details.push({ plate: service.plate, status: 'skipped', reason: 'Duplicado no lote' });
             }

--- a/index.html
+++ b/index.html
@@ -1354,6 +1354,8 @@
           <div class="mapping-row"><label>Morada</label><select id="mapAddress" class="mapping-select"><option value="">-- Selecionar Coluna --</option></select></div>
           <div class="mapping-row"><label>Contacto</label><select id="mapPhone" class="mapping-select"><option value="">-- Selecionar Coluna --</option></select></div>
           <div class="mapping-row"><label>Outros Dados</label><select id="mapExtra" class="mapping-select"><option value="">-- Selecionar Coluna --</option></select></div>
+          <div class="mapping-row"><label>Encomenda 📦</label><select id="mapOrderRef" class="mapping-select"><option value="">-- Selecionar Coluna --</option></select></div>
+          <div class="mapping-row"><label>Receção / Stock ✅</label><select id="mapReceptionRef" class="mapping-select"><option value="">-- Selecionar Coluna --</option></select></div>
         </div>
         <div class="step-actions">
           <button type="button" class="btn btn-secondary" onclick="goToStep1()">← Voltar</button>


### PR DESCRIPTION
## Summary

Two new optional columns in the Excel import mapping modal:

| Coluna | Status resultante |
|--------|------------------|
| Nenhuma preenchida | 🔴 `NE` — Não encomendado |
| **Encomenda** preenchida | 🟡 `VE` — Vidro encomendado |
| **Receção/Stock** preenchida | 🟢 `ST` — Vidro em stock |

- Auto-detecção por keywords: `encomenda`, `enc`, `receção`, `rececao`, `stock`
- Re-importar um Excel com matrícula já existente agora **actualiza o status** se mudou (ex: passou de NE para VE após encomendar)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_