### PR TITLE
Fix Guia AT SEM GUIA para técnicos quando coordenadora gere múltiplos portais

### DIFF
--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -157,7 +157,17 @@
     `;
 
     widget.innerHTML = `
-      <!-- Botão toggle -->
+      <!-- Botão Receção Vidros -->
+      <button id="recBotBtn" onclick="window.glassReception?.openScan()" style="
+        width:52px;height:52px;border-radius:50%;border:none;cursor:pointer;
+        background:linear-gradient(135deg,#1d4ed8,#0f172a);
+        color:#fff;font-size:22px;
+        box-shadow:0 4px 16px rgba(29,78,216,0.5);
+        display:flex;align-items:center;justify-content:center;
+        transition:transform .15s;position:relative;
+      " title="Receção de Vidros">📦<span id="recBotBadge" style="display:none;position:absolute;top:2px;right:2px;width:10px;height:10px;background:#ef4444;border-radius:50%;animation:recPulse 1.2s infinite;"></span></button>
+
+      <!-- Botão toggle chatbot -->
       <button id="botToggle" onclick="window._toggleBot()" style="
         width:52px;height:52px;border-radius:50%;border:none;cursor:pointer;
         background:linear-gradient(135deg,#3b82f6,#1d4ed8);

--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@
         <button id="btnTimelineDesk" class="nav-button" style="background:#7c3aed;color:#fbbf24;" title="Timeline do dia">⏱️ Timeline</button>
         <button id="btnVidrosRetirados" class="nav-button" style="background:#f59e0b;color:#fff;font-weight:700;" title="Ver vidros retirados">🪟 Vidros Retirados</button>
         <button id="btnHistorico" class="nav-button" style="background:#0f172a;color:#94a3b8;border:1px solid rgba(255,255,255,0.15);font-weight:700;" title="Histórico de serviços" onclick="window.historicoModal?.open()">🕘 Histórico</button>
+        <button id="btnRececaoVidros" class="nav-button" style="display:none;background:#0f172a;color:#94a3b8;border:1px solid rgba(255,255,255,0.15);font-weight:700;position:relative;" title="Receção de Vidros" onclick="window.glassReception?.openCoordPanel()">📦 Receção Vidros<span id="rececaoBadge" style="display:none;position:absolute;top:-4px;right:-4px;width:10px;height:10px;background:#ef4444;border-radius:50%;animation:recPulse 1.2s infinite;"></span></button>
         <button id="printPage" class="nav-button" style="color:#fbbf24;">🖨 Imprimir</button>
         <!-- Guia AT upload (coordinator/admin only, desktop) -->
         <div id="guiaATUploadAreaDesk" style="display:none; align-items:center; gap:6px;">
@@ -1224,6 +1225,325 @@
   }
 })();
   </script>
+
+<!-- ===== RECEÇÃO DE VIDROS ===== -->
+<style>
+@keyframes recPulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.5;transform:scale(1.4)} }
+#grScanModal,#grCoordModal { display:none;position:fixed;inset:0;z-index:10100;background:rgba(0,0,0,0.6);align-items:center;justify-content:center;padding:16px; }
+.gr-modal-box { background:#fff;border-radius:16px;width:min(96vw,520px);box-shadow:0 24px 60px rgba(0,0,0,0.25);overflow:hidden; }
+.gr-modal-header { background:#0f172a;color:#fff;padding:16px 20px;display:flex;align-items:center;gap:10px; }
+.gr-modal-body { padding:20px; }
+</style>
+
+<!-- Modal Técnico: scan / receção -->
+<div id="grScanModal" style="display:none;position:fixed;inset:0;z-index:10100;background:rgba(0,0,0,0.6);align-items:center;justify-content:center;padding:16px;">
+  <div class="gr-modal-box">
+    <div class="gr-modal-header">
+      <span style="font-size:22px;">📦</span>
+      <span style="font-size:16px;font-weight:800;">Receção de Vidro</span>
+      <button onclick="window.glassReception.closeScan()" style="margin-left:auto;background:rgba(255,255,255,.15);border:none;color:#fff;width:28px;height:28px;border-radius:50%;cursor:pointer;font-size:16px;">✕</button>
+    </div>
+    <div class="gr-modal-body" id="grScanBody">
+      <!-- Steps injetados via JS -->
+    </div>
+  </div>
+</div>
+
+<!-- Modal Coordenador: lista de recepções -->
+<div id="grCoordModal" style="display:none;position:fixed;inset:0;z-index:10100;background:rgba(0,0,0,0.6);align-items:center;justify-content:center;padding:16px;">
+  <div class="gr-modal-box" style="width:min(96vw,700px);">
+    <div class="gr-modal-header">
+      <span style="font-size:22px;">📦</span>
+      <span style="font-size:16px;font-weight:800;">Receção de Vidros</span>
+      <span id="grCoordBadge" style="background:#ef4444;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px;margin-left:6px;display:none;"></span>
+      <button onclick="window.glassReception.closeCoord()" style="margin-left:auto;background:rgba(255,255,255,.15);border:none;color:#fff;width:28px;height:28px;border-radius:50%;cursor:pointer;font-size:16px;">✕</button>
+    </div>
+    <div class="gr-modal-body" id="grCoordBody" style="max-height:70vh;overflow-y:auto;">
+      <p style="color:#94a3b8;text-align:center;padding:20px;">A carregar…</p>
+    </div>
+  </div>
+</div>
+
+<script>
+// ===== GLASS RECEPTION MODULE =====
+(function() {
+  'use strict';
+
+  const API = '/.netlify/functions';
+
+  function authHeaders() {
+    const t = localStorage.getItem('auth_token') || sessionStorage.getItem('auth_token') || '';
+    return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + t };
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    return new Date(iso + (iso.includes('T') ? '' : 'T00:00:00')).toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  // ── SCAN MODAL (técnico) ──────────────────────────────────────────────────
+  function openScan() {
+    document.getElementById('grScanModal').style.display = 'flex';
+    renderStep1();
+  }
+
+  function closeScan() {
+    document.getElementById('grScanModal').style.display = 'none';
+  }
+
+  function renderStep1() {
+    document.getElementById('grScanBody').innerHTML = `
+      <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Tira uma foto à etiqueta do vidro ou introduz os dados manualmente.</p>
+      <div style="display:flex;flex-direction:column;gap:12px;">
+        <label style="display:flex;align-items:center;justify-content:center;gap:8px;background:#1d4ed8;color:#fff;font-weight:700;font-size:14px;padding:14px;border-radius:12px;cursor:pointer;border:none;">
+          📷 Tirar/Escolher Foto
+          <input id="grPhotoInput" type="file" accept="image/*" capture="environment" style="display:none;" onchange="window.glassReception._onPhoto(this)">
+        </label>
+        <div style="text-align:center;color:#94a3b8;font-size:12px;">— ou introduz manualmente —</div>
+        <input id="grManualOrder" type="text" placeholder="N.º de encomenda (opcional)" style="border:1.5px solid #e2e8f0;border-radius:8px;padding:10px 12px;font-size:14px;width:100%;">
+        <input id="grManualEurocode" type="text" placeholder="Eurocode (ex: FW1234)" style="border:1.5px solid #e2e8f0;border-radius:8px;padding:10px 12px;font-size:14px;width:100%;">
+        <button onclick="window.glassReception._manualSearch()" style="background:#0f172a;color:#fff;font-weight:700;font-size:14px;padding:12px;border-radius:12px;border:none;cursor:pointer;">🔍 Procurar</button>
+      </div>
+    `;
+  }
+
+  async function _onPhoto(input) {
+    const file = input.files[0];
+    if (!file) return;
+    document.getElementById('grScanBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">🔍 A analisar etiqueta com IA…</p>`;
+
+    try {
+      const base64 = await fileToBase64(file);
+      const res = await fetch(API + '/glass-label-ocr', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ image_base64: base64.split(',')[1], media_type: file.type })
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      _doSearch(json.data.order_ref, json.data.eurocode, json.data.raw_text, base64);
+    } catch (e) {
+      document.getElementById('grScanBody').innerHTML = `
+        <p style="color:#dc2626;text-align:center;margin-bottom:12px;">Erro: ${e.message}</p>
+        <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;">← Tentar novamente</button>
+      `;
+    }
+  }
+
+  function _manualSearch() {
+    const order = (document.getElementById('grManualOrder')?.value || '').trim();
+    const euro  = (document.getElementById('grManualEurocode')?.value || '').trim();
+    if (!order && !euro) { alert('Introduz pelo menos o n.º de encomenda ou eurocode.'); return; }
+    _doSearch(order || null, euro || null, null, null);
+  }
+
+  function _step1() { renderStep1(); }
+
+  function _doSearch(orderRef, eurocode, rawText, photoBase64) {
+    const appts = (window.appointments || []).filter(a => {
+      if (a.executed === true || a.glass_removed) return false;
+      const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
+      const matchEuro  = eurocode  && a.glass_eurocode && a.glass_eurocode.trim().toLowerCase() === eurocode.trim().toLowerCase();
+      // Also search in notes/n_obra for eurocode as fallback
+      const matchEuroNotes = eurocode && ((a.notes || '') + ' ' + (a.n_obra || '')).toLowerCase().includes(eurocode.toLowerCase());
+      return matchOrder || matchEuro || matchEuroNotes;
+    });
+
+    renderMatches(appts, orderRef, eurocode, rawText, photoBase64);
+  }
+
+  function renderMatches(appts, orderRef, eurocode, rawText, photoBase64) {
+    const body = document.getElementById('grScanBody');
+
+    const infoHtml = `
+      <div style="background:#f8fafc;border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:12px;color:#64748b;">
+        ${orderRef ? `<div>📦 Encomenda: <strong style="color:#1e293b;">${orderRef}</strong></div>` : ''}
+        ${eurocode  ? `<div>🔢 Eurocode: <strong style="color:#1e293b;">${eurocode}</strong></div>` : ''}
+        ${!orderRef && !eurocode ? '<div>⚠️ Nenhum código identificado</div>' : ''}
+      </div>
+    `;
+
+    if (appts.length === 0) {
+      body.innerHTML = infoHtml + `
+        <p style="color:#ef4444;font-weight:600;text-align:center;margin:16px 0;">Nenhum processo encontrado com estes dados.</p>
+        <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;width:100%;">← Tentar novamente</button>
+      `;
+      return;
+    }
+
+    const cardsHtml = appts.map(a => `
+      <div style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
+           onmouseenter="this.style.borderColor='#2563eb'" onmouseleave="this.style.borderColor='#e2e8f0'"
+           onclick="window.glassReception._confirmReception(${a.id},'${(a.plate||'').replace(/'/g,"\\'")}','${orderRef||''}','${eurocode||''}','${(rawText||'').replace(/'/g,"\\'").substring(0,200)}')">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
+          <span style="font-family:monospace;font-weight:800;font-size:15px;background:#0f172a;color:#fff;padding:4px 10px;border-radius:6px;">${(a.plate||'').toUpperCase()}</span>
+          <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
+        </div>
+        <div style="display:flex;gap:16px;font-size:12px;color:#64748b;flex-wrap:wrap;">
+          <span>🏪 ${a.locality || a.portal_name || '—'}</span>
+          <span>🔧 ${a.service || '—'}</span>
+          ${a.date ? `<span>📅 ${fmtDate(a.date)}</span>` : '<span style="color:#f59e0b;">Sem data</span>'}
+        </div>
+        <div style="margin-top:8px;font-size:11px;font-weight:700;color:#2563eb;">✔ Confirmar este serviço →</div>
+      </div>
+    `).join('');
+
+    body.innerHTML = infoHtml + `
+      <p style="font-size:13px;font-weight:700;color:#374151;margin-bottom:10px;">Seleciona o processo para este vidro:</p>
+      ${cardsHtml}
+      <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;margin-top:4px;width:100%;">← Voltar</button>
+    `;
+  }
+
+  async function _confirmReception(appointmentId, plate, orderRef, eurocode, rawText) {
+    document.getElementById('grScanBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A registar receção…</p>`;
+    try {
+      const res = await fetch(API + '/glass-reception', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ appointment_id: appointmentId, order_ref: orderRef, eurocode, raw_label_text: rawText })
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+
+      document.getElementById('grScanBody').innerHTML = `
+        <div style="text-align:center;padding:24px 0;">
+          <div style="font-size:48px;margin-bottom:12px;">✅</div>
+          <p style="font-size:16px;font-weight:800;color:#16a34a;margin-bottom:6px;">Receção registada!</p>
+          <p style="font-size:13px;color:#64748b;margin-bottom:20px;">Matrícula <strong>${plate}</strong> — aguarda confirmação do coordenador.</p>
+          <button onclick="window.glassReception.closeScan()" style="background:#0f172a;color:#fff;font-weight:700;padding:12px 28px;border-radius:10px;border:none;cursor:pointer;">Fechar</button>
+        </div>
+      `;
+      _pollPendingBadge();
+    } catch (e) {
+      document.getElementById('grScanBody').innerHTML = `
+        <p style="color:#dc2626;text-align:center;margin-bottom:12px;">Erro: ${e.message}</p>
+        <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;">← Tentar novamente</button>
+      `;
+    }
+  }
+
+  // ── COORDINATOR PANEL ────────────────────────────────────────────────────
+  async function openCoordPanel() {
+    document.getElementById('grCoordModal').style.display = 'flex';
+    document.getElementById('grCoordBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A carregar…</p>`;
+    await _loadCoordList();
+  }
+
+  function closeCoord() {
+    document.getElementById('grCoordModal').style.display = 'none';
+  }
+
+  async function _loadCoordList() {
+    try {
+      const res = await fetch(API + '/glass-reception?status=confirmed', { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      _renderCoordList(json.data);
+    } catch (e) {
+      document.getElementById('grCoordBody').innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+    }
+  }
+
+  function _renderCoordList(items) {
+    const badge = document.getElementById('grCoordBadge');
+    if (badge) { badge.textContent = items.length + ' pendente' + (items.length !== 1 ? 's' : ''); badge.style.display = items.length ? '' : 'none'; }
+
+    if (items.length === 0) {
+      document.getElementById('grCoordBody').innerHTML = `
+        <div style="text-align:center;padding:40px;color:#94a3b8;">
+          <div style="font-size:40px;margin-bottom:12px;">✅</div>
+          <p style="font-size:14px;font-weight:600;">Sem vidros pendentes de receção.</p>
+        </div>`;
+      return;
+    }
+
+    document.getElementById('grCoordBody').innerHTML = items.map(r => `
+      <div id="grRow${r.id}" style="border:1px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;background:#fff;">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
+          <span style="font-family:monospace;font-weight:800;font-size:14px;background:#0f172a;color:#fff;padding:3px 10px;border-radius:6px;">${(r.apt_plate || r.order_ref || '—').toUpperCase()}</span>
+          <span style="font-size:13px;font-weight:600;color:#374151;">${r.apt_car || '—'}</span>
+          <span style="font-size:11px;color:#64748b;margin-left:auto;">${fmtDate(r.created_at)}</span>
+        </div>
+        <div style="display:flex;gap:14px;font-size:12px;color:#64748b;flex-wrap:wrap;margin-bottom:10px;">
+          <span>🏪 ${r.portal_label || r.portal_name || '—'}</span>
+          <span>👤 ${r.technician_name || '—'}</span>
+          ${r.order_ref ? `<span>📦 ${r.order_ref}</span>` : ''}
+          ${r.eurocode   ? `<span>🔢 ${r.eurocode}</span>` : ''}
+        </div>
+        <button onclick="window.glassReception._markReceived(${r.id})" style="background:#16a34a;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">✅ Rececionado</button>
+      </div>
+    `).join('');
+  }
+
+  async function _markReceived(id) {
+    const btn = document.querySelector(`#grRow${id} button`);
+    if (btn) { btn.disabled = true; btn.textContent = 'A registar…'; }
+    try {
+      const res = await fetch(API + '/glass-reception', {
+        method: 'PUT',
+        headers: authHeaders(),
+        body: JSON.stringify({ id, status: 'received' })
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      const row = document.getElementById('grRow' + id);
+      if (row) row.remove();
+      await _loadCoordList();
+      _pollPendingBadge();
+    } catch (e) {
+      if (btn) { btn.disabled = false; btn.textContent = '✅ Rececionado'; }
+      alert('Erro: ' + e.message);
+    }
+  }
+
+  // ── BADGE POLLING ────────────────────────────────────────────────────────
+  async function _pollPendingBadge() {
+    try {
+      const res = await fetch(API + '/glass-reception?status=confirmed', { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) return;
+      const n = (json.data || []).length;
+      const deskBadge = document.getElementById('rececaoBadge');
+      const botBadge  = document.getElementById('recBotBadge');
+      if (deskBadge) deskBadge.style.display = n > 0 ? '' : 'none';
+      if (botBadge)  botBadge.style.display  = n > 0 ? '' : 'none';
+    } catch (_) {}
+  }
+
+  // ── VISIBILITY ────────────────────────────────────────────────────────────
+  function _initVisibility() {
+    const user = window.authClient?.getUser?.() || JSON.parse(localStorage.getItem('user_data') || 'null');
+    if (!user) return;
+    const role = user.role || '';
+    // Coordinator/admin: show desk button + poll badge
+    if (role === 'admin' || role === 'coordenador') {
+      const btn = document.getElementById('btnRececaoVidros');
+      if (btn) btn.style.display = '';
+      _pollPendingBadge();
+      setInterval(_pollPendingBadge, 60000);
+    }
+  }
+
+  // ── HELPERS ───────────────────────────────────────────────────────────────
+  function fileToBase64(file) {
+    return new Promise((res, rej) => {
+      const r = new FileReader();
+      r.onload = e => res(e.target.result);
+      r.onerror = rej;
+      r.readAsDataURL(file);
+    });
+  }
+
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _onPhoto, _manualSearch, _step1, _doSearch, _confirmReception, _markReceived };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _initVisibility);
+  } else {
+    setTimeout(_initVisibility, 500);
+  }
+})();
+</script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -894,7 +894,7 @@
     </div>
   </div>
 
-  <script src="transport-guide.js?v=2026-05-19j"></script>
+  <script src="transport-guide.js?v=2026-05-28a"></script>
   <script src="eurocode-reminder.js?v=2026-05-19a"></script>
   <script>
 // ===== HISTÓRICO DE SERVIÇOS (inline) =====

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -39,6 +39,11 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
   } catch(migErr) { console.warn('Migration n_obra warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS order_ref TEXT`);
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS glass_eurocode TEXT`);
+  } catch(migErr) { console.warn('Migration order_ref/eurocode warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -79,7 +84,8 @@ exports.handler = async (event) => {
                vehicle_type, travel_time, auto_imported, executed, confirmed,
                calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
-               custom_service_time, foreign_plate, extra_services, n_obra, created_at, updated_at
+               custom_service_time, foreign_plate, extra_services, n_obra,
+               order_ref, glass_eurocode, created_at, updated_at
         FROM appointments
         WHERE portal_id = $1
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
@@ -114,9 +120,10 @@ exports.handler = async (event) => {
           notes, address, extra, phone, km, sortIndex, "glassOrdered",
           vehicle_type, travel_time, confirmed, calibration, first_of_day, second_of_day,
           not_done_reason, commercial_user_id, return_km, return_time, client_name, damage_details,
-          glass_removed_date, custom_service_time, foreign_plate, extra_services, n_obra, portal_id, created_at, updated_at
+          glass_removed_date, custom_service_time, foreign_plate, extra_services, n_obra,
+          order_ref, glass_eurocode, portal_id, created_at, updated_at
         ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36
         ) RETURNING *
       `;
       const v = [
@@ -141,6 +148,8 @@ exports.handler = async (event) => {
         data.foreign_plate === true,
         data.extra_services ? JSON.stringify(data.extra_services) : null,
         data.n_obra || null,
+        data.order_ref || null,
+        data.glass_eurocode || data.eurocode || null,
         portalId, createdAt, new Date().toISOString()
       ];
       const { rows } = await pool.query(q, v);

--- a/netlify/functions/glass-label-ocr.js
+++ b/netlify/functions/glass-label-ocr.js
@@ -1,0 +1,98 @@
+// netlify/functions/glass-label-ocr.js
+const https = require('https');
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+
+function verifyToken(event) {
+  const h = event.headers.authorization || event.headers.Authorization || '';
+  if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
+  return jwt.verify(h.substring(7), JWT_SECRET);
+}
+
+function callVision(imageBase64, mediaType) {
+  return new Promise((resolve, reject) => {
+    if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
+
+    const body = JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 400,
+      messages: [{
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: mediaType || 'image/jpeg', data: imageBase64 }
+          },
+          {
+            type: 'text',
+            text: `Analisa esta etiqueta de vidro automóvel. Extrai APENAS:
+1. Número de encomenda (campo "Order", "Pedido", "Enc.", "N.º Enc", ou similar — normalmente numérico ou alfanumérico)
+2. Eurocode do vidro (identificador do tipo de vidro — formato comum: 2 letras + 4-6 dígitos, ex: FW1234, AGC5678, ou similar)
+
+Responde EXCLUSIVAMENTE em JSON válido, sem texto adicional:
+{"order_ref": "...", "eurocode": "...", "raw_text": "..."}
+
+Se não encontrares algum campo coloca null.`
+          }
+        ]
+      }]
+    });
+
+    const options = {
+      hostname: 'api.anthropic.com',
+      path: '/v1/messages',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'Content-Length': Buffer.byteLength(body)
+      }
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          const text = parsed.content?.[0]?.text || '';
+          const m = text.match(/\{[\s\S]*\}/);
+          resolve(m ? JSON.parse(m[0]) : { order_ref: null, eurocode: null, raw_text: text });
+        } catch (e) {
+          reject(new Error('Erro ao processar resposta da IA: ' + e.message));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'POST') return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'POST only' }) };
+
+  try {
+    verifyToken(event);
+    const data = JSON.parse(event.body || '{}');
+    if (!data.image_base64) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'image_base64 obrigatório' }) };
+
+    const result = await callVision(data.image_base64, data.media_type || 'image/jpeg');
+    return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: result }) };
+  } catch (err) {
+    console.error('glass-label-ocr:', err);
+    const code = err.message.includes('autenticado') ? 401 : 500;
+    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  }
+};

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -1,0 +1,141 @@
+// netlify/functions/glass-reception.js
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+function verifyToken(event) {
+  const h = event.headers.authorization || event.headers.Authorization || '';
+  if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
+  return jwt.verify(h.substring(7), JWT_SECRET);
+}
+
+async function ensureTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS glass_receptions (
+      id           SERIAL PRIMARY KEY,
+      appointment_id INTEGER REFERENCES appointments(id) ON DELETE SET NULL,
+      order_ref    TEXT,
+      eurocode     TEXT,
+      raw_label_text TEXT,
+      technician_id  INTEGER,
+      technician_name TEXT,
+      portal_id    INTEGER,
+      portal_name  TEXT,
+      status       VARCHAR(20) DEFAULT 'pending',
+      created_at   TIMESTAMPTZ DEFAULT NOW(),
+      updated_at   TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+
+  const client = await pool.connect();
+  try {
+    const user = verifyToken(event);
+    await ensureTable(client);
+
+    // ── GET ────────────────────────────────────────────────────────────────────
+    if (event.httpMethod === 'GET') {
+      const p = event.queryStringParameters || {};
+
+      let q = `
+        SELECT gr.*,
+               a.plate    AS apt_plate,
+               a.car      AS apt_car,
+               a.locality AS apt_locality,
+               a.service  AS apt_service,
+               a.date     AS apt_date,
+               po.name    AS portal_label
+        FROM glass_receptions gr
+        LEFT JOIN appointments a  ON a.id = gr.appointment_id
+        LEFT JOIN portals po      ON po.id = gr.portal_id
+        WHERE 1=1
+      `;
+      const vals = [];
+      let idx = 1;
+
+      if (p.status) { q += ` AND gr.status = $${idx++}`; vals.push(p.status); }
+
+      // Técnicos só vêem do seu portal
+      if (user.role === 'user') { q += ` AND gr.portal_id = $${idx++}`; vals.push(user.portalId); }
+
+      q += ` ORDER BY gr.created_at DESC LIMIT 300`;
+
+      const { rows } = await client.query(q, vals);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
+    }
+
+    // ── POST ───────────────────────────────────────────────────────────────────
+    if (event.httpMethod === 'POST') {
+      const d = JSON.parse(event.body || '{}');
+      const status = d.appointment_id ? 'confirmed' : 'pending';
+
+      const { rows } = await client.query(`
+        INSERT INTO glass_receptions
+          (order_ref, eurocode, raw_label_text, appointment_id,
+           technician_id, technician_name, portal_id, portal_name, status)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+        RETURNING *
+      `, [
+        d.order_ref || null, d.eurocode || null, d.raw_label_text || null,
+        d.appointment_id || null,
+        user.userId || user.id, user.username,
+        user.portalId || null, d.portal_name || null,
+        status
+      ]);
+
+      return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
+    }
+
+    // ── PUT ────────────────────────────────────────────────────────────────────
+    if (event.httpMethod === 'PUT') {
+      const d = JSON.parse(event.body || '{}');
+      const id = d.id || (event.path || '').split('/').filter(Boolean).pop();
+
+      const updates = ['updated_at = NOW()'];
+      const vals = [];
+      let idx = 1;
+
+      if (d.appointment_id !== undefined) { updates.push(`appointment_id = $${idx++}`); vals.push(d.appointment_id); }
+      if (d.status)                        { updates.push(`status = $${idx++}`);          vals.push(d.status); }
+      vals.push(id);
+
+      const { rows } = await client.query(
+        `UPDATE glass_receptions SET ${updates.join(', ')} WHERE id = $${idx} RETURNING *`,
+        vals
+      );
+
+      if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Não encontrado' }) };
+
+      // Ao marcar como received → muda status do agendamento para ST
+      if (d.status === 'received' && rows[0].appointment_id) {
+        await client.query(
+          `UPDATE appointments SET status = 'ST', updated_at = NOW() WHERE id = $1`,
+          [rows[0].appointment_id]
+        );
+      }
+
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };
+
+  } catch (err) {
+    console.error('glass-reception:', err);
+    const code = err.message.includes('autenticado') ? 401 : 500;
+    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  } finally {
+    client.release();
+  }
+};

--- a/netlify/functions/transport-guide.js
+++ b/netlify/functions/transport-guide.js
@@ -109,8 +109,10 @@ exports.handler = async (event) => {
     if (event.httpMethod === 'GET') {
       const p = event.queryStringParameters || {};
       const date = p.date || new Date().toISOString().split('T')[0];
-      let portalId = user.portalId;
-      if (!portalId && p.portal_id) portalId = parseInt(p.portal_id);
+      // Prefer explicit portal_id from query (sent from window.activePortalId for coordinators
+      // managing multiple portals) over the JWT portal (which may be their primary portal, not
+      // the one they're currently viewing).
+      let portalId = p.portal_id ? parseInt(p.portal_id) : user.portalId;
       if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Portal não identificado' }) };
       const res = await client.query(
         `SELECT id, guide_date, guide_number, pdf_data, eurocodes, uploaded_at, COALESCE(file_type, 'application/pdf') AS file_type
@@ -131,8 +133,9 @@ exports.handler = async (event) => {
       const { pdf_data, file_type, _portalId, guide_date: rawGuideDate } = body;
       if (!pdf_data) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Ficheiro em falta' }) };
 
-      let portalId = user.portalId;
-      if (!portalId && _portalId) portalId = parseInt(_portalId);
+      // Prefer _portalId (from window.activePortalId on the frontend) over JWT portal so that
+      // coordinators managing multiple portals upload the guide to the correct portal.
+      let portalId = _portalId ? parseInt(_portalId) : user.portalId;
       if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Portal não identificado' }) };
 
       // guide_date: accept 'today', 'tomorrow', or ISO date string; default today

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -340,7 +340,7 @@
 
   // Calcula portalParam usando activePortalId (admin/coord) ou portalId do JWT (técnico)
   function getPortalParam() {
-    const id = window.activePortalId || window.authClient?.getUser?.()?.portalId;
+    const id = window.activePortalId || window.authClient?.getUser?.()?.portalId || window.portalConfig?.id;
     return id ? `&portal_id=${id}` : '';
   }
 


### PR DESCRIPTION
## Problema

Quando a coordenadora gere múltiplos portais (ex: SM Braga + Famalicão SM), o seu JWT tem `portalId` do portal principal. Ao mudar para Famalicão SM, o `window.activePortalId` fica com o ID correto (ex: 7).

Ao **carregar a guia AT**, o frontend envia `_portalId=7`, mas o backend ignorava esse valor porque `user.portalId` (do JWT) já estava preenchido — gravando a guia para o portal errado.

Ao **visualizar**, a coordenadora via o portal do seu JWT (e a guia estava lá), mas os técnicos de Famalicão SM (`portalId=7`) procuravam a guia para o portal 7 e não encontravam → **SEM GUIA**.

## Fix

- **Backend GET**: usar `portal_id` do query param quando enviado (enviado pelo `window.activePortalId`), em vez de sempre usar o JWT
- **Backend POST**: usar `_portalId` quando enviado, em vez de só usá-lo como fallback quando `user.portalId` é null
- **Frontend `getPortalParam()`**: adicionar `window.portalConfig?.id` como fallback extra para técnicos cujo JWT `portalId` possa ser null

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_