### PR TITLE
Fix eurocode regex: sempre extrair do raw_text (não só fallback)

### DIFF
--- a/netlify/functions/glass-label-ocr.js
+++ b/netlify/functions/glass-label-ocr.js
@@ -71,18 +71,14 @@ Se não encontrares algum campo coloca null.`
           const m = text.match(/\{[\s\S]*\}/);
           const result = m ? JSON.parse(m[0]) : { order_ref: null, eurocode: null, raw_text: text };
 
-          // Validate and fix eurocode using regex on raw_text.
-          // If AI returned something like "1605AGACMVZ" (digits from before "/" combined
-          // with letters from after "/"), correct it by finding valid eurocodes in raw_text.
-          const isValidEc = (ec) => ec && /^\d{4}[A-Z]{3,}/.test(String(ec).toUpperCase());
-          if (result.raw_text && !isValidEc(result.eurocode)) {
+          // Always extract eurocode from raw_text via regex — more reliable than AI parsing.
+          // Splits on "/" so "1605/6577AGACMVZ" yields ["1605", "6577AGACMVZ"] and finds 6577AGACMVZ.
+          if (result.raw_text) {
             const rawUpper = String(result.raw_text).toUpperCase();
-            // Split on common separators so "1605/6577AGACMVZ" → tokens include "6577AGACMVZ"
             const candidates = rawUpper.split(/[\s\/,;|:]+/)
               .map(t => t.replace(/^[^A-Z0-9]+/, '').replace(/[^A-Z0-9]+$/, ''))
               .filter(t => /^\d{4}[A-Z]{3,}/.test(t));
             if (candidates.length > 0) {
-              // Prefer the longest candidate (more specific code)
               result.eurocode = candidates.sort((a, b) => b.length - a.length)[0];
             }
           }


### PR DESCRIPTION
## Problema

`1605AGACMVZ` também passava no regex `^\d{4}[A-Z]{3,}` (4 dígitos + letras), por isso o fix anterior não corrigia nada — o código tratava-o como válido.

## Fix

Remover a condição de validação e **sempre** usar o regex sobre `raw_text`:
- Split por `/` → `"1605/6577AGACMVZ"` → tokens `["1605", "6577AGACMVZ"]`  
- `1605` não tem letras → não passa  
- `6577AGACMVZ` passa → resultado correto  

O eurocode da IA é ignorado — o regex é mais fiável para este padrão.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_