### PR TITLE
Guardar e mostrar n.º de encomenda no card (só coordenador)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1501,7 +1501,11 @@
       const aptId = json.data?.appointment_id;
       if (aptId && window.appointments) {
         const apt = window.appointments.find(a => a.id === aptId);
-        if (apt) { apt.status = 'ST'; apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode; }
+        if (apt) {
+          apt.status = 'ST';
+          apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode;
+          apt.order_ref = json.data.order_ref || apt.order_ref;
+        }
         if (typeof renderAll === 'function') renderAll();
         window.guiaAT?.injectBadges();
       }

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -95,6 +95,14 @@ exports.handler = async (event) => {
         status
       ]);
 
+      // Propagate order_ref to the appointment so coordinators can see it on the card
+      if (d.appointment_id && d.order_ref) {
+        await client.query(
+          `UPDATE appointments SET order_ref = $1, updated_at = NOW() WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
+          [d.order_ref, d.appointment_id]
+        );
+      }
+
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 

--- a/script-tail.js
+++ b/script-tail.js
@@ -63,7 +63,9 @@ const telBtn = phone ? `
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
-  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const _mRole = window.authClient?.getUser?.()?.role;
+  const _orderRefMobile = (_mRole === 'admin' || _mRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
+  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefMobile].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');

--- a/script.js
+++ b/script.js
@@ -2504,9 +2504,10 @@ function buildDesktopCard(a){
   if (_extraDisplay) {
     try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
   }
+  const _orderRefStr = (userRole === 'admin' || userRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Funcionalidade

Ao confirmar uma receção de vidro com scan da etiqueta, o número de encomenda (ex: `65178`) fica guardado no agendamento e visível no card — mas apenas para coordenadores e admins.

## Como funciona

1. **Backend `glass-reception` POST**: após criar o registo de receção, propaga `order_ref` para `appointments.order_ref` (só se ainda estiver vazio — não sobrescreve entradas manuais)

2. **`_markReceived`**: quando o coordenador clica "Rececionado", atualiza também `apt.order_ref` no array local `window.appointments` para o re-render imediato

3. **Cards desktop (`script.js`) e mobile (`script-tail.js`)**: mostram `📦 Enc: 65178` na linha de info do card, mas apenas quando `role === 'coordenador' || 'admin'`

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_