### PR TITLE
Limpar corpo do email: remover avisos, assinatura e morada

### DIFF
--- a/index.html
+++ b/index.html
@@ -1501,7 +1501,11 @@
       const aptId = json.data?.appointment_id;
       if (aptId && window.appointments) {
         const apt = window.appointments.find(a => a.id === aptId);
-        if (apt) { apt.status = 'ST'; apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode; }
+        if (apt) {
+          apt.status = 'ST';
+          apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode;
+          apt.order_ref = json.data.order_ref || apt.order_ref;
+        }
         if (typeof renderAll === 'function') renderAll();
         window.guiaAT?.injectBadges();
       }

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -95,6 +95,14 @@ exports.handler = async (event) => {
         status
       ]);
 
+      // Propagate order_ref to the appointment so coordinators can see it on the card
+      if (d.appointment_id && d.order_ref) {
+        await client.query(
+          `UPDATE appointments SET order_ref = $1, updated_at = NOW() WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
+          [d.order_ref, d.appointment_id]
+        );
+      }
+
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -105,13 +105,29 @@ function cleanEmailBody(text) {
     text = lines.slice(bodyStart).join('\n');
   }
 
+  // Cortar na palavra de fecho — assinatura começa depois
+  const closingRx = /^(Obrigad[ao][\.\!,]?|Cumprimentos[\.\!]?|Com os melhores cumprimentos|Atenciosamente[\.\!]?|Com estima|Regards|Best regards|Abraços)/im;
+  const closingMatch = text.match(closingRx);
+  if (closingMatch) {
+    text = text.slice(0, closingMatch.index + closingMatch[0].length);
+  }
+
   const cleaned = text.split('\n').filter(line => {
     const t = line.trim();
     if (!t) return false;
-    if (/^[-=_*>]{3,}$/.test(t)) return false;           // dividers / quoted markers
+    if (/^[-=_*>]{3,}$/.test(t)) return false;                        // dividers / quoted markers
     if (/^(From|De|Date|Data|Subject|Assunto|To|Para|Cc|Sent|Enviado):/i.test(t)) return false;
-    if (/^\[?(image|imagem|cid:)/i.test(t)) return false; // inline images
-    if ((t.match(/\t/g) || []).length >= 2) return false;  // linhas de tabela
+    if (/^\[?(image|imagem|cid:)/i.test(t)) return false;             // inline images
+    if ((t.match(/\t/g) || []).length >= 2) return false;             // linhas de tabela
+    // Avisos de segurança do servidor de email
+    if (/segurança.*email|email.*nossa.*organiza|email externo|não carregue|atenção.*email/i.test(t)) return false;
+    if (/^[\[🔒].*segurança/i.test(t) || /^\[aten/i.test(t)) return false;
+    // Linhas de assinatura
+    if (/\d{4}-\d{3}/.test(t)) return false;                         // código postal
+    if (/^T[:\.\s]+[\+\d]/.test(t) || /^Tel[:\.\s]+[\+\d]/i.test(t)) return false; // telefone
+    if (/mailto:|<[^>]+@[^>]{1,30}>/.test(t)) return false;          // mailto / email entre <>
+    if (/^(Rua|Av\.|Avenida|Largo|Travessa|Praceta|Estrada)\s/i.test(t)) return false; // morada
+    if (/^Enviada?:/i.test(t)) return false;                         // data de reencaminhamento
     return true;
   }).join('\n').replace(/\n{3,}/g, '\n\n').trim();
 

--- a/script-tail.js
+++ b/script-tail.js
@@ -63,7 +63,9 @@ const telBtn = phone ? `
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
-  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const _mRole = window.authClient?.getUser?.()?.role;
+  const _orderRefMobile = (_mRole === 'admin' || _mRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
+  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefMobile].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');

--- a/script.js
+++ b/script.js
@@ -2504,9 +2504,10 @@ function buildDesktopCard(a){
   if (_extraDisplay) {
     try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
   }
+  const _orderRefStr = (userRole === 'admin' || userRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Problema

O "CORPO DO EMAIL" mostrava o conteúdo em bruto com avisos de segurança do servidor, assinatura completa (nome, empresa, morada, telefone, email), e headers de reencaminhamento.

## Fix em `cleanEmailBody`

Adicionadas as seguintes limpezas:

- **Corte na palavra de fecho** (`Obrigada`, `Cumprimentos`, etc.) — tudo depois é assinatura e é descartado
- **Avisos de segurança** (`🔒 Segurança:`, `[ATENÇÃO: email externo]`) — removidos por regex
- **Linhas de morada** (`Rua`, `Av.`, `Avenida`, etc.)
- **Código postal** (padrão `\d{4}-\d{3}`)
- **Telefone** (`T:.`, `Tel:`)
- **Links mailto** e emails entre `<>`
- **Data de reencaminhamento** (`Enviada: ...`)

Resultado para o email da screenshot:
```
Bom dia,
Podem avançar com o pedido.
Serviço a ser realizado no Mycarcenter.
Obrigada.
```

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_