### PR TITLE
feat: cross-portal glass reception search

### DIFF
--- a/index.html
+++ b/index.html
@@ -1345,20 +1345,42 @@
 
   function _step1() { renderStep1(); }
 
-  function _doSearch(orderRef, eurocode, rawText, photoBase64) {
+  async function _doSearch(orderRef, eurocode, rawText, photoBase64) {
+    // Show loading state
+    const body = document.getElementById('grScanBody');
+    if (body) body.innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A procurar em todos os portais…</p>`;
+
     const ecLow = eurocode ? eurocode.trim().toLowerCase() : null;
-    const appts = (window.appointments || []).filter(a => {
+
+    // Local search first (active portal appointments already loaded)
+    const localResults = (window.appointments || []).filter(a => {
       if (a.executed === true || a.glass_removed) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
       const matchEuro  = ecLow && a.glass_eurocode && a.glass_eurocode.trim().toLowerCase() === ecLow;
-      // Search in notes, n_obra, and extra JSON for eurocode
       let extraEuro = '';
       if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || '').toLowerCase(); } catch(e) { extraEuro = (a.extra || '').toLowerCase(); } }
       const matchEuroNotes = ecLow && ((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).toLowerCase().includes(ecLow);
       return matchOrder || matchEuro || matchEuroNotes;
     });
 
-    renderMatches(appts, orderRef, eurocode, rawText, photoBase64);
+    // Cross-portal API search
+    let apiResults = [];
+    try {
+      const qp = new URLSearchParams();
+      if (eurocode) qp.set('search_eurocode', eurocode.trim());
+      if (orderRef) qp.set('search_order_ref', orderRef.trim());
+      if (qp.toString()) {
+        const res = await fetch(API + '/appointments?' + qp.toString(), { headers: authHeaders() });
+        const json = await res.json();
+        if (json.success) apiResults = json.data || [];
+      }
+    } catch (e) { console.warn('Cross-portal search failed:', e); }
+
+    // Merge: local results + API results (deduplicate by id)
+    const seen = new Set(localResults.map(a => a.id));
+    const merged = [...localResults, ...apiResults.filter(a => !seen.has(a.id))];
+
+    renderMatches(merged, orderRef, eurocode, rawText, photoBase64);
   }
 
   function renderMatches(appts, orderRef, eurocode, rawText, photoBase64) {

--- a/index.html
+++ b/index.html
@@ -1501,7 +1501,11 @@
       const aptId = json.data?.appointment_id;
       if (aptId && window.appointments) {
         const apt = window.appointments.find(a => a.id === aptId);
-        if (apt) { apt.status = 'ST'; apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode; }
+        if (apt) {
+          apt.status = 'ST';
+          apt.glass_eurocode = json.data.eurocode || apt.glass_eurocode;
+          apt.order_ref = json.data.order_ref || apt.order_ref;
+        }
         if (typeof renderAll === 'function') renderAll();
         window.guiaAT?.injectBadges();
       }

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -78,6 +78,55 @@ exports.handler = async (event) => {
 
     // ---------- GET ----------
     if (event.httpMethod === 'GET') {
+      // Cross-portal search for glass reception matching
+      if (params.search_eurocode || params.search_order_ref) {
+        let allowedPortalIds;
+        if (user.role === 'admin') {
+          const { rows: allPortals } = await pool.query('SELECT id FROM portals');
+          allowedPortalIds = allPortals.map(r => r.id);
+        } else {
+          const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+          allowedPortalIds = ids;
+        }
+        if (!allowedPortalIds.length) {
+          return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: [] }) };
+        }
+
+        const conditions = [];
+        const vals = [allowedPortalIds];
+        let idx = 2;
+
+        if (params.search_eurocode) {
+          conditions.push(`(LOWER(glass_eurocode) = LOWER($${idx}) OR LOWER(notes) LIKE '%' || LOWER($${idx}) || '%' OR LOWER(extra::text) LIKE '%' || LOWER($${idx}) || '%')`);
+          vals.push(params.search_eurocode.trim());
+          idx++;
+        }
+        if (params.search_order_ref) {
+          conditions.push(`LOWER(order_ref) = LOWER($${idx})`);
+          vals.push(params.search_order_ref.trim());
+          idx++;
+        }
+
+        const searchQ = `
+          SELECT id, date, period, plate, car, service, locality, status,
+                 notes, address, extra, phone, km, sortIndex, "glassOrdered",
+                 vehicle_type, travel_time, auto_imported, executed, confirmed,
+                 calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
+                 return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
+                 custom_service_time, foreign_plate, extra_services, n_obra,
+                 order_ref, glass_eurocode, created_at, updated_at, portal_id
+          FROM appointments
+          WHERE portal_id = ANY($1)
+            AND executed IS NOT TRUE
+            AND glass_removed IS NOT TRUE
+            AND (${conditions.join(' OR ')})
+          ORDER BY date ASC NULLS LAST, created_at ASC
+          LIMIT 50
+        `;
+        const { rows } = await pool.query(searchQ, vals);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
+      }
+
       const q = `
         SELECT id, date, period, plate, car, service, locality, status,
                notes, address, extra, phone, km, sortIndex, "glassOrdered",

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -95,6 +95,14 @@ exports.handler = async (event) => {
         status
       ]);
 
+      // Propagate order_ref to the appointment so coordinators can see it on the card
+      if (d.appointment_id && d.order_ref) {
+        await client.query(
+          `UPDATE appointments SET order_ref = $1, updated_at = NOW() WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
+          [d.order_ref, d.appointment_id]
+        );
+      }
+
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -105,13 +105,29 @@ function cleanEmailBody(text) {
     text = lines.slice(bodyStart).join('\n');
   }
 
+  // Cortar na palavra de fecho — assinatura começa depois
+  const closingRx = /^(Obrigad[ao][\.\!,]?|Cumprimentos[\.\!]?|Com os melhores cumprimentos|Atenciosamente[\.\!]?|Com estima|Regards|Best regards|Abraços)/im;
+  const closingMatch = text.match(closingRx);
+  if (closingMatch) {
+    text = text.slice(0, closingMatch.index + closingMatch[0].length);
+  }
+
   const cleaned = text.split('\n').filter(line => {
     const t = line.trim();
     if (!t) return false;
-    if (/^[-=_*>]{3,}$/.test(t)) return false;           // dividers / quoted markers
+    if (/^[-=_*>]{3,}$/.test(t)) return false;                        // dividers / quoted markers
     if (/^(From|De|Date|Data|Subject|Assunto|To|Para|Cc|Sent|Enviado):/i.test(t)) return false;
-    if (/^\[?(image|imagem|cid:)/i.test(t)) return false; // inline images
-    if ((t.match(/\t/g) || []).length >= 2) return false;  // linhas de tabela
+    if (/^\[?(image|imagem|cid:)/i.test(t)) return false;             // inline images
+    if ((t.match(/\t/g) || []).length >= 2) return false;             // linhas de tabela
+    // Avisos de segurança do servidor de email
+    if (/segurança.*email|email.*nossa.*organiza|email externo|não carregue|atenção.*email/i.test(t)) return false;
+    if (/^[\[🔒].*segurança/i.test(t) || /^\[aten/i.test(t)) return false;
+    // Linhas de assinatura
+    if (/\d{4}-\d{3}/.test(t)) return false;                         // código postal
+    if (/^T[:\.\s]+[\+\d]/.test(t) || /^Tel[:\.\s]+[\+\d]/i.test(t)) return false; // telefone
+    if (/mailto:|<[^>]+@[^>]{1,30}>/.test(t)) return false;          // mailto / email entre <>
+    if (/^(Rua|Av\.|Avenida|Largo|Travessa|Praceta|Estrada)\s/i.test(t)) return false; // morada
+    if (/^Enviada?:/i.test(t)) return false;                         // data de reencaminhamento
     return true;
   }).join('\n').replace(/\n{3,}/g, '\n\n').trim();
 

--- a/script-tail.js
+++ b/script-tail.js
@@ -63,7 +63,9 @@ const telBtn = phone ? `
   ].filter(Boolean).join('');
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
-  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const _mRole = window.authClient?.getUser?.()?.role;
+  const _orderRefMobile = (_mRole === 'admin' || _mRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
+  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefMobile].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');

--- a/script.js
+++ b/script.js
@@ -2504,9 +2504,10 @@ function buildDesktopCard(a){
   if (_extraDisplay) {
     try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
   }
+  const _orderRefStr = (userRole === 'admin' || userRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Summary
- `_doSearch` is now async and queries `GET /appointments?search_eurocode=X&search_order_ref=Y` after the local search
- Backend searches across **all portals the user has access to** (JWT `portalIds[]` for coordinators, all portals for admins, single portal for technicians)
- Local `window.appointments` results (active portal) are merged with API results, deduplicated by ID
- Loading state shown while the API call is in progress

## Test plan
- [ ] Technician scans a label for an appointment in their portal → found as before
- [ ] Coordinator scans a label for an appointment in a *different* portal they manage → now found
- [ ] Admin scans → searches all portals
- [ ] No regression when search returns zero results

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_