### PR TITLE
fix: normalize I↔1 and O↔0 in eurocode search to handle OCR confusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1350,16 +1350,18 @@
     const body = document.getElementById('grScanBody');
     if (body) body.innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A procurar em todos os portais…</p>`;
 
-    const ecLow = eurocode ? eurocode.trim().toLowerCase() : null;
+    // Normalize I↔1 and O↔0 to handle OCR character confusion
+    const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
+    const ecNorm = eurocode ? normEc(eurocode.trim()) : null;
 
     // Local search first (active portal appointments already loaded)
     const localResults = (window.appointments || []).filter(a => {
       if (a.executed === true || a.glass_removed) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
-      const matchEuro  = ecLow && a.glass_eurocode && a.glass_eurocode.trim().toLowerCase() === ecLow;
+      const matchEuro  = ecNorm && a.glass_eurocode && normEc(a.glass_eurocode) === ecNorm;
       let extraEuro = '';
-      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || '').toLowerCase(); } catch(e) { extraEuro = (a.extra || '').toLowerCase(); } }
-      const matchEuroNotes = ecLow && ((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).toLowerCase().includes(ecLow);
+      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || ''); } catch(e) { extraEuro = (a.extra || ''); } }
+      const matchEuroNotes = ecNorm && normEc((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).includes(ecNorm);
       return matchOrder || matchEuro || matchEuroNotes;
     });
 

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -98,7 +98,12 @@ exports.handler = async (event) => {
         let idx = 2;
 
         if (params.search_eurocode) {
-          conditions.push(`(LOWER(glass_eurocode) = LOWER($${idx}) OR LOWER(notes) LIKE '%' || LOWER($${idx}) || '%' OR LOWER(extra::text) LIKE '%' || LOWER($${idx}) || '%')`);
+          // Normalize I↔1 and O↔0 to handle OCR character confusion
+          conditions.push(`(
+            REPLACE(REPLACE(LOWER(glass_eurocode), 'i', '1'), 'o', '0') = REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0')
+            OR REPLACE(REPLACE(LOWER(notes), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+            OR REPLACE(REPLACE(LOWER(extra::text), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+          )`);
           vals.push(params.search_eurocode.trim());
           idx++;
         }


### PR DESCRIPTION
## Summary
- OCR consistently confuses digit `1` with letter `I` (and `0` with `O`) in delivery label fonts
- Both backend SQL and frontend local search now normalize before comparing: `replace(lower(field), 'i', '1')` so `7274AGAMIR` matches `7274AGAM1R`

## Test plan
- [ ] Scan label with `7274AGAM1R` — should now find the appointment even if OCR reads it as `7274AGAMIR`

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_