### PR TITLE
fix: glass reception date limit and correct portal name in match cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1350,16 +1350,18 @@
     const body = document.getElementById('grScanBody');
     if (body) body.innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A procurar em todos os portais…</p>`;
 
-    const ecLow = eurocode ? eurocode.trim().toLowerCase() : null;
+    // Normalize I↔1 and O↔0 to handle OCR character confusion
+    const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
+    const ecNorm = eurocode ? normEc(eurocode.trim()) : null;
 
     // Local search first (active portal appointments already loaded)
     const localResults = (window.appointments || []).filter(a => {
       if (a.executed === true || a.glass_removed) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
-      const matchEuro  = ecLow && a.glass_eurocode && a.glass_eurocode.trim().toLowerCase() === ecLow;
+      const matchEuro  = ecNorm && a.glass_eurocode && normEc(a.glass_eurocode) === ecNorm;
       let extraEuro = '';
-      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || '').toLowerCase(); } catch(e) { extraEuro = (a.extra || '').toLowerCase(); } }
-      const matchEuroNotes = ecLow && ((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).toLowerCase().includes(ecLow);
+      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || ''); } catch(e) { extraEuro = (a.extra || ''); } }
+      const matchEuroNotes = ecNorm && normEc((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).includes(ecNorm);
       return matchOrder || matchEuro || matchEuroNotes;
     });
 

--- a/index.html
+++ b/index.html
@@ -1413,7 +1413,7 @@
           <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
         </div>
         <div style="display:flex;gap:16px;font-size:12px;color:#64748b;flex-wrap:wrap;">
-          <span>🏪 ${a.locality || window.portalConfig?.name || '—'}</span>
+          <span>🏪 ${a.portal_name || a.locality || window.portalConfig?.name || '—'}</span>
           <span>🔧 ${a.service || '—'}</span>
           ${a.date ? `<span>📅 ${fmtDate(a.date)}</span>` : '<span style="color:#f59e0b;">Sem data</span>'}
         </div>

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -98,7 +98,12 @@ exports.handler = async (event) => {
         let idx = 2;
 
         if (params.search_eurocode) {
-          conditions.push(`(LOWER(glass_eurocode) = LOWER($${idx}) OR LOWER(notes) LIKE '%' || LOWER($${idx}) || '%' OR LOWER(extra::text) LIKE '%' || LOWER($${idx}) || '%')`);
+          // Normalize I↔1 and O↔0 to handle OCR character confusion
+          conditions.push(`(
+            REPLACE(REPLACE(LOWER(glass_eurocode), 'i', '1'), 'o', '0') = REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0')
+            OR REPLACE(REPLACE(LOWER(notes), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+            OR REPLACE(REPLACE(LOWER(extra::text), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+          )`);
           vals.push(params.search_eurocode.trim());
           idx++;
         }

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -114,19 +114,22 @@ exports.handler = async (event) => {
         }
 
         const searchQ = `
-          SELECT id, date, period, plate, car, service, locality, status,
-                 notes, address, extra, phone, km, sortIndex, "glassOrdered",
-                 vehicle_type, travel_time, auto_imported, executed, confirmed,
-                 calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
-                 return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
-                 custom_service_time, foreign_plate, extra_services, n_obra,
-                 order_ref, glass_eurocode, created_at, updated_at, portal_id
-          FROM appointments
-          WHERE portal_id = ANY($1)
-            AND executed IS NOT TRUE
-            AND glass_removed IS NOT TRUE
+          SELECT a.id, a.date, a.period, a.plate, a.car, a.service, a.locality, a.status,
+                 a.notes, a.address, a.extra, a.phone, a.km, a.sortIndex, a."glassOrdered",
+                 a.vehicle_type, a.travel_time, a.auto_imported, a.executed, a.confirmed,
+                 a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
+                 a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
+                 a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
+                 a.order_ref, a.glass_eurocode, a.created_at, a.updated_at, a.portal_id,
+                 p.name AS portal_name
+          FROM appointments a
+          LEFT JOIN portals p ON p.id = a.portal_id
+          WHERE a.portal_id = ANY($1)
+            AND a.executed IS NOT TRUE
+            AND a.glass_removed IS NOT TRUE
+            AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '5 days')
             AND (${conditions.join(' OR ')})
-          ORDER BY date ASC NULLS LAST, created_at ASC
+          ORDER BY a.date ASC NULLS LAST, a.created_at ASC
           LIMIT 50
         `;
         const { rows } = await pool.query(searchQ, vals);


### PR DESCRIPTION
## Summary
- Cross-portal glass reception search now filters `date >= CURRENT_DATE - 5 days` to avoid surfacing old appointments
- Backend does `LEFT JOIN portals` to return `portal_name` alongside each result
- Match cards now show the actual portal name (`portal_name`) instead of falling back to `window.portalConfig.name` (the active portal), which caused all cross-portal results to show "Braga"

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_