### PR TITLE
feat: morning alert for technicians with unresolved service statuses

### DIFF
--- a/incomplete-services-alert.js
+++ b/incomplete-services-alert.js
@@ -1,0 +1,201 @@
+// incomplete-services-alert.js
+// Morning alert for technicians: appointments from previous days without a final service status.
+// Shows a blocking popup (similar to glass-alert-urgent.js) at or after 09:00 once per day.
+
+(function () {
+  const DISMISS_PREFIX = 'incompleteServicesDismissed_';
+  const SHOW_AFTER_HOUR = 9; // show at/after 09:00
+
+  function todayKey() {
+    return DISMISS_PREFIX + new Date().toDateString();
+  }
+
+  function isDismissed() {
+    return !!localStorage.getItem(todayKey());
+  }
+
+  function dismiss() {
+    localStorage.setItem(todayKey(), '1');
+  }
+
+  function isPastShowTime() {
+    return new Date().getHours() >= SHOW_AFTER_HOUR;
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return '';
+    const d = new Date(iso + 'T00:00:00');
+    return d.toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', weekday: 'short' });
+  }
+
+  async function fetchPending() {
+    try {
+      const token = window.authClient?.getToken?.() || localStorage.getItem('authToken');
+      if (!token) return [];
+      const user = window.authClient?.getUser?.();
+      const portalId = user?.portalId || window.portalConfig?.id;
+      if (!portalId) return [];
+      const resp = await fetch(
+        `/.netlify/functions/appointments?portal_id=${portalId}&pending_conclusion=true`,
+        { headers: { Authorization: 'Bearer ' + token } }
+      );
+      const data = await resp.json();
+      if (!data.success || !Array.isArray(data.data)) return [];
+      return data.data;
+    } catch (e) {
+      console.warn('[IncompleteServices] Fetch error:', e);
+      return [];
+    }
+  }
+
+  function injectStyles() {
+    if (document.getElementById('incServStyles')) return;
+    const s = document.createElement('style');
+    s.id = 'incServStyles';
+    s.textContent = `
+      @keyframes incServPulse {
+        0%,100% { color:#b45309; transform:scale(1); }
+        50%      { color:#f59e0b; transform:scale(1.04); }
+      }
+      @keyframes incServFade { from{opacity:0} to{opacity:1} }
+      #incServOverlay {
+        position:fixed; inset:0;
+        background:rgba(0,0,0,.85);
+        z-index:999999;
+        display:flex; align-items:center; justify-content:center;
+        padding:20px;
+        animation:incServFade .25s ease-in;
+      }
+      #incServBox {
+        background:#fff;
+        border:6px solid #d97706;
+        border-radius:18px;
+        max-width:540px; width:100%;
+        text-align:center;
+        padding:36px 24px 28px;
+        box-shadow:0 25px 80px rgba(217,119,6,.45);
+        max-height:90vh; overflow-y:auto;
+      }
+      #incServBox .is-icon  { font-size:54px; margin-bottom:6px; }
+      #incServBox .is-title {
+        font-size:24px; font-weight:900;
+        text-transform:uppercase; line-height:1.2;
+        animation:incServPulse .75s infinite;
+        margin:0 0 8px;
+      }
+      #incServBox .is-sub {
+        font-size:15px; font-weight:600; color:#1e293b;
+        margin:0 0 18px; line-height:1.4;
+      }
+      #incServList {
+        text-align:left;
+        background:#fffbeb;
+        border:1.5px solid #fde68a;
+        border-radius:10px;
+        padding:10px 14px;
+        margin-bottom:20px;
+        max-height:210px; overflow-y:auto;
+      }
+      .inc-item {
+        display:flex; align-items:center; gap:8px; flex-wrap:wrap;
+        padding:7px 0;
+        border-bottom:1px solid #fde68a;
+        font-size:13px; font-weight:600; color:#1e293b;
+      }
+      .inc-item:last-child { border-bottom:none; }
+      .inc-date {
+        font-size:11px; color:#92400e; font-weight:700;
+        background:#fef3c7; border-radius:6px;
+        padding:2px 7px; white-space:nowrap;
+      }
+      .inc-svc {
+        font-size:11px; color:#92400e;
+        margin-left:auto; white-space:nowrap;
+      }
+      #incServBox .is-btns { display:flex; gap:12px; justify-content:center; flex-wrap:wrap; }
+      #incServBox button {
+        border:none; border-radius:12px; cursor:pointer;
+        font-size:15px; font-weight:800;
+        padding:12px 26px; transition:background .15s;
+      }
+      #incServBtnVer { background:#d97706; color:#fff; }
+      #incServBtnVer:hover { background:#b45309; }
+      #incServBtnOk  { background:#16a34a; color:#fff; }
+      #incServBtnOk:hover  { background:#15803d; }
+      @media(max-width:480px){
+        #incServBox .is-title { font-size:19px; }
+        #incServBox .is-sub   { font-size:13px; }
+        #incServBox button    { padding:11px 18px; font-size:14px; }
+      }
+    `;
+    document.head.appendChild(s);
+  }
+
+  function showPopup(services) {
+    if (document.getElementById('incServOverlay')) return;
+    injectStyles();
+
+    const listHTML = services.map(a => `
+      <div class="inc-item">
+        <span class="inc-date">${fmtDate(a.date)}</span>
+        <strong>${a.plate || '—'}</strong>
+        <span style="color:#64748b;font-weight:400;">${a.car || ''}</span>
+        ${a.service ? `<span class="inc-svc">${a.service}</span>` : ''}
+      </div>`).join('');
+
+    const n = services.length;
+    const overlay = document.createElement('div');
+    overlay.id = 'incServOverlay';
+    overlay.innerHTML = `
+      <div id="incServBox">
+        <div class="is-icon">⚠️</div>
+        <h1 class="is-title">Falta concluir ${n} serviço${n > 1 ? 's' : ''}!</h1>
+        <p class="is-sub">
+          Os seguintes serviços de véspera ainda não têm estado marcado<br>
+          (Realizado / Não Realizado). Por favor actualiza antes de continuar.
+        </p>
+        <div id="incServList">${listHTML}</div>
+        <div class="is-btns">
+          <button id="incServBtnVer">📋 Ver serviços</button>
+          <button id="incServBtnOk">✅ Já tratei</button>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+
+    document.getElementById('incServBtnVer').onclick = () => {
+      overlay.remove();
+      // Navigate calendar to the week of the first unresolved appointment
+      const firstDate = services[0]?.date;
+      if (firstDate && typeof getMonday === 'function' && typeof renderAll === 'function') {
+        currentMonday = getMonday(new Date(firstDate + 'T00:00:00'));
+        renderAll();
+      }
+    };
+
+    document.getElementById('incServBtnOk').onclick = () => {
+      dismiss();
+      overlay.remove();
+    };
+  }
+
+  async function check() {
+    const role = window.authClient?.getUser?.()?.role;
+    if (role !== 'user') return;
+    if (!isPastShowTime()) return;
+    if (isDismissed()) return;
+
+    const pending = await fetchPending();
+    if (pending.length > 0) showPopup(pending);
+  }
+
+  function init() {
+    setTimeout(check, 3500);
+    setInterval(check, 5 * 60 * 1000);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1350,16 +1350,18 @@
     const body = document.getElementById('grScanBody');
     if (body) body.innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A procurar em todos os portais…</p>`;
 
-    const ecLow = eurocode ? eurocode.trim().toLowerCase() : null;
+    // Normalize I↔1 and O↔0 to handle OCR character confusion
+    const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
+    const ecNorm = eurocode ? normEc(eurocode.trim()) : null;
 
     // Local search first (active portal appointments already loaded)
     const localResults = (window.appointments || []).filter(a => {
       if (a.executed === true || a.glass_removed) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
-      const matchEuro  = ecLow && a.glass_eurocode && a.glass_eurocode.trim().toLowerCase() === ecLow;
+      const matchEuro  = ecNorm && a.glass_eurocode && normEc(a.glass_eurocode) === ecNorm;
       let extraEuro = '';
-      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || '').toLowerCase(); } catch(e) { extraEuro = (a.extra || '').toLowerCase(); } }
-      const matchEuroNotes = ecLow && ((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).toLowerCase().includes(ecLow);
+      if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || ''); } catch(e) { extraEuro = (a.extra || ''); } }
+      const matchEuroNotes = ecNorm && normEc((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).includes(ecNorm);
       return matchOrder || matchEuro || matchEuroNotes;
     });
 

--- a/index.html
+++ b/index.html
@@ -1413,7 +1413,7 @@
           <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
         </div>
         <div style="display:flex;gap:16px;font-size:12px;color:#64748b;flex-wrap:wrap;">
-          <span>🏪 ${a.locality || window.portalConfig?.name || '—'}</span>
+          <span>🏪 ${a.portal_name || a.locality || window.portalConfig?.name || '—'}</span>
           <span>🔧 ${a.service || '—'}</span>
           ${a.date ? `<span>📅 ${fmtDate(a.date)}</span>` : '<span style="color:#f59e0b;">Sem data</span>'}
         </div>

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
         <button id="btnRelatorioDesk" class="nav-button" style="color:#fbbf24;" title="Relatório semanal">📊 Relatório</button>
         <button id="btnTimelineDesk" class="nav-button" style="background:#7c3aed;color:#fbbf24;" title="Timeline do dia">⏱️ Timeline</button>
         <button id="btnVidrosRetirados" class="nav-button" style="background:#f59e0b;color:#fff;font-weight:700;" title="Ver vidros retirados">🪟 Vidros Retirados</button>
-        <button id="btnHistorico" class="nav-button" style="background:#0f172a;color:#94a3b8;border:1px solid rgba(255,255,255,0.15);font-weight:700;" title="Histórico de serviços" onclick="window.historicoModal?.open()">🕘 Histórico</button>
+
         <button id="btnRececaoVidros" class="nav-button" style="display:none;background:#0f172a;color:#94a3b8;border:1px solid rgba(255,255,255,0.15);font-weight:700;position:relative;" title="Receção de Vidros" onclick="window.glassReception?.openCoordPanel()">📦 Receção Vidros<span id="rececaoBadge" style="display:none;position:absolute;top:-4px;right:-4px;width:10px;height:10px;background:#ef4444;border-radius:50%;animation:recPulse 1.2s infinite;"></span></button>
         <button id="printPage" class="nav-button" style="color:#fbbf24;">🖨 Imprimir</button>
         <!-- Guia AT upload (coordinator/admin only, desktop) -->

--- a/index.html
+++ b/index.html
@@ -685,6 +685,7 @@
   <script src="excel-import-ui.js?v=2026-04-09"></script>
   <script src="glass-alert.js?v=2026-04-09"></script>
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
+  <script src="incomplete-services-alert.js?v=2026-06-01"></script>
   <script src="agenda-bot.js?v=2026-04-09"></script>
   <script src="pesados-coord.js?v=2026-04-17"></script>
   <script src="rota-do-dia-map.js?v=2026-05-14o"></script>

--- a/index.html
+++ b/index.html
@@ -1459,12 +1459,44 @@
   // ── COORDINATOR PANEL ────────────────────────────────────────────────────
   async function openCoordPanel() {
     document.getElementById('grCoordModal').style.display = 'flex';
-    document.getElementById('grCoordBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A carregar…</p>`;
-    await _loadCoordList();
+    document.getElementById('grCoordBody').innerHTML = `
+      <div style="display:flex;gap:0;border-bottom:2px solid #e2e8f0;margin-bottom:0;">
+        <button id="grTabPending" onclick="window.glassReception._switchTab('pending')"
+                style="padding:10px 18px;border:none;border-bottom:3px solid #2563eb;margin-bottom:-2px;font-weight:700;cursor:pointer;color:#2563eb;background:transparent;font-size:13px;">
+          📋 Pendentes
+        </button>
+        <button id="grTabHistory" onclick="window.glassReception._switchTab('history')"
+                style="padding:10px 18px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:13px;">
+          📊 Histórico
+        </button>
+      </div>
+      <div id="grTabContent" style="padding-top:12px;"></div>
+    `;
+    await _switchTab('pending');
   }
 
   function closeCoord() {
     document.getElementById('grCoordModal').style.display = 'none';
+  }
+
+  async function _switchTab(tab) {
+    const tabs = { pending: 'grTabPending', history: 'grTabHistory' };
+    Object.entries(tabs).forEach(([key, id]) => {
+      const btn = document.getElementById(id);
+      if (!btn) return;
+      const active = key === tab;
+      btn.style.borderBottomColor = active ? '#2563eb' : 'transparent';
+      btn.style.color = active ? '#2563eb' : '#94a3b8';
+      btn.style.fontWeight = active ? '700' : '600';
+    });
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+    if (tab === 'pending') {
+      content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar…</p>`;
+      await _loadCoordList();
+    } else {
+      await _openHistory();
+    }
   }
 
   async function _loadCoordList() {
@@ -1474,7 +1506,8 @@
       if (!json.success) throw new Error(json.error);
       _renderCoordList(json.data);
     } catch (e) {
-      document.getElementById('grCoordBody').innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+      const el = document.getElementById('grTabContent');
+      if (el) el.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
     }
   }
 
@@ -1482,8 +1515,11 @@
     const badge = document.getElementById('grCoordBadge');
     if (badge) { badge.textContent = items.length + ' pendente' + (items.length !== 1 ? 's' : ''); badge.style.display = items.length ? '' : 'none'; }
 
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+
     if (items.length === 0) {
-      document.getElementById('grCoordBody').innerHTML = `
+      content.innerHTML = `
         <div style="text-align:center;padding:40px;color:#94a3b8;">
           <div style="font-size:40px;margin-bottom:12px;">✅</div>
           <p style="font-size:14px;font-weight:600;">Sem vidros pendentes de receção.</p>
@@ -1491,7 +1527,7 @@
       return;
     }
 
-    document.getElementById('grCoordBody').innerHTML = items.map(r => `
+    content.innerHTML = items.map(r => `
       <div id="grRow${r.id}" style="border:1px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;background:#fff;">
         <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
           <span style="font-family:monospace;font-weight:800;font-size:14px;background:#0f172a;color:#fff;padding:3px 10px;border-radius:6px;">${(r.apt_plate || r.order_ref || '—').toUpperCase()}</span>
@@ -1507,6 +1543,192 @@
         <button onclick="window.glassReception._markReceived(${r.id})" style="background:#16a34a;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">✅ Rececionado</button>
       </div>
     `).join('');
+  }
+
+  // ── HISTORY ───────────────────────────────────────────────────────────────
+  async function _openHistory() {
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+    content.innerHTML = `<p style="text-align:center;padding:16px;color:#64748b;">A carregar…</p>`;
+
+    let portals = [];
+    try {
+      const res = await fetch(API + '/glass-reception?list_portals=true', { headers: authHeaders() });
+      const json = await res.json();
+      if (json.success) portals = json.data;
+    } catch(_) {}
+
+    const now = new Date();
+    const fromDef = now.toISOString().slice(0, 7) + '-01';
+    const today   = now.toISOString().slice(0, 10);
+
+    const portalOpts = `<option value="">Todos os portais</option>` +
+      portals.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+
+    content.innerHTML = `
+      <div style="background:#f8fafc;border-radius:10px;padding:14px;margin-bottom:12px;">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px;">
+          <div>
+            <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">PORTAL</label>
+            <select id="grHPortal" style="width:100%;border:1.5px solid #e2e8f0;border-radius:7px;padding:8px;font-size:13px;background:#fff;">
+              ${portalOpts}
+            </select>
+          </div>
+          <div>
+            <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">BUSCA</label>
+            <input id="grHSearch" type="text" placeholder="Matrícula, eurocode ou enc." onkeydown="if(event.key==='Enter')window.glassReception._loadHistory()"
+                   style="width:100%;border:1.5px solid #e2e8f0;border-radius:7px;padding:8px;font-size:13px;box-sizing:border-box;">
+          </div>
+        </div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:10px;">
+          <div>
+            <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">DE</label>
+            <input id="grHFrom" type="date" value="${fromDef}" style="width:100%;border:1.5px solid #e2e8f0;border-radius:7px;padding:8px;font-size:13px;box-sizing:border-box;">
+          </div>
+          <div>
+            <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">ATÉ</label>
+            <input id="grHTo" type="date" value="${today}" style="width:100%;border:1.5px solid #e2e8f0;border-radius:7px;padding:8px;font-size:13px;box-sizing:border-box;">
+          </div>
+        </div>
+        <button onclick="window.glassReception._loadHistory()" style="background:#0f172a;color:#fff;font-weight:700;font-size:13px;padding:10px;border-radius:8px;border:none;cursor:pointer;width:100%;">🔍 Filtrar</button>
+      </div>
+      <div id="grHResults"><p style="text-align:center;color:#94a3b8;font-size:13px;padding:12px;">Aplica os filtros para ver o histórico.</p></div>
+    `;
+  }
+
+  async function _loadHistory() {
+    const content = document.getElementById('grHResults');
+    if (!content) return;
+    content.innerHTML = `<p style="text-align:center;padding:16px;color:#64748b;">A carregar…</p>`;
+
+    const portalId = document.getElementById('grHPortal')?.value || '';
+    const search   = (document.getElementById('grHSearch')?.value || '').trim();
+    const fromDate = document.getElementById('grHFrom')?.value || '';
+    const toDate   = document.getElementById('grHTo')?.value || '';
+
+    const qp = new URLSearchParams({ history: 'true' });
+    if (portalId) qp.set('portal_id', portalId);
+    if (search)   qp.set('search', search);
+    if (fromDate) qp.set('from_date', fromDate);
+    if (toDate)   qp.set('to_date', toDate);
+
+    try {
+      const res = await fetch(API + '/glass-reception?' + qp.toString(), { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      _renderHistoryTable(json.data);
+    } catch (e) {
+      if (content) content.innerHTML = `<p style="color:#dc2626;text-align:center;padding:12px;">Erro: ${e.message}</p>`;
+    }
+  }
+
+  function _statusLabel(s) {
+    if (s === 'received')  return '<span style="color:#16a34a;font-weight:700;">✅ Recebido</span>';
+    if (s === 'confirmed') return '<span style="color:#f59e0b;font-weight:700;">⏳ Confirmado</span>';
+    return '<span style="color:#94a3b8;">Pendente</span>';
+  }
+
+  function _renderHistoryTable(rows) {
+    const content = document.getElementById('grHResults');
+    if (!content) return;
+    window._grHistoryData = rows;
+
+    if (rows.length === 0) {
+      content.innerHTML = `<p style="text-align:center;color:#94a3b8;padding:20px;font-size:13px;">Sem resultados para os filtros seleccionados.</p>`;
+      return;
+    }
+
+    content.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+        <span style="font-size:12px;color:#64748b;">${rows.length} registo${rows.length !== 1 ? 's' : ''}</span>
+        <div style="display:flex;gap:8px;">
+          <button onclick="window.glassReception._exportCSV()" style="background:#16a34a;color:#fff;font-size:12px;font-weight:700;padding:7px 14px;border-radius:7px;border:none;cursor:pointer;">📥 Excel</button>
+          <button onclick="window.glassReception._printHistory()" style="background:#2563eb;color:#fff;font-size:12px;font-weight:700;padding:7px 14px;border-radius:7px;border:none;cursor:pointer;">🖨️ Imprimir</button>
+        </div>
+      </div>
+      <div style="overflow-x:auto;">
+        <table style="width:100%;border-collapse:collapse;font-size:12px;min-width:560px;">
+          <thead>
+            <tr style="background:#0f172a;color:#fff;">
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Data</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Matrícula</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Carro</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Loja</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Eurocode</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Encomenda</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Técnico</th>
+              <th style="padding:8px 10px;text-align:left;white-space:nowrap;">Estado</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map((r, i) => `
+              <tr style="background:${i % 2 === 0 ? '#fff' : '#f8fafc'};">
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${fmtDate(r.created_at)}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;font-weight:700;">${(r.apt_plate || '—').toUpperCase()}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${r.apt_car || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${r.portal_label || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${r.eurocode || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${r.order_ref || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${r.technician_name || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${_statusLabel(r.status)}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function _exportCSV() {
+    const data = window._grHistoryData || [];
+    if (!data.length) return;
+    const hdr = ['Data','Matrícula','Carro','Loja','Eurocode','Encomenda','Técnico','Estado'];
+    const statusTxt = s => s === 'received' ? 'Recebido' : s === 'confirmed' ? 'Confirmado' : 'Pendente';
+    const rows = data.map(r => [
+      fmtDate(r.created_at), (r.apt_plate || '').toUpperCase(),
+      r.apt_car || '', r.portal_label || '',
+      r.eurocode || '', r.order_ref || '',
+      r.technician_name || '', statusTxt(r.status)
+    ]);
+    const csv = [hdr, ...rows].map(row => row.map(v => `"${String(v).replace(/"/g,'""')}"`).join(',')).join('\r\n');
+    const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `rececao-vidros-${new Date().toISOString().slice(0,10)}.csv`;
+    a.click(); URL.revokeObjectURL(url);
+  }
+
+  function _printHistory() {
+    const data = window._grHistoryData || [];
+    const statusTxt = s => s === 'received' ? 'Recebido' : s === 'confirmed' ? 'Confirmado' : 'Pendente';
+    const w = window.open('', '_blank');
+    w.document.write(`<!DOCTYPE html><html><head><title>Histórico Receção de Vidros</title>
+      <style>
+        body{font-family:Arial,sans-serif;font-size:11px;margin:20px;}
+        h2{font-size:16px;margin-bottom:4px;}
+        p.meta{color:#666;font-size:11px;margin-bottom:12px;}
+        table{border-collapse:collapse;width:100%;}
+        th,td{border:1px solid #ccc;padding:4px 8px;text-align:left;}
+        th{background:#0f172a;color:#fff;}
+        tr:nth-child(even) td{background:#f8fafc;}
+        @media print{body{margin:8px;}}
+      </style>
+    </head><body>
+      <h2>Histórico — Receção de Vidros</h2>
+      <p class="meta">Impresso em ${new Date().toLocaleDateString('pt-PT')} — ${data.length} registo${data.length !== 1 ? 's' : ''}</p>
+      <table>
+        <thead><tr><th>Data</th><th>Matrícula</th><th>Carro</th><th>Loja</th><th>Eurocode</th><th>Encomenda</th><th>Técnico</th><th>Estado</th></tr></thead>
+        <tbody>${data.map(r => `<tr>
+          <td>${fmtDate(r.created_at)}</td>
+          <td style="font-family:monospace;font-weight:bold;">${(r.apt_plate||'—').toUpperCase()}</td>
+          <td>${r.apt_car||'—'}</td><td>${r.portal_label||'—'}</td>
+          <td style="font-family:monospace;">${r.eurocode||'—'}</td>
+          <td>${r.order_ref||'—'}</td><td>${r.technician_name||'—'}</td>
+          <td>${statusTxt(r.status)}</td>
+        </tr>`).join('')}</tbody>
+      </table>
+    </body></html>`);
+    w.document.close(); w.print();
   }
 
   async function _markReceived(id) {
@@ -1582,7 +1804,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _onPhoto, _manualSearch, _step1, _doSearch, _confirmReception, _markReceived };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _onPhoto, _manualSearch, _step1, _doSearch, _confirmReception, _markReceived, _switchTab, _loadHistory, _exportCSV, _printHistory };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -98,7 +98,12 @@ exports.handler = async (event) => {
         let idx = 2;
 
         if (params.search_eurocode) {
-          conditions.push(`(LOWER(glass_eurocode) = LOWER($${idx}) OR LOWER(notes) LIKE '%' || LOWER($${idx}) || '%' OR LOWER(extra::text) LIKE '%' || LOWER($${idx}) || '%')`);
+          // Normalize I↔1 and O↔0 to handle OCR character confusion
+          conditions.push(`(
+            REPLACE(REPLACE(LOWER(glass_eurocode), 'i', '1'), 'o', '0') = REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0')
+            OR REPLACE(REPLACE(LOWER(notes), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+            OR REPLACE(REPLACE(LOWER(extra::text), 'i', '1'), 'o', '0') LIKE '%' || REPLACE(REPLACE(LOWER($${idx}), 'i', '1'), 'o', '0') || '%'
+          )`);
           vals.push(params.search_eurocode.trim());
           idx++;
         }

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -114,19 +114,22 @@ exports.handler = async (event) => {
         }
 
         const searchQ = `
-          SELECT id, date, period, plate, car, service, locality, status,
-                 notes, address, extra, phone, km, sortIndex, "glassOrdered",
-                 vehicle_type, travel_time, auto_imported, executed, confirmed,
-                 calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
-                 return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
-                 custom_service_time, foreign_plate, extra_services, n_obra,
-                 order_ref, glass_eurocode, created_at, updated_at, portal_id
-          FROM appointments
-          WHERE portal_id = ANY($1)
-            AND executed IS NOT TRUE
-            AND glass_removed IS NOT TRUE
+          SELECT a.id, a.date, a.period, a.plate, a.car, a.service, a.locality, a.status,
+                 a.notes, a.address, a.extra, a.phone, a.km, a.sortIndex, a."glassOrdered",
+                 a.vehicle_type, a.travel_time, a.auto_imported, a.executed, a.confirmed,
+                 a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
+                 a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
+                 a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
+                 a.order_ref, a.glass_eurocode, a.created_at, a.updated_at, a.portal_id,
+                 p.name AS portal_name
+          FROM appointments a
+          LEFT JOIN portals p ON p.id = a.portal_id
+          WHERE a.portal_id = ANY($1)
+            AND a.executed IS NOT TRUE
+            AND a.glass_removed IS NOT TRUE
+            AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '5 days')
             AND (${conditions.join(' OR ')})
-          ORDER BY date ASC NULLS LAST, created_at ASC
+          ORDER BY a.date ASC NULLS LAST, a.created_at ASC
           LIMIT 50
         `;
         const { rows } = await pool.query(searchQ, vals);

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -136,6 +136,21 @@ exports.handler = async (event) => {
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
       }
 
+      // Pending conclusion: appointments from previous days without a final service status
+      if (params.pending_conclusion === 'true') {
+        const { rows } = await pool.query(`
+          SELECT id, date, period, plate, car, service, locality
+          FROM appointments
+          WHERE portal_id = $1
+            AND date < CURRENT_DATE
+            AND date >= CURRENT_DATE - INTERVAL '7 days'
+            AND executed IS NULL
+            AND glass_removed IS NOT TRUE
+          ORDER BY date ASC
+        `, [portalId]);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
+      }
+
       const q = `
         SELECT id, date, period, plate, car, service, locality, status,
                notes, address, extra, phone, km, sortIndex, "glassOrdered",

--- a/netlify/functions/glass-label-ocr.js
+++ b/netlify/functions/glass-label-ocr.js
@@ -33,12 +33,19 @@ Extrai APENAS estes dois campos:
 
 1. Número de encomenda — procura nos campos: "PEDIDO", "N.º Enc", "Order", "Enc.", "COD AT" ou referência numérica/alfanumérica do pedido. Exemplo: "65178"
 
-2. Eurocode do vidro — código com formato EXATO: 4 dígitos seguidos IMEDIATAMENTE de 3 ou mais letras maiúsculas (ex: 6577AGACMVZ, 3739ABCDE, 5385AGNVZPBL).
+2. Eurocode do vidro — código com formato EXATO: 4 dígitos seguidos IMEDIATAMENTE de 3 ou mais caracteres alfanuméricos maiúsculos (ex: 6577AGACMVZ, 3739ABCDE, 7274AGAM1R).
    Procura em campos como PICK_LABELS, OBS, Observações.
    REGRA CRÍTICA para PICK_LABELS com formato "NNNN/DDDDLLLLL" (ex: "1605/6577AGACMVZ"):
    - O número ANTES da barra "/" (ex: 1605) é uma sequência — NÃO é o eurocode
    - O eurocode é o código COMPLETO APÓS a barra "/" (ex: 6577AGACMVZ)
    - NUNCA combines dígitos de antes da barra com letras de depois da barra
+
+   ⚠️ ATENÇÃO CRÍTICA — confusão 1 vs I vs O vs 0:
+   Nesta fonte de impressora térmica, o DÍGITO '1' (um) e a LETRA 'I' maiúscula são visualmente muito semelhantes. O mesmo para o DÍGITO '0' (zero) e a LETRA 'O'.
+   Em eurocodes, os sistemas de vidro automóvel NÃO utilizam as letras 'I' nem 'O' no código para evitar exactamente esta confusão. Por isso:
+   - Se vires um caracter que parece 'I' dentro do eurocode → é o DÍGITO '1'
+   - Se vires um caracter que parece 'O' dentro do eurocode → é o DÍGITO '0'
+   Exemplo: "7274AGAM1R" tem um dígito '1' a seguir a 'AGAM', NÃO a letra 'I'.
 
 Responde EXCLUSIVAMENTE em JSON válido, sem texto adicional:
 {"order_ref": "...", "eurocode": "...", "raw_text": "..."}
@@ -77,11 +84,20 @@ Se não encontrares algum campo coloca null.`
             const rawUpper = String(result.raw_text).toUpperCase();
             const candidates = rawUpper.split(/[\s\/,;|:]+/)
               .map(t => t.replace(/^[^A-Z0-9]+/, '').replace(/[^A-Z0-9]+$/, ''))
-              .filter(t => /^\d{4}[A-Z]{3,}/.test(t));
+              .filter(t => /^\d{4}[A-Z0-9]{3,}/.test(t));
             if (candidates.length > 0) {
               result.eurocode = candidates.sort((a, b) => b.length - a.length)[0];
             }
           }
+
+          // Normalize I→1 and O→0 in the eurocode: auto-glass eurocode systems
+          // never use the letters I or O precisely to avoid confusion with digits.
+          if (result.eurocode) {
+            const ec = String(result.eurocode).toUpperCase();
+            // Keep first 4 chars as-is (already digits from regex), normalize rest
+            result.eurocode = ec.slice(0, 4) + ec.slice(4).replace(/I/g, '1').replace(/O/g, '0');
+          }
+
           resolve(result);
         } catch (e) {
           reject(new Error('Erro ao processar resposta da IA: ' + e.message));

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -49,6 +49,62 @@ exports.handler = async (event) => {
     if (event.httpMethod === 'GET') {
       const p = event.queryStringParameters || {};
 
+      // ── List portals accessible to this user (for history dropdown) ──────────
+      if (p.list_portals === 'true') {
+        let pq, pVals;
+        if (user.role === 'admin') {
+          pq = `SELECT id, name FROM portals ORDER BY name`;
+          pVals = [];
+        } else {
+          const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+          pq = `SELECT id, name FROM portals WHERE id = ANY($1) ORDER BY name`;
+          pVals = [ids];
+        }
+        const { rows: pRows } = await client.query(pq, pVals);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: pRows }) };
+      }
+
+      // ── History query ─────────────────────────────────────────────────────────
+      if (p.history === 'true') {
+        let hq = `
+          SELECT gr.*,
+                 a.plate    AS apt_plate,
+                 a.car      AS apt_car,
+                 a.locality AS apt_locality,
+                 a.service  AS apt_service,
+                 a.date     AS apt_date,
+                 po.name    AS portal_label
+          FROM glass_receptions gr
+          LEFT JOIN appointments a  ON a.id = gr.appointment_id
+          LEFT JOIN portals po      ON po.id = gr.portal_id
+          WHERE 1=1
+        `;
+        const hVals = [];
+        let hIdx = 1;
+
+        // Portal access control
+        if (user.role === 'user') {
+          hq += ` AND gr.portal_id = $${hIdx++}`; hVals.push(user.portalId);
+        } else if (user.role !== 'admin') {
+          const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+          if (ids.length) { hq += ` AND gr.portal_id = ANY($${hIdx++})`; hVals.push(ids); }
+        }
+
+        if (p.portal_id) { hq += ` AND gr.portal_id = $${hIdx++}`; hVals.push(parseInt(p.portal_id)); }
+        if (p.from_date) { hq += ` AND gr.created_at >= $${hIdx++}`; hVals.push(p.from_date); }
+        if (p.to_date)   { hq += ` AND gr.created_at < ($${hIdx++}::date + INTERVAL '1 day')`; hVals.push(p.to_date); }
+        if (p.search) {
+          const s = '%' + p.search.trim().toLowerCase() + '%';
+          hq += ` AND (LOWER(gr.eurocode) LIKE $${hIdx} OR LOWER(gr.order_ref) LIKE $${hIdx} OR LOWER(a.plate) LIKE $${hIdx})`;
+          hVals.push(s); hIdx++;
+        }
+
+        hq += ` ORDER BY gr.created_at DESC LIMIT 1000`;
+        const { rows: hRows } = await client.query(hq, hVals);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: hRows }) };
+      }
+
+      // ── Default: pending list ─────────────────────────────────────────────────
       let q = `
         SELECT gr.*,
                a.plate    AS apt_plate,

--- a/script-tail.js
+++ b/script-tail.js
@@ -1583,11 +1583,24 @@ document.addEventListener('DOMContentLoaded', function() {
             const localityField = document.getElementById('appointmentLocality');
             const currentLocality = localityField?.value || '';
             const known = window._localityList || [];
-            const match = known.find(l => 
-              l.toLowerCase() === detectedLocality.toLowerCase() ||
-              detectedLocality.toLowerCase().includes(l.toLowerCase()) ||
-              l.toLowerCase().includes(detectedLocality.toLowerCase())
-            );
+            const dLow = detectedLocality.toLowerCase().trim();
+
+            // Priority: superset match (e.g. "Vila Nova de Famalicão" when Google returns "Famalicão")
+            // > exact match > subset match
+            const supersetMatches = known.filter(l => l.toLowerCase().includes(dLow) && l.toLowerCase() !== dLow);
+            const exactMatches    = known.filter(l => l.toLowerCase() === dLow);
+            const subsetMatches   = known.filter(l => dLow.includes(l.toLowerCase()) && l.toLowerCase() !== dLow);
+
+            let match = null;
+            if (supersetMatches.length > 0) {
+              // Shortest superset = most direct extension (e.g. "Vila Nova de Famalicão" over "Famalicão, Vila Nova de Famalicão")
+              match = supersetMatches.sort((a, b) => a.length - b.length)[0];
+            } else if (exactMatches.length > 0) {
+              match = exactMatches[0];
+            } else if (subsetMatches.length > 0) {
+              match = subsetMatches.sort((a, b) => b.length - a.length)[0];
+            }
+
             const toSet = match || detectedLocality;
 
             if (currentLocality && currentLocality !== toSet) {

--- a/script.js
+++ b/script.js
@@ -2504,13 +2504,13 @@ function buildDesktopCard(a){
   if (_extraDisplay) {
     try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
   }
+  const userRole = window.authClient?.getUser()?.role;
+  const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
   const _orderRefStr = (userRole === 'admin' || userRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
   const sub = loja
     ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ')
     : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ');
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
-  const userRole = window.authClient?.getUser()?.role;
-  const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
   const isPreAgendado = a.confirmed === false;
   const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
   const locWarning = needsLoc ? `


### PR DESCRIPTION
## Summary

- New backend param `?pending_conclusion=true` on the appointments API returns appointments from the last 7 days that have no final service status (`executed IS NULL`, `glass_removed IS NOT TRUE`, `date < today`)
- New `incomplete-services-alert.js` — a blocking popup for technicians (role=`user`) that appears at/after 09:00 each morning, listing all plates/dates with missing statuses
- Popup has two actions: **Ver serviços** (navigates the calendar to the first unresolved date) and **Já tratei** (dismisses until tomorrow via LocalStorage)
- Mirrors the existing `glass-alert-urgent.js` UX pattern (amber theme instead of red)

## Test plan

- [ ] Log in as a technician (`role=user`) with appointments from yesterday/before that have no `executed` value
- [ ] Verify popup appears at/after 09:00 listing the correct plates and dates
- [ ] Click "Ver serviços" → calendar navigates to the week of the first unresolved appointment
- [ ] Click "Já tratei" → popup dismissed, does not reappear until next day
- [ ] Log in as `coordenador` or `admin` → popup should NOT appear
- [ ] Verify the `?pending_conclusion=true` API call returns only appointments with `date < today` and `executed IS NULL`

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_