### PR TITLE
fix: incomplete services alert not showing for some technician roles

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1512,7 +1512,12 @@ async function showKpiDetail(type) {
     }
 
     const isNR = type === 'nao_realizados';
-    const fmtD = iso => iso ? new Date(iso + 'T12:00:00').toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', year: '2-digit' }) : '—';
+    const fmtD = iso => {
+      if (!iso) return '—';
+      const s = String(iso).slice(0, 10); // extract YYYY-MM-DD regardless of backend format
+      const d = new Date(s + 'T12:00:00');
+      return isNaN(d) ? '—' : d.toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', year: '2-digit' });
+    };
 
     const thStyle = 'padding:9px 12px;text-align:left;font-size:12px;font-weight:700;color:#6b7280;text-transform:uppercase;letter-spacing:.04em;border-bottom:2px solid #e2e8f0;white-space:nowrap;';
     const tdStyle = 'padding:9px 12px;font-size:13px;border-bottom:1px solid #f1f5f9;vertical-align:middle;';

--- a/incomplete-services-alert.js
+++ b/incomplete-services-alert.js
@@ -178,9 +178,15 @@
     };
   }
 
+  // Management roles that should NOT see this alert
+  const SKIP_ROLES = new Set(['admin', 'coordenador', 'coordinator', 'comercial', 'pesados_coord']);
+
   async function check() {
     const role = window.authClient?.getUser?.()?.role;
-    if (role !== 'user') return;
+    // Skip if auth not ready yet — will retry on next interval
+    if (!role) return;
+    // Skip management / multi-portal roles
+    if (SKIP_ROLES.has(role)) return;
     if (!isPastShowTime()) return;
     if (isDismissed()) return;
 
@@ -189,7 +195,10 @@
   }
 
   function init() {
-    setTimeout(check, 3500);
+    // Try at 4s, 8s, 15s to handle slow auth init, then every 5 minutes
+    setTimeout(check, 4000);
+    setTimeout(check, 8000);
+    setTimeout(check, 15000);
     setInterval(check, 5 * 60 * 1000);
   }
 


### PR DESCRIPTION
## Problem
The alert was only checking `role === 'user'` which missed portals with custom technician roles (e.g. `pesados_coord` variants). Also, a single 3.5s attempt could race against slow auth initialisation.

## Fix
- Replace strict `role === 'user'` with a **blocklist** of management roles (`admin`, `coordenador`, `coordinator`, `comercial`, `pesados_coord`) — any role not in this list gets the alert
- Add retry attempts at **4s, 8s and 15s** after page load (in addition to the 5-minute interval) so a slow login doesn't cause the first check to silently bail out

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_