### PR TITLE
fix: limit pending services alert to last 7 days + fix Invalid Date

### DIFF
--- a/incomplete-services-alert.js
+++ b/incomplete-services-alert.js
@@ -19,8 +19,9 @@
 
   function fmtDate(iso) {
     if (!iso) return '';
-    const d = new Date(iso + 'T00:00:00');
-    return d.toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', weekday: 'short' });
+    const s = String(iso).slice(0, 10);
+    const d = new Date(s + 'T12:00:00');
+    return isNaN(d) ? s : d.toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', weekday: 'short' });
   }
 
   async function fetchPending() {
@@ -37,7 +38,7 @@
         { headers: { Authorization: 'Bearer ' + token } }
       );
       const data = await resp.json();
-      console.log('[IncServ] API resposta: success=' + data.success + ' count=' + (data.data?.length ?? 'N/A'), 'diag:', JSON.stringify(data.diag));
+      console.log('[IncServ] API resposta: success=' + data.success + ' count=' + (data.data?.length ?? 'N/A'));
       if (!data.success || !Array.isArray(data.data)) return [];
       return data.data;
     } catch (e) {

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -142,8 +142,8 @@ exports.handler = async (event) => {
           SELECT id, date, period, plate, car, service, locality
           FROM appointments
           WHERE portal_id = $1
-            AND date <= CURRENT_DATE
-            AND date >= CURRENT_DATE - INTERVAL '30 days'
+            AND date < CURRENT_DATE
+            AND date >= CURRENT_DATE - INTERVAL '7 days'
             AND (
               executed IS NULL
               OR (executed = false AND (not_done_reason IS NULL OR not_done_reason = ''))
@@ -152,18 +152,7 @@ exports.handler = async (event) => {
           ORDER BY date ASC
         `, [portalId]);
 
-        // diagnostic: also count total recent appointments regardless of status
-        const { rows: diag } = await pool.query(`
-          SELECT COUNT(*) AS total,
-                 COUNT(*) FILTER (WHERE executed IS NULL) AS null_exec,
-                 COUNT(*) FILTER (WHERE executed = true) AS done,
-                 COUNT(*) FILTER (WHERE executed = false) AS not_done,
-                 MIN(date) AS oldest, MAX(date) AS newest
-          FROM appointments
-          WHERE portal_id = $1 AND date >= CURRENT_DATE - INTERVAL '30 days'
-        `, [portalId]);
-
-        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows, diag: diag[0] }) };
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
       }
 
       const q = `


### PR DESCRIPTION
- Reduces lookback from 30 → 7 days (covers the last 5 working days)
- Fixes `Invalid Date` in the popup list by slicing the ISO timestamp to `YYYY-MM-DD` before parsing
- Removes diagnostic diag counters from the API response

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_