### PR TITLE
feat: track not_done_at and show correct date on Não Realizado badge

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -44,6 +44,10 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS glass_eurocode TEXT`);
   } catch(migErr) { console.warn('Migration order_ref/eurocode warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS not_done_at TIMESTAMPTZ`);
+  } catch(migErr) { console.warn('Migration not_done_at warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -120,7 +124,7 @@ exports.handler = async (event) => {
                  a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
                  a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
                  a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
-                 a.order_ref, a.glass_eurocode, a.created_at, a.updated_at, a.portal_id,
+                 a.order_ref, a.glass_eurocode, a.created_at, a.updated_at, a.not_done_at, a.portal_id,
                  p.name AS portal_name
           FROM appointments a
           LEFT JOIN portals p ON p.id = a.portal_id
@@ -162,7 +166,7 @@ exports.handler = async (event) => {
                calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
                custom_service_time, foreign_plate, extra_services, n_obra,
-               order_ref, glass_eurocode, created_at, updated_at
+               order_ref, glass_eurocode, created_at, updated_at, not_done_at
         FROM appointments
         WHERE portal_id = $1
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
@@ -243,7 +247,7 @@ exports.handler = async (event) => {
       const isAdmin = user.role === 'admin';
       const isCoord = user.role === 'coordinator' || user.role === 'coordenador';
       const checkResult = await pool.query(
-        'SELECT id, portal_id, executed, not_done_reason, glass_removed, glass_removed_date FROM appointments WHERE id = $1',
+        'SELECT id, portal_id, executed, not_done_reason, not_done_at, glass_removed, glass_removed_date FROM appointments WHERE id = $1',
         [id]
       );
       if (checkResult.rows.length === 0) {
@@ -262,6 +266,10 @@ exports.handler = async (event) => {
       const effectivePortalId = existing.portal_id;
       const executedVal = data.executed !== undefined ? data.executed : existing.executed;
       const notDoneReasonVal = data.not_done_reason !== undefined ? data.not_done_reason : existing.not_done_reason;
+      // Set not_done_at when reason is first set; clear it when reason is cleared; otherwise keep existing
+      const notDoneAtVal = notDoneReasonVal
+        ? (existing.not_done_reason ? existing.not_done_at : new Date().toISOString())
+        : null;
 
       const q = `
         UPDATE appointments SET
@@ -273,7 +281,7 @@ exports.handler = async (event) => {
           executed = $18, confirmed = $19, calibration = $20,
           first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
-          glass_removed_date = $31, n_obra = $32, updated_at = $33
+          glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36
         WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
@@ -303,7 +311,7 @@ exports.handler = async (event) => {
         JSON.stringify(data.extra_services !== undefined ? (data.extra_services || []) : (existing.extra_services || [])),
         data.glass_removed_date !== undefined ? (data.glass_removed_date || null) : (existing.glass_removed_date || null),
         data.n_obra !== undefined ? (data.n_obra || null) : null,
-        new Date().toISOString(), id, effectivePortalId
+        new Date().toISOString(), id, effectivePortalId, notDoneAtVal
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };

--- a/script-tail.js
+++ b/script-tail.js
@@ -83,8 +83,10 @@ const telBtn = phone ? `
 
   const motivoBadge = isNaoRealizado && a.not_done_reason ? (() => {
     const _nd = a.not_done_reason;
+    const _ndAt = a.not_done_at || a.notDoneAt;
+    const _ndDate = _ndAt ? (() => { const _s = String(_ndAt).slice(0,10); const _d = new Date(_s + 'T12:00:00'); return isNaN(_d) ? _s : _d.toLocaleDateString('pt-PT', {day:'2-digit',month:'2-digit',year:'numeric'}); })() : null;
     return `<div style="margin:6px 8px 0;padding:7px 12px;background:rgba(220,38,38,0.15);border-left:3px solid #dc2626;border-radius:6px;font-size:12px;font-weight:700;color:#dc2626;">
-      <div style="display:flex;align-items:center;gap:6px;">❌ <span style="color:inherit;">${_nd}</span></div>
+      <div style="display:flex;align-items:center;gap:6px;">❌ <span style="color:inherit;">${_nd}</span></div>${_ndDate ? `<div style="font-size:11px;font-weight:400;color:#64748b;margin-top:3px;">📅 ${_ndDate}</div>` : ''}
     </div>`;
   })() : '';
 

--- a/script.js
+++ b/script.js
@@ -2544,8 +2544,10 @@ function buildDesktopCard(a){
   const canExecDesk = isPastOrToday || _roleDesk === 'admin' || _roleDesk === 'coordenador';
   const motivoDesktop = (a.executed === false && a.not_done_reason) ? (() => {
     const _nd = a.not_done_reason;
+    const _ndAt = a.not_done_at || a.notDoneAt;
+    const _ndDate = _ndAt ? (() => { const _s = String(_ndAt).slice(0,10); const _d = new Date(_s + 'T12:00:00'); return isNaN(_d) ? _s : _d.toLocaleDateString('pt-PT', {day:'2-digit',month:'2-digit',year:'numeric'}); })() : null;
     return `<div style="margin:4px 0 0;padding:5px 10px;background:rgba(220,38,38,0.12);border-left:3px solid #dc2626;border-radius:5px;font-size:11px;font-weight:700;color:#dc2626;">
-      ❌ ${_nd}
+      ❌ ${_nd}${_ndDate ? `<span style="font-weight:400;color:#64748b;margin-left:8px;">📅 ${_ndDate}</span>` : ''}
     </div>`;
   })() : '';
 


### PR DESCRIPTION
## Summary
- Adds `not_done_at` (TIMESTAMPTZ) column to appointments table via auto-migration
- Set when `not_done_reason` is first applied; preserved if reason changes; cleared when reason is removed
- Frontend (desktop + mobile cards) now shows the actual date the service was marked as Não Realizado — not the appointment's current scheduled date
- Existing appointments without `not_done_at` will show no date until next time the status is set

## Test plan
- [ ] Mark a service as Não Realizado → date shown should be today
- [ ] Reschedule that appointment to a future date → date next to reason should still show when it was marked, not the new scheduled date
- [ ] Clear the Não Realizado status → date disappears
- [ ] Re-mark as Não Realizado → date resets to today

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_