### PR TITLE
fix: extend glass reception search window to 60 days

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -131,7 +131,7 @@ exports.handler = async (event) => {
           WHERE a.portal_id = ANY($1)
             AND a.executed IS NOT TRUE
             AND a.glass_removed IS NOT TRUE
-            AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '5 days')
+          AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '60 days')
             AND (${conditions.join(' OR ')})
           ORDER BY a.date ASC NULLS LAST, a.created_at ASC
           LIMIT 50


### PR DESCRIPTION
## Summary
- The glass reception cross-portal search had a `date >= CURRENT_DATE - INTERVAL '5 days'` filter that excluded appointments older than 5 days
- The appointment in question was from 21/05/2026 (12 days ago), so it was invisible to the search
- Extended the window to 60 days — glass can be ordered weeks before the installation appointment

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_