### PR TITLE
feat: sync PHC order/reception numbers and show EncNº/RecNº on cards

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1929,3 +1929,116 @@ function renderReport(data) {
 function downloadReportPDF() {
   window.print();
 }
+
+// ── Sincronizar Encomendas PHC ────────────────────────────────────────────────
+
+function syncEncPreview(input) {
+  const file = input.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = function(e) {
+    try {
+      const wb = XLSX.read(e.target.result, { type: 'array' });
+      const sh = wb.Sheets[wb.SheetNames[0]];
+      const rawRows = XLSX.utils.sheet_to_json(sh, { header: 1, defval: '' });
+      if (rawRows.length < 2) { alert('Ficheiro sem dados.'); return; }
+
+      const hdrs = rawRows[0].map(h => String(h).trim().toLowerCase());
+      const col = name => hdrs.indexOf(name);
+
+      const iMatricula = col('matricula');
+      const iArmazem   = col('armazem');
+      const iEnc       = col('numeros_encomendas');
+      const iRec       = col('numeros_rececao_mercadorias');
+      const iRef       = col('ref');
+
+      if (iMatricula < 0 || iArmazem < 0 || iEnc < 0) {
+        alert('Colunas obrigatórias não encontradas: matricula, armazem, numeros_encomendas');
+        return;
+      }
+
+      const rows = [];
+      for (let r = 1; r < rawRows.length; r++) {
+        const row = rawRows[r];
+        const enc = String(row[iEnc] || '').trim();
+        const rec = String(row[iRec] || '').trim();
+        if (!enc && !rec) continue;
+        const plate = String(row[iMatricula] || '').trim();
+        const armazem = String(row[iArmazem] || '').trim().replace(/\.0$/, '');
+        const ref = String(row[iRef] || '').trim();
+        if (!plate || !armazem) continue;
+        rows.push({ plate, portal_id: parseInt(armazem), enc: enc || null, rec: rec || null, ref: ref || null });
+      }
+
+      if (rows.length === 0) { alert('Nenhuma linha com encomenda ou receção preenchida.'); return; }
+
+      const withRec = rows.filter(r => r.rec).length;
+      const withEnc = rows.filter(r => r.enc && !r.rec).length;
+
+      document.getElementById('syncEncPreview').style.display = 'block';
+      document.getElementById('syncEncPreview').innerHTML = `
+        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
+          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
+          <div style="font-size:13px;color:#374151;margin-top:6px;">
+            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
+          </div>
+        </div>
+        <button onclick="syncEncRun(${JSON.stringify(rows).split('"').join('&quot;')})"
+          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
+          🔄 Sincronizar agora (${rows.length} linhas)
+        </button>`;
+
+      // Store rows in window for the onclick
+      window._syncEncRows = rows;
+      document.getElementById('syncEncPreview').innerHTML = `
+        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
+          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
+          <div style="font-size:13px;color:#374151;margin-top:6px;">
+            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
+          </div>
+        </div>
+        <button onclick="syncEncRun()"
+          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
+          🔄 Sincronizar agora (${rows.length} linhas)
+        </button>`;
+    } catch(e) {
+      alert('Erro ao ler ficheiro: ' + e.message);
+    }
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+async function syncEncRun() {
+  const rows = window._syncEncRows;
+  if (!rows || !rows.length) return;
+  const btn = document.querySelector('#syncEncPreview button');
+  if (btn) { btn.disabled = true; btn.textContent = '⏳ A sincronizar…'; }
+
+  try {
+    const token = authClient.getToken();
+    const resp = await fetch('/.netlify/functions/sync-enc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+      body: JSON.stringify({ rows })
+    });
+    const data = await resp.json();
+    const resDiv = document.getElementById('syncEncResult');
+    resDiv.style.display = 'block';
+    if (data.success) {
+      resDiv.innerHTML = `
+        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;">
+          <div style="font-weight:700;font-size:15px;color:#15803d;">✅ Sincronização concluída</div>
+          <div style="font-size:13px;color:#374151;margin-top:6px;">
+            Actualizados: <strong>${data.updated}</strong> ·
+            Não encontrados: <strong>${data.not_found}</strong> ·
+            Ignorados: <strong>${data.skipped}</strong>
+          </div>
+        </div>`;
+    } else {
+      resDiv.innerHTML = `<div style="color:#dc2626;font-weight:700;">Erro: ${data.error}</div>`;
+    }
+  } catch(e) {
+    document.getElementById('syncEncResult').style.display = 'block';
+    document.getElementById('syncEncResult').innerHTML = `<div style="color:#dc2626;">Erro: ${e.message}</div>`;
+  }
+}

--- a/admin.html
+++ b/admin.html
@@ -155,6 +155,20 @@
           <div id="importResultsContent"></div>
         </div>
       </div>
+
+      <!-- Sincronizar Encomendas PHC -->
+      <div style="margin-top:32px;padding:20px;background:#fff;border:1px solid #e2e8f0;border-radius:12px;">
+        <h3 style="margin:0 0 6px;font-size:16px;">📦 Sincronizar Encomendas / Receções (PHC)</h3>
+        <p style="color:#6b7280;font-size:13px;margin:0 0 16px;">Carrega o Excel exportado do PHC para preencher automaticamente os n.ºs de encomenda e receção nos agendamentos. Actualiza também o status (NE→VE se encomendado, VE/NE→ST se recebido).</p>
+        <div id="syncEncUploadArea" style="border:2px dashed #cbd5e1;border-radius:10px;padding:28px;text-align:center;cursor:pointer;background:#f8fafc;" onclick="document.getElementById('syncEncFile').click()">
+          <div style="font-size:28px;margin-bottom:6px;">📄</div>
+          <div style="font-weight:700;font-size:14px;color:#1e293b;">Clica para selecionar o ficheiro PHC</div>
+          <div style="color:#94a3b8;font-size:12px;margin-top:4px;">Formato: .xls ou .xlsx</div>
+          <input type="file" id="syncEncFile" accept=".xls,.xlsx" style="display:none" onchange="syncEncPreview(this)">
+        </div>
+        <div id="syncEncPreview" style="display:none;margin-top:16px;"></div>
+        <div id="syncEncResult" style="display:none;margin-top:12px;"></div>
+      </div>
     </div>
 
     <!-- Tab Content: Configurações -->

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -48,6 +48,10 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS not_done_at TIMESTAMPTZ`);
   } catch(migErr) { console.warn('Migration not_done_at warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS reception_ref TEXT`);
+  } catch(migErr) { console.warn('Migration reception_ref warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -124,7 +128,7 @@ exports.handler = async (event) => {
                  a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
                  a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
                  a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
-                 a.order_ref, a.glass_eurocode, a.created_at, a.updated_at, a.not_done_at, a.portal_id,
+                 a.order_ref, a.glass_eurocode, a.reception_ref, a.created_at, a.updated_at, a.not_done_at, a.portal_id,
                  p.name AS portal_name
           FROM appointments a
           LEFT JOIN portals p ON p.id = a.portal_id
@@ -166,7 +170,7 @@ exports.handler = async (event) => {
                calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
                custom_service_time, foreign_plate, extra_services, n_obra,
-               order_ref, glass_eurocode, created_at, updated_at, not_done_at
+               order_ref, glass_eurocode, reception_ref, created_at, updated_at, not_done_at
         FROM appointments
         WHERE portal_id = $1
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
@@ -281,7 +285,7 @@ exports.handler = async (event) => {
           executed = $18, confirmed = $19, calibration = $20,
           first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
-          glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36
+          glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36, reception_ref = $37
         WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
@@ -311,7 +315,8 @@ exports.handler = async (event) => {
         JSON.stringify(data.extra_services !== undefined ? (data.extra_services || []) : (existing.extra_services || [])),
         data.glass_removed_date !== undefined ? (data.glass_removed_date || null) : (existing.glass_removed_date || null),
         data.n_obra !== undefined ? (data.n_obra || null) : null,
-        new Date().toISOString(), id, effectivePortalId, notDoneAtVal
+        new Date().toISOString(), id, effectivePortalId, notDoneAtVal,
+        data.reception_ref !== undefined ? (data.reception_ref || null) : null
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };

--- a/netlify/functions/sync-enc.js
+++ b/netlify/functions/sync-enc.js
@@ -1,0 +1,104 @@
+// netlify/functions/sync-enc.js
+// Syncs order numbers (numeros_encomendas) and reception numbers
+// (numeros_rececao_mercadorias) from PHC Excel export into appointments.
+// Matched by plate (normalised) + portal_id (armazem).
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+function verifyToken(event) {
+  const h = event.headers.authorization || event.headers.Authorization || '';
+  if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
+  const decoded = jwt.verify(h.substring(7), JWT_SECRET);
+  if (!['admin', 'coordenador', 'coordinator'].includes(decoded.role)) throw new Error('Acesso negado');
+  return decoded;
+}
+
+function normPlate(p) {
+  return String(p || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'POST') return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };
+
+  try {
+    verifyToken(event);
+    const { rows } = JSON.parse(event.body || '{}');
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'Nenhum dado para sincronizar' }) };
+    }
+
+    const results = { updated: 0, not_found: 0, skipped: 0, details: [] };
+
+    for (const row of rows) {
+      const { plate, portal_id, enc, rec, ref } = row;
+      if (!plate || !portal_id) { results.skipped++; continue; }
+
+      // Find appointment by normalised plate + portal_id
+      const { rows: found } = await pool.query(
+        `SELECT id, status, order_ref, reception_ref, glass_eurocode
+         FROM appointments
+         WHERE portal_id = $1
+           AND UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) = $2
+         ORDER BY date DESC NULLS LAST, created_at DESC
+         LIMIT 1`,
+        [parseInt(portal_id), normPlate(plate)]
+      );
+
+      if (!found.length) {
+        results.not_found++;
+        results.details.push({ plate, status: 'not_found' });
+        continue;
+      }
+
+      const apt = found[0];
+      const updates = [];
+      const vals = [];
+      let idx = 1;
+
+      if (enc && !apt.order_ref) {
+        updates.push(`order_ref = $${idx++}`); vals.push(String(enc));
+      }
+      if (rec && !apt.reception_ref) {
+        updates.push(`reception_ref = $${idx++}`); vals.push(String(rec));
+      }
+      if (ref && !apt.glass_eurocode) {
+        updates.push(`glass_eurocode = $${idx++}`); vals.push(String(ref));
+      }
+
+      // Status upgrade: rec → ST, enc-only + current NE → VE
+      let newStatus = null;
+      if (rec && apt.status !== 'ST') newStatus = 'ST';
+      else if (enc && !rec && apt.status === 'NE') newStatus = 'VE';
+      if (newStatus) { updates.push(`status = $${idx++}`); vals.push(newStatus); }
+
+      if (!updates.length) { results.skipped++; continue; }
+
+      updates.push(`updated_at = NOW()`);
+      vals.push(apt.id);
+
+      await pool.query(
+        `UPDATE appointments SET ${updates.join(', ')} WHERE id = $${idx}`,
+        vals
+      );
+
+      results.updated++;
+      results.details.push({ plate, status: 'updated', enc, rec, newStatus });
+    }
+
+    return { statusCode: 200, headers, body: JSON.stringify({ success: true, ...results }) };
+  } catch (err) {
+    console.error('sync-enc:', err);
+    return { statusCode: err.message.includes('autenticado') || err.message.includes('negado') ? 401 : 500, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  }
+};

--- a/script-tail.js
+++ b/script-tail.js
@@ -64,8 +64,12 @@ const telBtn = phone ? `
   let _extraDisp = '';
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
   const _mRole = window.authClient?.getUser?.()?.role;
-  const _orderRefMobile = (_mRole === 'admin' || _mRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
-  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefMobile].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  const mEncRecFooter = (a.order_ref || a.reception_ref) ? `
+    <div style="margin:5px 8px 0;padding:3px 10px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
+      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    </div>` : '';
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');
@@ -167,6 +171,7 @@ const telBtn = phone ? `
           : ''
         }
         ${isLoja() ? '' : buildKmRow(a)}
+        ${mEncRecFooter}
       </div>
       ${statusToggle}
       ${mGlassRemovedBadge}

--- a/script.js
+++ b/script.js
@@ -2506,10 +2506,14 @@ function buildDesktopCard(a){
   }
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
-  const _orderRefStr = (userRole === 'admin' || userRole === 'coordenador') && a.order_ref ? `📦 Enc: ${a.order_ref}` : null;
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ')
-    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null, _orderRefStr].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
+    : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
+  const encRecFooter = (a.order_ref || a.reception_ref) ? `
+    <div style="margin:4px 0 0;padding:3px 8px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
+      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;
   const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
@@ -2618,7 +2622,7 @@ function buildDesktopCard(a){
         <button class="icon edit" onclick="editAppointment('${a.id}')" title="Editar" aria-label="Editar">✏️</button>
         <button class="icon delete" onclick="deleteAppointment('${a.id}')" title="Eliminar" aria-label="Eliminar">🗑️</button>
       </div>
-    ${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
+    ${encRecFooter}${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
 }
 
 function renderSchedule(){


### PR DESCRIPTION
## Summary
- New `reception_ref` TEXT column on appointments table (auto-migration)
- New `sync-enc` endpoint: matches by plate + portal_id, updates `order_ref` / `reception_ref` / `glass_eurocode`, and auto-upgrades status (NE→VE if order set, NE/VE→ST if reception set)
- Desktop and mobile appointment cards show `📦 Enc: XXXX` and `✅ Rec: XXXX` footer when populated
- Admin → Importar Excel tab has new "Sincronizar Encomendas PHC" section: upload the PHC Excel, see preview (n.º lines / with reception / with order only), click to sync

## Test plan
- [ ] Upload PHC Excel in admin → Importar Excel → Sincronizar Encomendas PHC
- [ ] Check appointments with matching plates have order_ref / reception_ref populated
- [ ] Verify status upgraded: NE→VE (order only), NE→ST (with reception)
- [ ] Card footer shows EncNº and RecNº on desktop and mobile

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_