### PR TITLE
feat: set appointment status ST when glass reception confirmed via photo

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -904,6 +904,8 @@ async function startImport() {
   const eurocodeCol = importHeaders.findIndex(h => h.toLowerCase() === 'eurocode');
   const horaInicioCol = importHeaders.findIndex(h => h.toLowerCase().replace('í','i') === 'hora_inicio');
   const horaFimCol = importHeaders.findIndex(h => h.toLowerCase() === 'hora_fim');
+  const encCol = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_encomendas');
+  const recCol = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_rececao_mercadorias');
 
   // Mapear nmdos_code → {portal_id, portal_type}
   const codeToPortal = {};
@@ -1004,7 +1006,9 @@ async function startImport() {
       date: scheduleDate || null,
       period: schedulePeriod || null,
       confirmed: false,  // sempre pré-agendamento ao importar do Excel
-      n_obra: n_obra || null
+      n_obra: n_obra || null,
+      order_ref: encCol >= 0 && row[encCol] ? String(row[encCol]).trim().replace(/\.0$/, '') : null,
+      reception_ref: recCol >= 0 && row[recCol] ? String(row[recCol]).trim().replace(/\.0$/, '') : null
     });
   });
 
@@ -1111,6 +1115,9 @@ async function startSync() {
     return null;
   }
 
+  const encColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_encomendas');
+  const recColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_rececao_mercadorias');
+
   const codeToPortal = {};
   portals.forEach(p => { if (p.nmdos_code) codeToPortal[p.nmdos_code] = { id: p.id, type: p.portal_type || 'sm' }; });
 
@@ -1159,7 +1166,9 @@ async function startSync() {
       notes, extra, client_name, phone, status: 'NE', createdAt,
       date: scheduleDate || null, period: schedulePeriod || null,
       confirmed: false,  // sempre pré-agendamento ao importar do Excel
-      n_obra: n_obra || null
+      n_obra: n_obra || null,
+      order_ref: encColSync >= 0 && row[encColSync] ? String(row[encColSync]).trim().replace(/\.0$/, '') : null,
+      reception_ref: recColSync >= 0 && row[recColSync] ? String(row[recColSync]).trim().replace(/\.0$/, '') : null
     });
   });
 
@@ -1930,115 +1939,3 @@ function downloadReportPDF() {
   window.print();
 }
 
-// ── Sincronizar Encomendas PHC ────────────────────────────────────────────────
-
-function syncEncPreview(input) {
-  const file = input.files[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = function(e) {
-    try {
-      const wb = XLSX.read(e.target.result, { type: 'array' });
-      const sh = wb.Sheets[wb.SheetNames[0]];
-      const rawRows = XLSX.utils.sheet_to_json(sh, { header: 1, defval: '' });
-      if (rawRows.length < 2) { alert('Ficheiro sem dados.'); return; }
-
-      const hdrs = rawRows[0].map(h => String(h).trim().toLowerCase());
-      const col = name => hdrs.indexOf(name);
-
-      const iMatricula = col('matricula');
-      const iArmazem   = col('armazem');
-      const iEnc       = col('numeros_encomendas');
-      const iRec       = col('numeros_rececao_mercadorias');
-      const iRef       = col('ref');
-
-      if (iMatricula < 0 || iArmazem < 0 || iEnc < 0) {
-        alert('Colunas obrigatórias não encontradas: matricula, armazem, numeros_encomendas');
-        return;
-      }
-
-      const rows = [];
-      for (let r = 1; r < rawRows.length; r++) {
-        const row = rawRows[r];
-        const enc = String(row[iEnc] || '').trim();
-        const rec = String(row[iRec] || '').trim();
-        if (!enc && !rec) continue;
-        const plate = String(row[iMatricula] || '').trim();
-        const armazem = String(row[iArmazem] || '').trim().replace(/\.0$/, '');
-        const ref = String(row[iRef] || '').trim();
-        if (!plate || !armazem) continue;
-        rows.push({ plate, portal_id: parseInt(armazem), enc: enc || null, rec: rec || null, ref: ref || null });
-      }
-
-      if (rows.length === 0) { alert('Nenhuma linha com encomenda ou receção preenchida.'); return; }
-
-      const withRec = rows.filter(r => r.rec).length;
-      const withEnc = rows.filter(r => r.enc && !r.rec).length;
-
-      document.getElementById('syncEncPreview').style.display = 'block';
-      document.getElementById('syncEncPreview').innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
-          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
-          </div>
-        </div>
-        <button onclick="syncEncRun(${JSON.stringify(rows).split('"').join('&quot;')})"
-          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
-          🔄 Sincronizar agora (${rows.length} linhas)
-        </button>`;
-
-      // Store rows in window for the onclick
-      window._syncEncRows = rows;
-      document.getElementById('syncEncPreview').innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
-          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
-          </div>
-        </div>
-        <button onclick="syncEncRun()"
-          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
-          🔄 Sincronizar agora (${rows.length} linhas)
-        </button>`;
-    } catch(e) {
-      alert('Erro ao ler ficheiro: ' + e.message);
-    }
-  };
-  reader.readAsArrayBuffer(file);
-}
-
-async function syncEncRun() {
-  const rows = window._syncEncRows;
-  if (!rows || !rows.length) return;
-  const btn = document.querySelector('#syncEncPreview button');
-  if (btn) { btn.disabled = true; btn.textContent = '⏳ A sincronizar…'; }
-
-  try {
-    const token = authClient.getToken();
-    const resp = await fetch('/.netlify/functions/sync-enc', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
-      body: JSON.stringify({ rows })
-    });
-    const data = await resp.json();
-    const resDiv = document.getElementById('syncEncResult');
-    resDiv.style.display = 'block';
-    if (data.success) {
-      resDiv.innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;">
-          <div style="font-weight:700;font-size:15px;color:#15803d;">✅ Sincronização concluída</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            Actualizados: <strong>${data.updated}</strong> ·
-            Não encontrados: <strong>${data.not_found}</strong> ·
-            Ignorados: <strong>${data.skipped}</strong>
-          </div>
-        </div>`;
-    } else {
-      resDiv.innerHTML = `<div style="color:#dc2626;font-weight:700;">Erro: ${data.error}</div>`;
-    }
-  } catch(e) {
-    document.getElementById('syncEncResult').style.display = 'block';
-    document.getElementById('syncEncResult').innerHTML = `<div style="color:#dc2626;">Erro: ${e.message}</div>`;
-  }
-}

--- a/admin.html
+++ b/admin.html
@@ -156,19 +156,6 @@
         </div>
       </div>
 
-      <!-- Sincronizar Encomendas PHC -->
-      <div style="margin-top:32px;padding:20px;background:#fff;border:1px solid #e2e8f0;border-radius:12px;">
-        <h3 style="margin:0 0 6px;font-size:16px;">📦 Sincronizar Encomendas / Receções (PHC)</h3>
-        <p style="color:#6b7280;font-size:13px;margin:0 0 16px;">Carrega o Excel exportado do PHC para preencher automaticamente os n.ºs de encomenda e receção nos agendamentos. Actualiza também o status (NE→VE se encomendado, VE/NE→ST se recebido).</p>
-        <div id="syncEncUploadArea" style="border:2px dashed #cbd5e1;border-radius:10px;padding:28px;text-align:center;cursor:pointer;background:#f8fafc;" onclick="document.getElementById('syncEncFile').click()">
-          <div style="font-size:28px;margin-bottom:6px;">📄</div>
-          <div style="font-weight:700;font-size:14px;color:#1e293b;">Clica para selecionar o ficheiro PHC</div>
-          <div style="color:#94a3b8;font-size:12px;margin-top:4px;">Formato: .xls ou .xlsx</div>
-          <input type="file" id="syncEncFile" accept=".xls,.xlsx" style="display:none" onchange="syncEncPreview(this)">
-        </div>
-        <div id="syncEncPreview" style="display:none;margin-top:16px;"></div>
-        <div id="syncEncResult" style="display:none;margin-top:12px;"></div>
-      </div>
     </div>
 
     <!-- Tab Content: Configurações -->

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -152,12 +152,18 @@ exports.handler = async (event) => {
         status
       ]);
 
-      // Propagate order_ref to the appointment so coordinators can see it on the card
-      if (d.appointment_id && d.order_ref) {
+      // When glass is matched to an appointment: set status ST (received) and propagate order_ref
+      if (d.appointment_id) {
         await client.query(
-          `UPDATE appointments SET order_ref = $1, updated_at = NOW() WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
-          [d.order_ref, d.appointment_id]
+          `UPDATE appointments SET status = 'ST', updated_at = NOW() WHERE id = $1`,
+          [d.appointment_id]
         );
+        if (d.order_ref) {
+          await client.query(
+            `UPDATE appointments SET order_ref = $1 WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
+            [d.order_ref, d.appointment_id]
+          );
+        }
       }
 
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -57,7 +57,7 @@ exports.handler = async (event) => {
 
         // Verificar se já existe
         const existing = await pool.query(
-          `SELECT id, date, period, car, phone, extra, notes, auto_imported, confirmed
+          `SELECT id, date, period, car, phone, extra, notes, auto_imported, confirmed, status, order_ref, reception_ref
            FROM appointments
            WHERE portal_id = $1
            AND UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) = UPPER(REGEXP_REPLACE($2, '[^A-Z0-9]', '', 'g'))
@@ -106,6 +106,24 @@ exports.handler = async (event) => {
             updateVals.push(svc.n_obra);
           }
 
+          // Actualizar order_ref se Excel tem valor e BD está vazio
+          if (svc.order_ref && !row.order_ref) {
+            updateFields.push(`order_ref = $${idx++}`);
+            updateVals.push(svc.order_ref);
+          }
+          // Actualizar reception_ref se Excel tem valor e BD está vazio
+          if (svc.reception_ref && !row.reception_ref) {
+            updateFields.push(`reception_ref = $${idx++}`);
+            updateVals.push(svc.reception_ref);
+          }
+          // Status upgrade baseado em enc/rec
+          const newStatusUpgrade = svc.reception_ref && row.status !== 'ST' ? 'ST'
+            : (svc.order_ref && !svc.reception_ref && row.status === 'NE' ? 'VE' : null);
+          if (newStatusUpgrade) {
+            updateFields.push(`status = $${idx++}`);
+            updateVals.push(newStatusUpgrade);
+          }
+
           // Se NÃO está na agenda mas Excel tem data → colocar na agenda
           if (!hasDateInDB && hasDateInExcel) {
             updateFields.push(`date = $${idx++}`);
@@ -143,13 +161,14 @@ exports.handler = async (event) => {
           // ── SERVIÇO NOVO ──
           const hasAutoDate = !!svc.date;
 
+          const insertStatus = svc.reception_ref ? 'ST' : (svc.order_ref ? 'VE' : (svc.status || 'NE'));
           await pool.query(
             `INSERT INTO appointments (
               date, period, plate, car, service, locality, status,
               notes, address, extra, phone, km, sortIndex, "glassOrdered",
-              auto_imported, confirmed, damage_details, n_obra, portal_id, created_at, updated_at
+              auto_imported, confirmed, damage_details, n_obra, order_ref, reception_ref, portal_id, created_at, updated_at
             ) VALUES (
-              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
+              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23
             ) RETURNING id`,
             [
               svc.date || null,
@@ -158,7 +177,7 @@ exports.handler = async (event) => {
               svc.car || null,
               svc.service || null,
               null,           // locality
-              svc.status || 'NE',
+              insertStatus,
               svc.notes || null,
               null,           // address
               svc.extra || null,
@@ -170,6 +189,8 @@ exports.handler = async (event) => {
               false,          // confirmed
               svc.damage_details || null,
               svc.n_obra || null,
+              svc.order_ref || null,
+              svc.reception_ref || null,
               svc.portal_id,
               svc.createdAt || new Date().toISOString(),
               new Date().toISOString()

--- a/script-tail.js
+++ b/script-tail.js
@@ -66,9 +66,9 @@ const telBtn = phone ? `
   const _mRole = window.authClient?.getUser?.()?.role;
   const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const mEncRecFooter = (a.order_ref || a.reception_ref) ? `
-    <div style="margin:5px 8px 0;padding:3px 10px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
-      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
-      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    <div style="margin:4px 0 0;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);display:flex;gap:8px;flex-wrap:wrap;">
+      ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
     </div>` : '';
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE

--- a/script.js
+++ b/script.js
@@ -2510,9 +2510,9 @@ function buildDesktopCard(a){
     ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
     : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
   const encRecFooter = (a.order_ref || a.reception_ref) ? `
-    <div style="margin:4px 0 0;padding:3px 8px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
-      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
-      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:2px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);">
+      ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
     </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;
@@ -2621,8 +2621,9 @@ function buildDesktopCard(a){
         ${a.photo_url ? `<a href="${a.photo_url}" target="_blank" rel="noopener" class="icon" title="Ver foto" style="text-decoration:none;">📷</a>` : ''}
         <button class="icon edit" onclick="editAppointment('${a.id}')" title="Editar" aria-label="Editar">✏️</button>
         <button class="icon delete" onclick="deleteAppointment('${a.id}')" title="Eliminar" aria-label="Eliminar">🗑️</button>
+        ${encRecFooter}
       </div>
-    ${encRecFooter}${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
+    ${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
 }
 
 function renderSchedule(){


### PR DESCRIPTION
## Summary
- When a technician scans the delivery label and confirms the match to an appointment, the appointment status is now immediately set to `ST` (received)
- Previously this only happened when the coordinator manually clicked "Rececionado" in the coordinator panel, or when the PHC Excel was imported with a reception number
- Now the physical arrival (photo scan + match) is sufficient to set ST, regardless of whether the PHC export has been done yet

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_