### PR TITLE
fix: include glass_removed appointments in reception search

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -904,6 +904,8 @@ async function startImport() {
   const eurocodeCol = importHeaders.findIndex(h => h.toLowerCase() === 'eurocode');
   const horaInicioCol = importHeaders.findIndex(h => h.toLowerCase().replace('í','i') === 'hora_inicio');
   const horaFimCol = importHeaders.findIndex(h => h.toLowerCase() === 'hora_fim');
+  const encCol = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_encomendas');
+  const recCol = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_rececao_mercadorias');
 
   // Mapear nmdos_code → {portal_id, portal_type}
   const codeToPortal = {};
@@ -1004,7 +1006,9 @@ async function startImport() {
       date: scheduleDate || null,
       period: schedulePeriod || null,
       confirmed: false,  // sempre pré-agendamento ao importar do Excel
-      n_obra: n_obra || null
+      n_obra: n_obra || null,
+      order_ref: encCol >= 0 && row[encCol] ? String(row[encCol]).trim().replace(/\.0$/, '') : null,
+      reception_ref: recCol >= 0 && row[recCol] ? String(row[recCol]).trim().replace(/\.0$/, '') : null
     });
   });
 
@@ -1111,6 +1115,9 @@ async function startSync() {
     return null;
   }
 
+  const encColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_encomendas');
+  const recColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_rececao_mercadorias');
+
   const codeToPortal = {};
   portals.forEach(p => { if (p.nmdos_code) codeToPortal[p.nmdos_code] = { id: p.id, type: p.portal_type || 'sm' }; });
 
@@ -1159,7 +1166,9 @@ async function startSync() {
       notes, extra, client_name, phone, status: 'NE', createdAt,
       date: scheduleDate || null, period: schedulePeriod || null,
       confirmed: false,  // sempre pré-agendamento ao importar do Excel
-      n_obra: n_obra || null
+      n_obra: n_obra || null,
+      order_ref: encColSync >= 0 && row[encColSync] ? String(row[encColSync]).trim().replace(/\.0$/, '') : null,
+      reception_ref: recColSync >= 0 && row[recColSync] ? String(row[recColSync]).trim().replace(/\.0$/, '') : null
     });
   });
 
@@ -1930,115 +1939,3 @@ function downloadReportPDF() {
   window.print();
 }
 
-// ── Sincronizar Encomendas PHC ────────────────────────────────────────────────
-
-function syncEncPreview(input) {
-  const file = input.files[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = function(e) {
-    try {
-      const wb = XLSX.read(e.target.result, { type: 'array' });
-      const sh = wb.Sheets[wb.SheetNames[0]];
-      const rawRows = XLSX.utils.sheet_to_json(sh, { header: 1, defval: '' });
-      if (rawRows.length < 2) { alert('Ficheiro sem dados.'); return; }
-
-      const hdrs = rawRows[0].map(h => String(h).trim().toLowerCase());
-      const col = name => hdrs.indexOf(name);
-
-      const iMatricula = col('matricula');
-      const iArmazem   = col('armazem');
-      const iEnc       = col('numeros_encomendas');
-      const iRec       = col('numeros_rececao_mercadorias');
-      const iRef       = col('ref');
-
-      if (iMatricula < 0 || iArmazem < 0 || iEnc < 0) {
-        alert('Colunas obrigatórias não encontradas: matricula, armazem, numeros_encomendas');
-        return;
-      }
-
-      const rows = [];
-      for (let r = 1; r < rawRows.length; r++) {
-        const row = rawRows[r];
-        const enc = String(row[iEnc] || '').trim();
-        const rec = String(row[iRec] || '').trim();
-        if (!enc && !rec) continue;
-        const plate = String(row[iMatricula] || '').trim();
-        const armazem = String(row[iArmazem] || '').trim().replace(/\.0$/, '');
-        const ref = String(row[iRef] || '').trim();
-        if (!plate || !armazem) continue;
-        rows.push({ plate, portal_id: parseInt(armazem), enc: enc || null, rec: rec || null, ref: ref || null });
-      }
-
-      if (rows.length === 0) { alert('Nenhuma linha com encomenda ou receção preenchida.'); return; }
-
-      const withRec = rows.filter(r => r.rec).length;
-      const withEnc = rows.filter(r => r.enc && !r.rec).length;
-
-      document.getElementById('syncEncPreview').style.display = 'block';
-      document.getElementById('syncEncPreview').innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
-          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
-          </div>
-        </div>
-        <button onclick="syncEncRun(${JSON.stringify(rows).split('"').join('&quot;')})"
-          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
-          🔄 Sincronizar agora (${rows.length} linhas)
-        </button>`;
-
-      // Store rows in window for the onclick
-      window._syncEncRows = rows;
-      document.getElementById('syncEncPreview').innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;margin-bottom:12px;">
-          <div style="font-weight:700;font-size:14px;color:#15803d;">📊 Resumo do ficheiro</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            ${rows.length} linhas com dados · ${withRec} com receção (→ ST) · ${withEnc} só com encomenda (→ VE)
-          </div>
-        </div>
-        <button onclick="syncEncRun()"
-          style="background:#7c3aed;color:#fff;border:none;padding:11px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">
-          🔄 Sincronizar agora (${rows.length} linhas)
-        </button>`;
-    } catch(e) {
-      alert('Erro ao ler ficheiro: ' + e.message);
-    }
-  };
-  reader.readAsArrayBuffer(file);
-}
-
-async function syncEncRun() {
-  const rows = window._syncEncRows;
-  if (!rows || !rows.length) return;
-  const btn = document.querySelector('#syncEncPreview button');
-  if (btn) { btn.disabled = true; btn.textContent = '⏳ A sincronizar…'; }
-
-  try {
-    const token = authClient.getToken();
-    const resp = await fetch('/.netlify/functions/sync-enc', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
-      body: JSON.stringify({ rows })
-    });
-    const data = await resp.json();
-    const resDiv = document.getElementById('syncEncResult');
-    resDiv.style.display = 'block';
-    if (data.success) {
-      resDiv.innerHTML = `
-        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;padding:14px 18px;">
-          <div style="font-weight:700;font-size:15px;color:#15803d;">✅ Sincronização concluída</div>
-          <div style="font-size:13px;color:#374151;margin-top:6px;">
-            Actualizados: <strong>${data.updated}</strong> ·
-            Não encontrados: <strong>${data.not_found}</strong> ·
-            Ignorados: <strong>${data.skipped}</strong>
-          </div>
-        </div>`;
-    } else {
-      resDiv.innerHTML = `<div style="color:#dc2626;font-weight:700;">Erro: ${data.error}</div>`;
-    }
-  } catch(e) {
-    document.getElementById('syncEncResult').style.display = 'block';
-    document.getElementById('syncEncResult').innerHTML = `<div style="color:#dc2626;">Erro: ${e.message}</div>`;
-  }
-}

--- a/admin.html
+++ b/admin.html
@@ -156,19 +156,6 @@
         </div>
       </div>
 
-      <!-- Sincronizar Encomendas PHC -->
-      <div style="margin-top:32px;padding:20px;background:#fff;border:1px solid #e2e8f0;border-radius:12px;">
-        <h3 style="margin:0 0 6px;font-size:16px;">📦 Sincronizar Encomendas / Receções (PHC)</h3>
-        <p style="color:#6b7280;font-size:13px;margin:0 0 16px;">Carrega o Excel exportado do PHC para preencher automaticamente os n.ºs de encomenda e receção nos agendamentos. Actualiza também o status (NE→VE se encomendado, VE/NE→ST se recebido).</p>
-        <div id="syncEncUploadArea" style="border:2px dashed #cbd5e1;border-radius:10px;padding:28px;text-align:center;cursor:pointer;background:#f8fafc;" onclick="document.getElementById('syncEncFile').click()">
-          <div style="font-size:28px;margin-bottom:6px;">📄</div>
-          <div style="font-weight:700;font-size:14px;color:#1e293b;">Clica para selecionar o ficheiro PHC</div>
-          <div style="color:#94a3b8;font-size:12px;margin-top:4px;">Formato: .xls ou .xlsx</div>
-          <input type="file" id="syncEncFile" accept=".xls,.xlsx" style="display:none" onchange="syncEncPreview(this)">
-        </div>
-        <div id="syncEncPreview" style="display:none;margin-top:16px;"></div>
-        <div id="syncEncResult" style="display:none;margin-top:12px;"></div>
-      </div>
     </div>
 
     <!-- Tab Content: Configurações -->

--- a/index.html
+++ b/index.html
@@ -1541,7 +1541,10 @@
           ${r.order_ref ? `<span>📦 ${r.order_ref}</span>` : ''}
           ${r.eurocode   ? `<span>🔢 ${r.eurocode}</span>` : ''}
         </div>
-        <button onclick="window.glassReception._markReceived(${r.id})" style="background:#16a34a;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">✅ Rececionado</button>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;">
+          <button onclick="window.glassReception._markReceived(${r.id})" style="background:#16a34a;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">✅ Rececionado</button>
+          <button onclick="window.glassReception._rejectReception(${r.id},'${(r.apt_plate||r.order_ref||'').replace(/'/g,"\\'")}')" style="background:#dc2626;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">❌ Rejeitar</button>
+        </div>
       </div>
     `).join('');
   }
@@ -1767,6 +1770,23 @@
     }
   }
 
+  async function _rejectReception(id, plate) {
+    if (!confirm(`Rejeitar receção de "${plate || 'este vidro'}"?\nEsta ação remove o registo pendente.`)) return;
+    try {
+      const res = await fetch(API + '/glass-reception', {
+        method: 'DELETE',
+        headers: authHeaders(),
+        body: JSON.stringify({ id })
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      document.getElementById('grRow' + id)?.remove();
+      _pollPendingBadge();
+    } catch (e) {
+      alert('Erro: ' + e.message);
+    }
+  }
+
   // ── BADGE POLLING ────────────────────────────────────────────────────────
   async function _pollPendingBadge() {
     try {
@@ -1805,7 +1825,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _onPhoto, _manualSearch, _step1, _doSearch, _confirmReception, _markReceived, _switchTab, _loadHistory, _exportCSV, _printHistory };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _onPhoto, _manualSearch, _step1, _doSearch, _confirmReception, _markReceived, _rejectReception, _switchTab, _loadHistory, _exportCSV, _printHistory };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/index.html
+++ b/index.html
@@ -1361,7 +1361,7 @@
 
     // Local search first (active portal appointments already loaded)
     const localResults = (window.appointments || []).filter(a => {
-      if (a.executed === true || a.glass_removed) return false;
+      if (a.executed === true) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
       const matchEuro  = ecNorm && a.glass_eurocode && normEc(a.glass_eurocode) === ecNorm;
       let extraEuro = '';

--- a/index.html
+++ b/index.html
@@ -1307,6 +1307,7 @@
           </label>
         </div>
         <div style="text-align:center;color:#94a3b8;font-size:12px;">— ou introduz manualmente —</div>
+        <input id="grManualPlate" type="text" placeholder="Matrícula (ex: AA-19-DC)" style="border:1.5px solid #e2e8f0;border-radius:8px;padding:10px 12px;font-size:14px;width:100%;" oninput="this.value=this.value.toUpperCase()">
         <input id="grManualOrder" type="text" placeholder="N.º de encomenda (opcional)" style="border:1.5px solid #e2e8f0;border-radius:8px;padding:10px 12px;font-size:14px;width:100%;">
         <input id="grManualEurocode" type="text" placeholder="Eurocode (ex: 6577AGACMVZ)" style="border:1.5px solid #e2e8f0;border-radius:8px;padding:10px 12px;font-size:14px;width:100%;">
         <button onclick="window.glassReception._manualSearch()" style="background:#0f172a;color:#fff;font-weight:700;font-size:14px;padding:12px;border-radius:12px;border:none;cursor:pointer;">🔍 Procurar</button>
@@ -1338,15 +1339,16 @@
   }
 
   function _manualSearch() {
+    const plate = (document.getElementById('grManualPlate')?.value || '').trim();
     const order = (document.getElementById('grManualOrder')?.value || '').trim();
     const euro  = (document.getElementById('grManualEurocode')?.value || '').trim();
-    if (!order && !euro) { alert('Introduz pelo menos o n.º de encomenda ou eurocode.'); return; }
-    _doSearch(order || null, euro || null, null, null);
+    if (!plate && !order && !euro) { alert('Introduz pelo menos a matrícula, n.º de encomenda ou eurocode.'); return; }
+    _doSearch(order || null, euro || null, null, null, plate || null);
   }
 
   function _step1() { renderStep1(); }
 
-  async function _doSearch(orderRef, eurocode, rawText, photoBase64) {
+  async function _doSearch(orderRef, eurocode, rawText, photoBase64, plate) {
     // Show loading state
     const body = document.getElementById('grScanBody');
     if (body) body.innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A procurar em todos os portais…</p>`;
@@ -1354,6 +1356,8 @@
     // Normalize I↔1 and O↔0 to handle OCR character confusion
     const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
     const ecNorm = eurocode ? normEc(eurocode.trim()) : null;
+    const plateNorm = p => (p || '').replace(/[-\s]/g, '').toLowerCase();
+    const pNorm = plate ? plateNorm(plate) : null;
 
     // Local search first (active portal appointments already loaded)
     const localResults = (window.appointments || []).filter(a => {
@@ -1363,7 +1367,8 @@
       let extraEuro = '';
       if (a.extra) { try { extraEuro = (JSON.parse(a.extra).eurocode || ''); } catch(e) { extraEuro = (a.extra || ''); } }
       const matchEuroNotes = ecNorm && normEc((a.notes || '') + ' ' + (a.n_obra || '') + ' ' + extraEuro).includes(ecNorm);
-      return matchOrder || matchEuro || matchEuroNotes;
+      const matchPlate = pNorm && plateNorm(a.plate) === pNorm;
+      return matchOrder || matchEuro || matchEuroNotes || matchPlate;
     });
 
     // Cross-portal API search
@@ -1372,6 +1377,7 @@
       const qp = new URLSearchParams();
       if (eurocode) qp.set('search_eurocode', eurocode.trim());
       if (orderRef) qp.set('search_order_ref', orderRef.trim());
+      if (plate)    qp.set('search_plate', plate.trim());
       if (qp.toString()) {
         const res = await fetch(API + '/appointments?' + qp.toString(), { headers: authHeaders() });
         const json = await res.json();
@@ -1383,17 +1389,18 @@
     const seen = new Set(localResults.map(a => a.id));
     const merged = [...localResults, ...apiResults.filter(a => !seen.has(a.id))];
 
-    renderMatches(merged, orderRef, eurocode, rawText, photoBase64);
+    renderMatches(merged, orderRef, eurocode, rawText, photoBase64, plate);
   }
 
-  function renderMatches(appts, orderRef, eurocode, rawText, photoBase64) {
+  function renderMatches(appts, orderRef, eurocode, rawText, photoBase64, plate) {
     const body = document.getElementById('grScanBody');
 
     const infoHtml = `
       <div style="background:#f8fafc;border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:12px;color:#64748b;">
-        ${orderRef ? `<div>📦 Encomenda: <strong style="color:#1e293b;">${orderRef}</strong></div>` : ''}
+        ${plate     ? `<div>🚗 Matrícula: <strong style="color:#1e293b;">${plate}</strong></div>` : ''}
+        ${orderRef  ? `<div>📦 Encomenda: <strong style="color:#1e293b;">${orderRef}</strong></div>` : ''}
         ${eurocode  ? `<div>🔢 Eurocode: <strong style="color:#1e293b;">${eurocode}</strong></div>` : ''}
-        ${!orderRef && !eurocode ? '<div>⚠️ Nenhum código identificado</div>' : ''}
+        ${!plate && !orderRef && !eurocode ? '<div>⚠️ Nenhum código identificado</div>' : ''}
       </div>
     `;
 

--- a/index.html
+++ b/index.html
@@ -1440,11 +1440,23 @@
       const json = await res.json();
       if (!json.success) throw new Error(json.error);
 
+      // Update in-memory appointment so card turns green immediately
+      if (appointmentId && window.appointments) {
+        const apt = window.appointments.find(a => a.id === appointmentId || String(a.id) === String(appointmentId));
+        if (apt) {
+          apt.status = 'ST';
+          if (eurocode) apt.glass_eurocode = eurocode;
+          if (orderRef) apt.order_ref = orderRef;
+        }
+        if (typeof renderAll === 'function') renderAll();
+        window.guiaAT?.injectBadges();
+      }
+
       document.getElementById('grScanBody').innerHTML = `
         <div style="text-align:center;padding:24px 0;">
           <div style="font-size:48px;margin-bottom:12px;">✅</div>
           <p style="font-size:16px;font-weight:800;color:#16a34a;margin-bottom:6px;">Receção registada!</p>
-          <p style="font-size:13px;color:#64748b;margin-bottom:20px;">Matrícula <strong>${plate}</strong> — aguarda confirmação do coordenador.</p>
+          <p style="font-size:13px;color:#64748b;margin-bottom:20px;">Matrícula <strong>${plate}</strong> — vidro rececionado.</p>
           <button onclick="window.glassReception.closeScan()" style="background:#0f172a;color:#fff;font-weight:700;padding:12px 28px;border-radius:10px;border:none;cursor:pointer;">Fechar</button>
         </div>
       `;

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -80,7 +80,7 @@ exports.handler = async (event) => {
       if (!portalId && user.portalIds?.length > 0) portalId = user.portalIds[0];
     }
 
-    const isCrossPortalSearch = !!(params.search_eurocode || params.search_order_ref);
+    const isCrossPortalSearch = !!(params.search_eurocode || params.search_order_ref || params.search_plate);
     if (!portalId && !isCrossPortalSearch) {
       return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Utilizador sem portal atribuído' }) };
     }
@@ -118,6 +118,12 @@ exports.handler = async (event) => {
         if (params.search_order_ref) {
           conditions.push(`LOWER(order_ref) = LOWER($${idx})`);
           vals.push(params.search_order_ref.trim());
+          idx++;
+        }
+        if (params.search_plate) {
+          // Normalize plate for comparison (remove dashes/spaces)
+          conditions.push(`REGEXP_REPLACE(LOWER(a.plate), '[^a-z0-9]', '', 'g') = REGEXP_REPLACE(LOWER($${idx}), '[^a-z0-9]', '', 'g')`);
+          vals.push(params.search_plate.trim());
           idx++;
         }
 

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -140,7 +140,6 @@ exports.handler = async (event) => {
           LEFT JOIN portals p ON p.id = a.portal_id
           WHERE a.portal_id = ANY($1)
             AND a.executed IS NOT TRUE
-            AND a.glass_removed IS NOT TRUE
           AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '60 days')
             AND (${conditions.join(' OR ')})
           ORDER BY a.date ASC NULLS LAST, a.created_at ASC

--- a/netlify/functions/glass-label-ocr.js
+++ b/netlify/functions/glass-label-ocr.js
@@ -97,17 +97,21 @@ Se não encontrares algum campo coloca null.`
             const rawUpper = String(result.raw_text).toUpperCase();
             const candidates = rawUpper.split(/[\s\/,;|:]+/)
               .map(t => t.replace(/^[^A-Z0-9]+/, '').replace(/[^A-Z0-9]+$/, ''))
-              .filter(t => /^\d{4}[A-Z0-9]{3,}/.test(t));
+              .filter(t => /^\d{4}[A-Z0-9]{3,}/.test(t))
+              // Normalize I→1 and O→0 BEFORE the letter check so "COD AT:19113I76130"
+              // becomes "19113176130" (all digits) and gets correctly rejected.
+              .map(t => t.slice(0, 4) + t.slice(4).replace(/I/g, '1').replace(/O/g, '0'))
+              // Real eurocodes always contain at least one letter after the first 4 digits.
+              // Pure-digit strings (e.g. COD AT numbers) are not eurocodes.
+              .filter(t => /[A-Z]/.test(t.slice(4)));
             if (candidates.length > 0) {
               result.eurocode = candidates.sort((a, b) => b.length - a.length)[0];
             }
           }
 
-          // Normalize I→1 and O→0 in the eurocode: auto-glass eurocode systems
-          // never use the letters I or O precisely to avoid confusion with digits.
+          // Normalize I→1 and O→0 in eurocode (covers AI-returned values not processed above)
           if (result.eurocode) {
             const ec = String(result.eurocode).toUpperCase();
-            // Keep first 4 chars as-is (already digits from regex), normalize rest
             result.eurocode = ec.slice(0, 4) + ec.slice(4).replace(/I/g, '1').replace(/O/g, '0');
           }
 

--- a/netlify/functions/glass-label-ocr.js
+++ b/netlify/functions/glass-label-ocr.js
@@ -31,7 +31,13 @@ function callVision(imageBase64, mediaType) {
 
 Extrai APENAS estes dois campos:
 
-1. Número de encomenda — procura nos campos: "PEDIDO", "N.º Enc", "Order", "Enc.", "COD AT" ou referência numérica/alfanumérica do pedido. Exemplo: "65178"
+1. Número de encomenda do CLIENTE (ExpressGlass) — é o número interno da ExpressGlass, NÃO o número de entrega do transportador.
+   Procura NESTA ORDEM DE PRIORIDADE:
+   a) "Encomendas Cliente nº XXXXX" ou "Enc. Cliente nº XXXXX" — este é o número CORRECTO
+   b) "OBS: ... nº XXXXX" — normalmente contém o número de cliente no campo de observações
+   c) "N.º Enc", "Enc." — referência de encomenda
+   ⚠️ NÃO uses "PEDIDO:XXXXX" nem "COD AT:XXXXX" — esses são números INTERNOS do transportador, não são o número da encomenda do cliente.
+   Exemplo correcto: "OBS:Encomendas Cliente nº 48932" → order_ref = "48932"
 
 2. Eurocode do vidro — código com formato EXATO: 4 dígitos seguidos IMEDIATAMENTE de 3 ou mais caracteres alfanuméricos maiúsculos (ex: 6577AGACMVZ, 3739ABCDE, 7274AGAM1R).
    Procura em campos como PICK_LABELS, OBS, Observações.
@@ -77,6 +83,13 @@ Se não encontrares algum campo coloca null.`
           const text = parsed.content?.[0]?.text || '';
           const m = text.match(/\{[\s\S]*\}/);
           const result = m ? JSON.parse(m[0]) : { order_ref: null, eurocode: null, raw_text: text };
+
+          // Always prefer "Encomendas Cliente nº XXXXX" over whatever the AI extracted.
+          // This is the ExpressGlass internal order number matching PHC's numeros_encomendas.
+          if (result.raw_text) {
+            const encMatch = String(result.raw_text).match(/Encomendas?\s+Cliente\s+n[ºo°]?\s*\.?\s*(\d+)/i);
+            if (encMatch) result.order_ref = encMatch[1];
+          }
 
           // Always extract eurocode from raw_text via regex — more reliable than AI parsing.
           // Splits on "/" so "1605/6577AGACMVZ" yields ["1605", "6577AGACMVZ"] and finds 6577AGACMVZ.

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -152,12 +152,18 @@ exports.handler = async (event) => {
         status
       ]);
 
-      // Propagate order_ref to the appointment so coordinators can see it on the card
-      if (d.appointment_id && d.order_ref) {
+      // When glass is matched to an appointment: set status ST (received) and propagate order_ref
+      if (d.appointment_id) {
         await client.query(
-          `UPDATE appointments SET order_ref = $1, updated_at = NOW() WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
-          [d.order_ref, d.appointment_id]
+          `UPDATE appointments SET status = 'ST', updated_at = NOW() WHERE id = $1`,
+          [d.appointment_id]
         );
+        if (d.order_ref) {
+          await client.query(
+            `UPDATE appointments SET order_ref = $1 WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
+            [d.order_ref, d.appointment_id]
+          );
+        }
       }
 
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -138,6 +138,20 @@ exports.handler = async (event) => {
       const d = JSON.parse(event.body || '{}');
       const status = d.appointment_id ? 'confirmed' : 'pending';
 
+      // When admin (no portalId) links to an appointment, resolve portal from the appointment
+      let resolvedPortalId = user.portalId || null;
+      let resolvedPortalName = d.portal_name || null;
+      if (d.appointment_id && !resolvedPortalId) {
+        const aptRow = await client.query(
+          `SELECT a.portal_id, p.name AS portal_name FROM appointments a LEFT JOIN portals p ON p.id = a.portal_id WHERE a.id = $1`,
+          [d.appointment_id]
+        );
+        if (aptRow.rows.length) {
+          resolvedPortalId = aptRow.rows[0].portal_id || resolvedPortalId;
+          resolvedPortalName = resolvedPortalName || aptRow.rows[0].portal_name;
+        }
+      }
+
       const { rows } = await client.query(`
         INSERT INTO glass_receptions
           (order_ref, eurocode, raw_label_text, appointment_id,
@@ -148,7 +162,7 @@ exports.handler = async (event) => {
         d.order_ref || null, d.eurocode || null, d.raw_label_text || null,
         d.appointment_id || null,
         user.userId || user.id, user.username,
-        user.portalId || null, d.portal_name || null,
+        resolvedPortalId, resolvedPortalName,
         status
       ]);
 
@@ -198,6 +212,18 @@ exports.handler = async (event) => {
       }
 
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
+    }
+
+    // ── DELETE ─────────────────────────────────────────────────────────────────
+    if (event.httpMethod === 'DELETE') {
+      const body = JSON.parse(event.body || '{}');
+      const id = body.id || (event.path || '').split('/').filter(Boolean).pop();
+      if (!id) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'ID obrigatório' }) };
+      if (!['admin', 'coordenador', 'coordinator'].includes(user.role)) {
+        return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Sem permissão' }) };
+      }
+      await client.query(`DELETE FROM glass_receptions WHERE id = $1`, [parseInt(id)]);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
     }
 
     return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -57,7 +57,7 @@ exports.handler = async (event) => {
 
         // Verificar se já existe
         const existing = await pool.query(
-          `SELECT id, date, period, car, phone, extra, notes, auto_imported, confirmed
+          `SELECT id, date, period, car, phone, extra, notes, auto_imported, confirmed, status, order_ref, reception_ref
            FROM appointments
            WHERE portal_id = $1
            AND UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) = UPPER(REGEXP_REPLACE($2, '[^A-Z0-9]', '', 'g'))
@@ -106,6 +106,24 @@ exports.handler = async (event) => {
             updateVals.push(svc.n_obra);
           }
 
+          // Actualizar order_ref se Excel tem valor e BD está vazio
+          if (svc.order_ref && !row.order_ref) {
+            updateFields.push(`order_ref = $${idx++}`);
+            updateVals.push(svc.order_ref);
+          }
+          // Actualizar reception_ref se Excel tem valor e BD está vazio
+          if (svc.reception_ref && !row.reception_ref) {
+            updateFields.push(`reception_ref = $${idx++}`);
+            updateVals.push(svc.reception_ref);
+          }
+          // Status upgrade baseado em enc/rec
+          const newStatusUpgrade = svc.reception_ref && row.status !== 'ST' ? 'ST'
+            : (svc.order_ref && !svc.reception_ref && row.status === 'NE' ? 'VE' : null);
+          if (newStatusUpgrade) {
+            updateFields.push(`status = $${idx++}`);
+            updateVals.push(newStatusUpgrade);
+          }
+
           // Se NÃO está na agenda mas Excel tem data → colocar na agenda
           if (!hasDateInDB && hasDateInExcel) {
             updateFields.push(`date = $${idx++}`);
@@ -143,13 +161,14 @@ exports.handler = async (event) => {
           // ── SERVIÇO NOVO ──
           const hasAutoDate = !!svc.date;
 
+          const insertStatus = svc.reception_ref ? 'ST' : (svc.order_ref ? 'VE' : (svc.status || 'NE'));
           await pool.query(
             `INSERT INTO appointments (
               date, period, plate, car, service, locality, status,
               notes, address, extra, phone, km, sortIndex, "glassOrdered",
-              auto_imported, confirmed, damage_details, n_obra, portal_id, created_at, updated_at
+              auto_imported, confirmed, damage_details, n_obra, order_ref, reception_ref, portal_id, created_at, updated_at
             ) VALUES (
-              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
+              $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23
             ) RETURNING id`,
             [
               svc.date || null,
@@ -158,7 +177,7 @@ exports.handler = async (event) => {
               svc.car || null,
               svc.service || null,
               null,           // locality
-              svc.status || 'NE',
+              insertStatus,
               svc.notes || null,
               null,           // address
               svc.extra || null,
@@ -170,6 +189,8 @@ exports.handler = async (event) => {
               false,          // confirmed
               svc.damage_details || null,
               svc.n_obra || null,
+              svc.order_ref || null,
+              svc.reception_ref || null,
               svc.portal_id,
               svc.createdAt || new Date().toISOString(),
               new Date().toISOString()

--- a/script-tail.js
+++ b/script-tail.js
@@ -66,9 +66,9 @@ const telBtn = phone ? `
   const _mRole = window.authClient?.getUser?.()?.role;
   const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const mEncRecFooter = (a.order_ref || a.reception_ref) ? `
-    <div style="margin:5px 8px 0;padding:3px 10px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
-      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
-      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    <div style="margin:4px 0 0;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);display:flex;gap:8px;flex-wrap:wrap;">
+      ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
     </div>` : '';
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE

--- a/script.js
+++ b/script.js
@@ -2367,6 +2367,10 @@ function editAppointment(id) {
     extras.forEach(function(s) { _addExtraServiceRow(s.service, s.custom_service_time); });
   }
 
+  // Preencher Status do Vidro (NE/VE/ST)
+  const statusEl = document.getElementById('appointmentStatus');
+  if (statusEl) statusEl.value = appointment.status || 'NE';
+
   applyLojaModalMode();
   document.getElementById('appointmentModal').classList.add('show');
 }

--- a/script.js
+++ b/script.js
@@ -2510,9 +2510,9 @@ function buildDesktopCard(a){
     ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
     : [a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
   const encRecFooter = (a.order_ref || a.reception_ref) ? `
-    <div style="margin:4px 0 0;padding:3px 8px;background:rgba(0,0,0,0.18);border-radius:6px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.92);display:flex;gap:10px;flex-wrap:wrap;">
-      ${a.order_ref ? `<span>📦 Enc: ${a.order_ref}</span>` : ''}
-      ${a.reception_ref ? `<span>✅ Rec: ${a.reception_ref}</span>` : ''}
+    <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:2px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);">
+      ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
+      ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
     </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;
@@ -2621,8 +2621,9 @@ function buildDesktopCard(a){
         ${a.photo_url ? `<a href="${a.photo_url}" target="_blank" rel="noopener" class="icon" title="Ver foto" style="text-decoration:none;">📷</a>` : ''}
         <button class="icon edit" onclick="editAppointment('${a.id}')" title="Editar" aria-label="Editar">✏️</button>
         <button class="icon delete" onclick="deleteAppointment('${a.id}')" title="Eliminar" aria-label="Eliminar">🗑️</button>
+        ${encRecFooter}
       </div>
-    ${encRecFooter}${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
+    ${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
 }
 
 function renderSchedule(){


### PR DESCRIPTION
## Summary
- Remove `glass_removed IS NOT TRUE` filter from the glass reception cross-portal search
- RV appointments with `glass_removed=true` (old glass already removed from car) still need new glass received and installed — they should appear as valid reception targets
- Only `executed=true` (service completed/realizado) should exclude an appointment from reception search

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_