### PR TITLE
feat: Vendas Complementares no modal de agendamento

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,6 +540,41 @@
             <textarea id="appointmentNotes" placeholder="Informações adicionais (não aparece no calendário)" rows="3"></textarea>
           </div>
 
+          <!-- VENDAS COMPLEMENTARES -->
+          <div class="form-group" id="compSalesSection" style="margin-bottom:16px;">
+            <label style="display:flex;align-items:center;gap:8px;cursor:pointer;font-weight:700;font-size:13px;color:#374151;margin-bottom:0;">
+              <input type="checkbox" id="hasCompSales" onchange="toggleCompSales(this.checked)"
+                style="width:16px;height:16px;accent-color:#7c3aed;cursor:pointer;">
+              💰 Venda complementar
+            </label>
+            <div id="compSalesFields" style="display:none;margin-top:10px;padding:12px 14px;background:#f5f3ff;border:1.5px solid #c4b5fd;border-radius:10px;">
+              <div style="display:flex;flex-direction:column;gap:10px;">
+                <div>
+                  <label style="font-size:12px;font-weight:600;color:#5b21b6;display:block;margin-bottom:4px;">Descrição da venda *</label>
+                  <textarea id="compSalesDesc" rows="2" placeholder="Ex: Câmara traseira, sensor de estacionamento..."
+                    style="width:100%;border:1.5px solid #ddd8fe;border-radius:8px;padding:8px;font-size:13px;resize:vertical;box-sizing:border-box;"></textarea>
+                </div>
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+                  <div>
+                    <label style="font-size:12px;font-weight:600;color:#5b21b6;display:block;margin-bottom:4px;">Nome do cliente</label>
+                    <input type="text" id="compSalesName" placeholder="Nome completo"
+                      style="width:100%;border:1.5px solid #ddd8fe;border-radius:8px;padding:8px;font-size:13px;box-sizing:border-box;">
+                  </div>
+                  <div>
+                    <label style="font-size:12px;font-weight:600;color:#5b21b6;display:block;margin-bottom:4px;">NIF</label>
+                    <input type="text" id="compSalesNif" placeholder="Ex: 123456789" maxlength="20"
+                      style="width:100%;border:1.5px solid #ddd8fe;border-radius:8px;padding:8px;font-size:13px;box-sizing:border-box;">
+                  </div>
+                </div>
+                <div id="compSalesFaturadoRow" style="display:none;align-items:center;gap:8px;">
+                  <input type="checkbox" id="compSalesFaturado"
+                    style="width:16px;height:16px;accent-color:#059669;cursor:pointer;">
+                  <label for="compSalesFaturado" style="font-size:13px;font-weight:700;color:#065f46;cursor:pointer;">✅ Faturado no programa</label>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- LINHA 10: Estado do Agendamento -->
           <div class="form-group" style="margin-bottom:20px;">
             <label style="font-weight:700;font-size:13px;color:#374151;margin-bottom:8px;display:block;">Estado do Agendamento *</label>

--- a/mycar.html
+++ b/mycar.html
@@ -811,8 +811,8 @@ function renderTable(groups) {
         </td>
         <td class="col-glass">${(function(){
           const gs = g.glass_status;
-          const col = gs === 'ST' ? '#10b981' : gs === 'VE' ? '#f59e0b' : gs === 'NE' ? '#ef4444' : '#d1d5db';
-          const lbl = gs === 'ST' ? 'ST' : gs === 'VE' ? 'V/E' : gs === 'NE' ? 'N/E' : '—';
+          const col = gs === 'ST' ? '#10b981' : gs === 'VE' ? '#f59e0b' : '#ef4444';
+          const lbl = gs === 'ST' ? 'ST' : gs === 'VE' ? 'V/E' : 'N/E';
           return `<div style="display:flex;flex-direction:column;align-items:center;gap:3px">
             <span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${col};flex-shrink:0"></span>
             ${g.apt_order_ref ? `<span style="font-size:.72rem;font-weight:700;color:#374151;white-space:nowrap">📦 ${g.apt_order_ref}</span>` : `<span style="font-size:.72rem;color:#9ca3af">${lbl}</span>`}

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -52,6 +52,13 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS reception_ref TEXT`);
   } catch(migErr) { console.warn('Migration reception_ref warning:', migErr.message); }
 
+  try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_desc TEXT`);
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_nif VARCHAR(20)`);
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_name VARCHAR(255)`);
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_faturado BOOLEAN DEFAULT FALSE`);
+  } catch(migErr) { console.warn('Migration comp_sales warning:', migErr.message); }
+
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
@@ -134,7 +141,9 @@ exports.handler = async (event) => {
                  a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
                  a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
                  a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
-                 a.order_ref, a.glass_eurocode, a.reception_ref, a.created_at, a.updated_at, a.not_done_at, a.portal_id,
+                 a.order_ref, a.glass_eurocode, a.reception_ref,
+                 a.comp_sales_desc, a.comp_sales_nif, a.comp_sales_name, a.comp_sales_faturado,
+                 a.created_at, a.updated_at, a.not_done_at, a.portal_id,
                  p.name AS portal_name
           FROM appointments a
           LEFT JOIN portals p ON p.id = a.portal_id
@@ -175,7 +184,9 @@ exports.handler = async (event) => {
                calibration, first_of_day, second_of_day, not_done_reason, commercial_user_id,
                return_km, return_time, client_name, damage_details, glass_removed, glass_removed_date,
                custom_service_time, foreign_plate, extra_services, n_obra,
-               order_ref, glass_eurocode, reception_ref, created_at, updated_at, not_done_at
+               order_ref, glass_eurocode, reception_ref,
+               comp_sales_desc, comp_sales_nif, comp_sales_name, comp_sales_faturado,
+               created_at, updated_at, not_done_at
         FROM appointments
         WHERE portal_id = $1
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
@@ -211,9 +222,10 @@ exports.handler = async (event) => {
           vehicle_type, travel_time, confirmed, calibration, first_of_day, second_of_day,
           not_done_reason, commercial_user_id, return_km, return_time, client_name, damage_details,
           glass_removed_date, custom_service_time, foreign_plate, extra_services, n_obra,
-          order_ref, glass_eurocode, portal_id, created_at, updated_at
+          order_ref, glass_eurocode, portal_id, created_at, updated_at,
+          comp_sales_desc, comp_sales_nif, comp_sales_name, comp_sales_faturado
         ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40
         ) RETURNING *
       `;
       const v = [
@@ -240,7 +252,11 @@ exports.handler = async (event) => {
         data.n_obra || null,
         data.order_ref || null,
         data.glass_eurocode || data.eurocode || null,
-        portalId, createdAt, new Date().toISOString()
+        portalId, createdAt, new Date().toISOString(),
+        data.comp_sales_desc || null,
+        data.comp_sales_nif || null,
+        data.comp_sales_name || null,
+        data.comp_sales_faturado === true
       ];
       const { rows } = await pool.query(q, v);
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
@@ -290,7 +306,8 @@ exports.handler = async (event) => {
           executed = $18, confirmed = $19, calibration = $20,
           first_of_day = $21, second_of_day = $22, not_done_reason = $23, commercial_user_id = $24,
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
-          glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36, reception_ref = $37
+          glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36, reception_ref = $37,
+          comp_sales_desc = $38, comp_sales_nif = $39, comp_sales_name = $40, comp_sales_faturado = $41
         WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
@@ -321,7 +338,11 @@ exports.handler = async (event) => {
         data.glass_removed_date !== undefined ? (data.glass_removed_date || null) : (existing.glass_removed_date || null),
         data.n_obra !== undefined ? (data.n_obra || null) : null,
         new Date().toISOString(), id, effectivePortalId, notDoneAtVal,
-        data.reception_ref !== undefined ? (data.reception_ref || null) : null
+        data.reception_ref !== undefined ? (data.reception_ref || null) : null,
+        data.comp_sales_desc !== undefined ? (data.comp_sales_desc || null) : null,
+        data.comp_sales_nif !== undefined ? (data.comp_sales_nif || null) : null,
+        data.comp_sales_name !== undefined ? (data.comp_sales_name || null) : null,
+        data.comp_sales_faturado !== undefined ? (!!data.comp_sales_faturado) : false
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };

--- a/script-tail.js
+++ b/script-tail.js
@@ -71,6 +71,11 @@ const telBtn = phone ? `
       ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
     </div>` : '';
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
+  const compSalesBadge = a.comp_sales_desc
+    ? (a.comp_sales_faturado
+        ? `<div style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:rgba(5,150,105,0.15);border-radius:6px;padding:2px 8px;font-size:11px;font-weight:800;color:#d1fae5;">✅ Venda faturada</div>`
+        : `<div style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:rgba(124,58,237,0.18);border-radius:6px;padding:2px 8px;font-size:11px;font-weight:800;color:#ede9fe;">💰 Venda complementar</div>`)
+    : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');
   const phcFooter = isAutoImported ? `
@@ -165,6 +170,7 @@ const telBtn = phone ? `
         ${a.commercial_user_id ? `<div style="display:inline-block;background:#7c3aed !important;color:#fff !important;font-size:11px;font-weight:800;padding:3px 10px;border-radius:12px;margin-bottom:4px;animation:blink 1.5s infinite;">🤝 COMERCIAL</div>` : ''}
         ${notes}
         ${damageRow}
+        ${compSalesBadge}
         ${preAgendadoM ? `<span class="pre-agendado-badge">⏳ Aguarda confirmação</span>` : ''}
         ${preAgendadoM
           ? `<div class="m-pending-confirm">⏳ Aguarda confirmação do coordenador</div>`
@@ -826,6 +832,27 @@ function setConfirmed(value) {
 }
 
 
+function toggleCompSales(show) {
+  const fields = document.getElementById('compSalesFields');
+  if (fields) fields.style.display = show ? 'block' : 'none';
+  if (!show) {
+    ['compSalesDesc','compSalesName','compSalesNif'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.value = '';
+    });
+    const fatEl = document.getElementById('compSalesFaturado');
+    if (fatEl) fatEl.checked = false;
+  }
+}
+
+function _syncCompSalesFaturadoVisibility() {
+  const row = document.getElementById('compSalesFaturadoRow');
+  if (!row) return;
+  const role = window.authClient?.getUser?.()?.role;
+  const canFaturar = role === 'admin' || role === 'coordenador' || role === 'coordinator';
+  row.style.display = canFaturar ? 'flex' : 'none';
+}
+
 function _injectLocalityFirstOverlay() {
   var existing = document.getElementById('localityFirstOverlay');
   if (existing) existing.remove();
@@ -1029,7 +1056,14 @@ function bootApp() {
         ? (parseInt(document.getElementById('appointmentCustomTime')?.value) || null)
         : null,
       foreign_plate: document.getElementById('foreignPlate')?.checked || false,
-      extra_services: typeof _readExtraServices === 'function' ? _readExtraServices() : []
+      extra_services: typeof _readExtraServices === 'function' ? _readExtraServices() : [],
+      comp_sales_desc: document.getElementById('hasCompSales')?.checked
+        ? ((document.getElementById('compSalesDesc')?.value || '').trim() || null) : null,
+      comp_sales_nif: document.getElementById('hasCompSales')?.checked
+        ? ((document.getElementById('compSalesNif')?.value || '').trim() || null) : null,
+      comp_sales_name: document.getElementById('hasCompSales')?.checked
+        ? ((document.getElementById('compSalesName')?.value || '').trim() || null) : null,
+      comp_sales_faturado: document.getElementById('compSalesFaturado')?.checked || false
     };
   }
 
@@ -1185,6 +1219,8 @@ cancelEdit?.();
       selectedDot.style.backgroundColor = '';
     }
     applyLojaModalMode();
+    toggleCompSales(false);
+    _syncCompSalesFaturadoVisibility();
     document.getElementById('appointmentModal').classList.add('show');
     if (!isLoja()) {
       setTimeout(() => _injectLocalityFirstOverlay(), 50);

--- a/script.js
+++ b/script.js
@@ -2303,6 +2303,25 @@ function editAppointment(id) {
   if (document.getElementById('appointmentDamageDetails')) {
     document.getElementById('appointmentDamageDetails').value = appointment.damage_details || '';
   }
+
+  // Vendas complementares
+  const hasCS = !!(appointment.comp_sales_desc);
+  const hasCompSalesCb = document.getElementById('hasCompSales');
+  if (hasCompSalesCb) {
+    hasCompSalesCb.checked = hasCS;
+    if (typeof toggleCompSales === 'function') toggleCompSales(hasCS);
+  }
+  if (hasCS) {
+    const el = document.getElementById('compSalesDesc');
+    if (el) el.value = appointment.comp_sales_desc || '';
+    const elName = document.getElementById('compSalesName');
+    if (elName) elName.value = appointment.comp_sales_name || '';
+    const elNif = document.getElementById('compSalesNif');
+    if (elNif) elNif.value = appointment.comp_sales_nif || '';
+    const elFat = document.getElementById('compSalesFaturado');
+    if (elFat) elFat.checked = !!appointment.comp_sales_faturado;
+  }
+  if (typeof _syncCompSalesFaturadoVisibility === 'function') _syncCompSalesFaturadoVisibility();
   
   // Preencher campo de quilómetros se existir
   const kmValue = getKmValue(appointment);
@@ -2612,6 +2631,8 @@ function buildDesktopCard(a){
       </div>
       ${sub ? `<div class="dc-sub">${sub}</div>` : ''}
       ${a.damage_details ? `<div class="dc-sub" style="margin-top:3px;font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : ''}
+      ${a.comp_sales_desc && !a.comp_sales_faturado ? `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:4px;background:rgba(124,58,237,0.18);border-radius:6px;padding:2px 8px;font-size:11px;font-weight:800;color:#ede9fe;">💰 Venda complementar</div>` : ''}
+      ${a.comp_sales_desc && a.comp_sales_faturado ? `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:4px;background:rgba(5,150,105,0.15);border-radius:6px;padding:2px 8px;font-size:11px;font-weight:800;color:#d1fae5;">✅ Venda faturada</div>` : ''}
       ${preAgendadoBadge}
       ${confirmBtn}
       ${locWarning}


### PR DESCRIPTION
## Summary

- New collapsible "💰 Venda complementar" section in the appointment modal
- Fields: sale description, client name, NIF
- "Faturado no programa" checkbox — only visible to coordinators and admins
- Cards show a purple badge **💰 Venda complementar** when pending invoice
- Cards show a green badge **✅ Venda faturada** after marking as invoiced
- DB: 4 new columns auto-migrated (`comp_sales_desc`, `comp_sales_nif`, `comp_sales_name`, `comp_sales_faturado`)

## Test plan
- [ ] Open appointment modal — verify "💰 Venda complementar" checkbox appears
- [ ] Check the checkbox — verify desc/name/NIF fields expand
- [ ] Save — verify data persists when reopening the appointment
- [ ] As coordinator: verify "Faturado no programa" checkbox is visible
- [ ] As technician: verify "Faturado no programa" is hidden
- [ ] Card shows purple badge when comp sales is pending
- [ ] Card shows green badge after marking as faturado

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_