### PR TITLE
Replace Relatório button with Vendas Complementares panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
       <div class="nav-right">
         <button id="calculateRoutes" class="nav-button" style="color:#fbbf24;" title="Otimizar rotas por proximidade">🗺️ Calcular Rotas</button>
         <button id="btnRotaDoDiaDesk" class="nav-button" style="background:#16a34a;color:#fbbf24;" title="Ver rota do dia no Google Maps">📍 Ver Rota</button>
-        <button id="btnRelatorioDesk" class="nav-button" style="color:#fbbf24;" title="Relatório semanal">📊 Relatório</button>
+        <button id="btnVendasComplDesk" class="nav-button" onclick="openVendasComplPanel()" style="color:#fbbf24;position:relative;" title="Vendas Complementares">💰 Vendas Compl.<span id="vendasComplBadgeDesk" style="display:none;position:absolute;top:-5px;right:-5px;min-width:18px;height:18px;background:#ef4444;color:#fff;border-radius:9px;font-size:11px;font-weight:700;line-height:18px;text-align:center;padding:0 3px;"></span></button>
         <button id="btnTimelineDesk" class="nav-button" style="background:#7c3aed;color:#fbbf24;" title="Timeline do dia">⏱️ Timeline</button>
         <button id="btnVidrosRetirados" class="nav-button" style="background:#f59e0b;color:#fff;font-weight:700;" title="Ver vidros retirados">🪟 Vidros Retirados</button>
 
@@ -271,9 +271,10 @@
           </button>
         </div>
         <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
-          <button id="btnRelatorio" class="m-report-btn" style="color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
-            Relatório
+          <button id="btnVendasCompl" class="m-report-btn" onclick="openVendasComplPanel()" style="color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;position:relative;">
+            💰
+            <span id="vendasComplBadge" style="display:none;position:absolute;top:-4px;right:-4px;min-width:16px;height:16px;background:#ef4444;color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:16px;text-align:center;padding:0 2px;"></span>
+            Vendas
           </button>
           <button id="calculateRoutesMobile" class="m-report-btn" style="background:#1d4ed8;color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="3 11 22 2 13 21 11 13 3 11"></polygon></svg>
@@ -706,8 +707,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-03d"></script>
-  <script src="script-tail.js?v=2026-06-03d"></script>
+  <script src="script.js?v=2026-06-03e"></script>
+  <script src="script-tail.js?v=2026-06-03e"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -960,6 +960,100 @@ function _syncCompSalesFaturadoVisibility() {
   row.style.display = canFaturar ? 'flex' : 'none';
 }
 
+function _updateVendasComplBadge() {
+  const pendingCount = (window.appointments || []).filter(function(a) {
+    return a.comp_sales_desc && !a.comp_sales_faturado;
+  }).length;
+  ['vendasComplBadge', 'vendasComplBadgeDesk'].forEach(function(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    if (pendingCount > 0) {
+      el.textContent = pendingCount;
+      el.style.display = 'inline-block';
+    } else {
+      el.style.display = 'none';
+    }
+  });
+}
+
+function openVendasComplPanel() {
+  var existing = document.getElementById('vendasComplPanel');
+  if (existing) existing.remove();
+
+  var role = window.authClient?.getUser?.()?.role;
+  var canFaturar = role === 'admin' || role === 'coordenador' || role === 'coordinator';
+
+  var appts = (window.appointments || []).filter(function(a) { return !!a.comp_sales_desc; });
+  appts.sort(function(a, b) {
+    // pending first, then by plate
+    var ap = (!a.comp_sales_faturado) ? 0 : 1;
+    var bp = (!b.comp_sales_faturado) ? 0 : 1;
+    if (ap !== bp) return ap - bp;
+    return (a.plate || '').localeCompare(b.plate || '');
+  });
+
+  var rows = '';
+  if (appts.length === 0) {
+    rows = '<tr><td colspan="' + (canFaturar ? '5' : '4') + '" style="text-align:center;padding:24px;color:#94a3b8;font-style:italic;">Sem vendas complementares registadas</td></tr>';
+  } else {
+    appts.forEach(function(a) {
+      var faturado = !!a.comp_sales_faturado;
+      var badge = faturado
+        ? '<span style="background:#059669;color:#fff;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:700;">✅ Faturado</span>'
+        : '<span style="background:#d97706;color:#fff;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:700;">⏳ Pendente</span>';
+      var actionBtn = '';
+      if (canFaturar && !faturado) {
+        actionBtn = '<button onclick="vendasComplMarkFaturado(\'' + a.id + '\')" style="background:#059669;color:#fff;border:none;border-radius:8px;padding:4px 10px;font-size:12px;font-weight:700;cursor:pointer;">✅ Faturar</button>';
+      }
+      rows += '<tr style="border-bottom:1px solid rgba(255,255,255,0.06);">'
+        + '<td style="padding:8px 10px;font-weight:700;color:#fbbf24;">' + (a.plate || '—') + '</td>'
+        + '<td style="padding:8px 10px;max-width:200px;word-break:break-word;">' + (a.comp_sales_desc || '—') + '</td>'
+        + '<td style="padding:8px 10px;">' + (a.comp_sales_name || '—') + '<br><span style="font-size:11px;color:#94a3b8;">' + (a.comp_sales_nif || '') + '</span></td>'
+        + '<td style="padding:8px 10px;">' + badge + '</td>'
+        + (canFaturar ? '<td style="padding:8px 10px;">' + actionBtn + '</td>' : '')
+        + '</tr>';
+    });
+  }
+
+  var panel = document.createElement('div');
+  panel.id = 'vendasComplPanel';
+  panel.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.7);padding:16px;box-sizing:border-box;';
+  panel.innerHTML = '<div style="background:#1e293b;border-radius:16px;width:100%;max-width:700px;max-height:80vh;display:flex;flex-direction:column;box-shadow:0 20px 60px rgba(0,0,0,0.5);">'
+    + '<div style="display:flex;align-items:center;justify-content:space-between;padding:16px 20px;border-bottom:1px solid rgba(255,255,255,0.1);">'
+    + '<h3 style="margin:0;color:#fff;font-size:16px;">💰 Vendas Complementares</h3>'
+    + '<button onclick="document.getElementById(\'vendasComplPanel\').remove()" style="background:none;border:none;color:#94a3b8;font-size:20px;cursor:pointer;line-height:1;">✕</button>'
+    + '</div>'
+    + '<div style="overflow-y:auto;flex:1;">'
+    + '<table style="width:100%;border-collapse:collapse;color:#e2e8f0;font-size:13px;">'
+    + '<thead><tr style="background:rgba(255,255,255,0.05);"><th style="padding:8px 10px;text-align:left;font-weight:600;color:#94a3b8;">Matrícula</th><th style="padding:8px 10px;text-align:left;font-weight:600;color:#94a3b8;">Descrição</th><th style="padding:8px 10px;text-align:left;font-weight:600;color:#94a3b8;">Cliente / NIF</th><th style="padding:8px 10px;text-align:left;font-weight:600;color:#94a3b8;">Estado</th>' + (canFaturar ? '<th style="padding:8px 10px;"></th>' : '') + '</tr></thead>'
+    + '<tbody>' + rows + '</tbody>'
+    + '</table>'
+    + '</div>'
+    + '</div>';
+
+  panel.addEventListener('click', function(e) { if (e.target === panel) panel.remove(); });
+  document.body.appendChild(panel);
+}
+
+async function vendasComplMarkFaturado(id) {
+  var appt = (window.appointments || []).find(function(a) { return String(a.id) === String(id); });
+  if (!appt) return;
+  var btn = document.querySelector('[onclick="vendasComplMarkFaturado(\'' + id + '\')"]');
+  if (btn) { btn.disabled = true; btn.textContent = '...'; }
+  try {
+    var updated = Object.assign({}, appt, { comp_sales_faturado: true });
+    await window.apiClient.updateAppointment(id, updated);
+    var idx = (window.appointments || []).findIndex(function(a) { return String(a.id) === String(id); });
+    if (idx !== -1) window.appointments[idx].comp_sales_faturado = true;
+    if (typeof renderAll === 'function') renderAll();
+    document.getElementById('vendasComplPanel')?.remove();
+    openVendasComplPanel();
+  } catch(e) {
+    if (btn) { btn.disabled = false; btn.textContent = '✅ Faturar'; }
+    alert('Erro ao atualizar: ' + e.message);
+  }
+}
+
 function _injectLocalityFirstOverlay() {
   var existing = document.getElementById('localityFirstOverlay');
   if (existing) existing.remove();
@@ -1050,16 +1144,7 @@ function bootApp() {
   });
   document.getElementById('calculateRoutesMobile')?.addEventListener('click', calculateAllRoutesFromToday);
 
-  // ── Relatório semanal (mobile + desktop) ──
-  const openRelatorio = () => {
-    buildRelatorio();
-    document.getElementById('relatorioModal')?.classList.add('show');
-  };
-  document.getElementById('btnRelatorio')?.addEventListener('click', openRelatorio);
-  document.getElementById('btnRelatorioDesk')?.addEventListener('click', openRelatorio);
-  document.getElementById('closeRelatorio')?.addEventListener('click', () => {
-    document.getElementById('relatorioModal')?.classList.remove('show');
-  });
+  // Vendas Complementares badge/panel buttons wired via onclick in HTML
 
   // Event listeners para edição
   document.getElementById('cancelForm')?.addEventListener('click', cancelEdit);
@@ -2421,6 +2506,7 @@ document.addEventListener('DOMContentLoaded', function() {
         window.renderAll = function() {
           origRA.apply(this, arguments);
           checkNotifications();
+          _updateVendasComplBadge();
         };
       }
     }, 800);
@@ -2428,6 +2514,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Also check once on initial load after appointments are available
   setTimeout(checkNotifications, 3000);
+  setTimeout(_updateVendasComplBadge, 3500);
 })();
 
 // ===== Filter bar logic =====


### PR DESCRIPTION
## Summary
- Removes the 📊 Relatório button from desktop and mobile toolbars
- Adds 💰 Vendas Compl. button with a red badge showing count of pending (unfaturado) comp sales
- Clicking opens a panel listing all appointments with comp sales by plate: description, client name/NIF, status
- Coordinators/admins see ✅ Faturar button per row to mark inline without opening the full appointment modal
- Badge updates on every renderAll call and after initial load

## Test plan
- [ ] Verify Relatório button is gone from desktop and mobile
- [ ] Add a comp sale via appointment modal and confirm badge appears on the button
- [ ] Open panel — confirm the row is listed with plate, description, client, and ⏳ Pendente badge
- [ ] Click ✅ Faturar — confirm status changes to ✅ Faturado and badge count decreases
- [ ] Technician role: confirm no Faturar button appears in panel

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_