### PR TITLE
Fix glass reception card showing locality instead of store name

### DIFF
--- a/index.html
+++ b/index.html
@@ -1498,7 +1498,7 @@
           <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
         </div>
         <div style="display:flex;gap:16px;font-size:12px;color:#64748b;flex-wrap:wrap;">
-          <span>🏪 ${a.portal_name || a.locality || window.portalConfig?.name || '—'}</span>
+          <span>🏪 ${a.portal_name || window.portalConfig?.name || '—'}</span>
           <span>🔧 ${a.service || '—'}</span>
           ${a.date ? `<span>📅 ${fmtDate(a.date)}</span>` : '<span style="color:#f59e0b;">Sem data</span>'}
         </div>


### PR DESCRIPTION
## Summary
- Removes `a.locality` from the store name fallback in the glass reception result card
- Local appointments don't have `portal_name` from a cross-portal JOIN, so now correctly falls back to `window.portalConfig.name` (the current store name, e.g. "Braga SM") instead of the service locality (e.g. "Guimarães")

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_