### PR TITLE
Fix store filter: exclusive select with card re-render

### DIFF
--- a/index.html
+++ b/index.html
@@ -1491,19 +1491,53 @@
 
     const safeRawForCard = (rawText||'').substring(0,200).replace(/'/g,"\\'").replace(/"/g,'&quot;');
 
-    // Build unique store list for filter
+    // Store appts globally for filter re-render
     const storeNames = [...new Set(appts.map(a => a.portal_name || window.portalConfig?.name || '—'))];
     const multiStore = storeNames.length > 1;
-    // All stores active by default
-    window._grActiveStores = new Set(storeNames);
+    window._grAllAppts = appts;
+    window._grRawForCard = safeRawForCard;
+    window._grOrderRef = orderRef;
+    window._grEurocode = eurocode;
+    window._grRawText = rawText;
+    window._grActiveStore = null; // null = show all
+
+    function buildCardsHtml(filtered) {
+      if (!filtered.length) return '<p style="color:#94a3b8;text-align:center;padding:20px;font-style:italic;">Nenhum serviço nesta loja.</p>';
+      return filtered.map(a => {
+        const storeName = a.portal_name || window.portalConfig?.name || '—';
+        const executedBadge = a.executed
+          ? '<span style="background:#dcfce7;color:#166534;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">✅ Realizado</span>'
+          : '<span style="background:#fef3c7;color:#92400e;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">⏳ Por realizar</span>';
+        const safeId = String(a.id);
+        const safeOrderRef2 = (orderRef||'').replace(/'/g,"\\'");
+        const safeEuro2 = (eurocode||'').replace(/'/g,"\\'");
+        return `
+        <div style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
+             onmouseenter="this.style.borderColor='#2563eb'" onmouseleave="this.style.borderColor='#e2e8f0'"
+             onclick="window.glassReception._showConfirm('${safeId}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${safeOrderRef2}','${safeEuro2}','${safeRawForCard}')">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap;">
+            <span style="font-family:monospace;font-weight:800;font-size:15px;background:#0f172a;color:#fff;padding:4px 10px;border-radius:6px;">${(a.plate||'').toUpperCase()}</span>
+            <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
+            ${executedBadge}
+          </div>
+          <div style="display:flex;gap:12px;font-size:12px;color:#64748b;flex-wrap:wrap;margin-bottom:4px;">
+            <span>🏪 ${storeName}</span>
+            ${a.date ? `<span>📅 ${fmtDate(a.date)}</span>` : '<span style="color:#f59e0b;">Sem data</span>'}
+          </div>
+          ${a.service ? `<div style="font-size:12px;color:#374151;font-weight:600;">🔧 ${a.service}</div>` : ''}
+          ${a.notes ? `<div style="font-size:11px;color:#94a3b8;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">📝 ${a.notes}</div>` : ''}
+          <div style="margin-top:8px;font-size:11px;font-weight:700;color:#2563eb;">Selecionar →</div>
+        </div>`;
+      }).join('');
+    }
 
     const storeFilterHtml = multiStore ? `
       <div style="margin-bottom:12px;">
-        <div style="font-size:11px;font-weight:700;color:#64748b;margin-bottom:6px;">Filtrar por loja:</div>
-        <div style="display:flex;flex-wrap:wrap;gap:6px;">
+        <div style="font-size:11px;font-weight:700;color:#64748b;margin-bottom:6px;">Mostrar só esta loja (toca para filtrar):</div>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;" id="grStoreChips">
           ${storeNames.map(s => `
             <button data-gr-store-btn="${s.replace(/"/g,'&quot;')}" onclick="window.glassReception._toggleStoreFilter('${s.replace(/'/g,"\\'")}')"
-              style="background:#0f172a;color:#fff;border:none;border-radius:20px;padding:5px 12px;font-size:12px;font-weight:700;cursor:pointer;transition:background .15s;">
+              style="background:#e2e8f0;color:#374151;border:none;border-radius:20px;padding:5px 12px;font-size:12px;font-weight:600;cursor:pointer;transition:all .15s;">
               🏪 ${s}
             </button>
           `).join('')}
@@ -1511,18 +1545,51 @@
       </div>
     ` : '';
 
-    const cardsHtml = appts.map(a => {
+    body.innerHTML = infoHtml + `
+      <p style="font-size:13px;font-weight:700;color:#374151;margin-bottom:10px;">Seleciona o processo para este vidro:</p>
+      ${storeFilterHtml}
+      <div id="grCardsList">${buildCardsHtml(appts)}</div>
+      <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;margin-top:4px;width:100%;">← Voltar</button>
+    `;
+  }
+
+  function _toggleStoreFilter(storeName) {
+    if (!window._grAllAppts) return;
+    // Exclusive: click → show only this store. Click same again → show all.
+    window._grActiveStore = (window._grActiveStore === storeName) ? null : storeName;
+
+    // Update chip styles: active chip = dark, others = grey
+    document.querySelectorAll('[data-gr-store-btn]').forEach(btn => {
+      const s = btn.getAttribute('data-gr-store-btn');
+      const active = (window._grActiveStore === null || window._grActiveStore === s);
+      btn.style.background = (window._grActiveStore === s) ? '#2563eb' : (window._grActiveStore === null ? '#e2e8f0' : '#e2e8f0');
+      btn.style.color = (window._grActiveStore === s) ? '#fff' : '#374151';
+      btn.style.fontWeight = (window._grActiveStore === s) ? '700' : '600';
+      btn.style.opacity = (!window._grActiveStore || window._grActiveStore === s) ? '1' : '0.45';
+    });
+
+    // Re-render cards
+    const filtered = window._grActiveStore
+      ? window._grAllAppts.filter(a => (a.portal_name || window.portalConfig?.name || '—') === window._grActiveStore)
+      : window._grAllAppts;
+    const list = document.getElementById('grCardsList');
+    if (!list) return;
+    const safeRawForCard = (window._grRawText||'').substring(0,200).replace(/'/g,"\\'").replace(/"/g,'&quot;');
+    const orderRef = window._grOrderRef || '';
+    const eurocode = window._grEurocode || '';
+    if (!filtered.length) {
+      list.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:20px;font-style:italic;">Nenhum serviço nesta loja.</p>';
+      return;
+    }
+    list.innerHTML = filtered.map(a => {
       const storeName = a.portal_name || window.portalConfig?.name || '—';
       const executedBadge = a.executed
         ? '<span style="background:#dcfce7;color:#166534;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">✅ Realizado</span>'
         : '<span style="background:#fef3c7;color:#92400e;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">⏳ Por realizar</span>';
-      const safeId = String(a.id);
-      const safeOrderRef = (orderRef||'').replace(/'/g,"\\'");
-      const safeEuro = (eurocode||'').replace(/'/g,"\\'");
       return `
-      <div data-gr-card-store="${storeName.replace(/"/g,'&quot;')}" style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
+      <div style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
            onmouseenter="this.style.borderColor='#2563eb'" onmouseleave="this.style.borderColor='#e2e8f0'"
-           onclick="window.glassReception._showConfirm('${safeId}','${(a.plate||'').replace(/'/g,"\\'")}','${a.car||''}','${storeName.replace(/'/g,"\\'")}','${a.service||''}','${a.date||''}',${!!a.executed},'${safeOrderRef}','${safeEuro}','${safeRawForCard}')">
+           onclick="window.glassReception._showConfirm('${String(a.id)}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${orderRef.replace(/'/g,"\\'")}','${eurocode.replace(/'/g,"\\'")}','${safeRawForCard}')">
         <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap;">
           <span style="font-family:monospace;font-weight:800;font-size:15px;background:#0f172a;color:#fff;padding:4px 10px;border-radius:6px;">${(a.plate||'').toUpperCase()}</span>
           <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
@@ -1535,40 +1602,8 @@
         ${a.service ? `<div style="font-size:12px;color:#374151;font-weight:600;">🔧 ${a.service}</div>` : ''}
         ${a.notes ? `<div style="font-size:11px;color:#94a3b8;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">📝 ${a.notes}</div>` : ''}
         <div style="margin-top:8px;font-size:11px;font-weight:700;color:#2563eb;">Selecionar →</div>
-      </div>
-    `}).join('');
-
-    body.innerHTML = infoHtml + `
-      <p style="font-size:13px;font-weight:700;color:#374151;margin-bottom:10px;">Seleciona o processo para este vidro:</p>
-      ${storeFilterHtml}
-      <div id="grCardsList">
-        ${cardsHtml}
-      </div>
-      <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;margin-top:4px;width:100%;">← Voltar</button>
-    `;
-  }
-
-  function _toggleStoreFilter(storeName) {
-    if (!window._grActiveStores) return;
-    if (window._grActiveStores.has(storeName)) {
-      // Don't allow deselecting the last active store
-      if (window._grActiveStores.size <= 1) return;
-      window._grActiveStores.delete(storeName);
-    } else {
-      window._grActiveStores.add(storeName);
-    }
-    // Update chip styles
-    document.querySelectorAll('[data-gr-store-btn]').forEach(btn => {
-      const s = btn.getAttribute('data-gr-store-btn');
-      const active = window._grActiveStores.has(s);
-      btn.style.background = active ? '#0f172a' : '#e2e8f0';
-      btn.style.color = active ? '#fff' : '#64748b';
-    });
-    // Show/hide cards
-    document.querySelectorAll('[data-gr-card-store]').forEach(card => {
-      const s = card.getAttribute('data-gr-card-store');
-      card.style.display = window._grActiveStores.has(s) ? '' : 'none';
-    });
+      </div>`;
+    }).join('');
   }
 
   function _showConfirm(appointmentId, plate, car, storeName, service, date, executed, orderRef, eurocode, rawText) {


### PR DESCRIPTION
## Summary
- Store filter now uses **exclusive select**: tap a chip → show ONLY that store's cards
- Tap the same chip again → reset to show all stores
- Active chip turns blue; other chips fade to 45% opacity for clear visual feedback
- Cards are re-rendered on filter change (no more display:none manipulation that was unreliable)

## Test plan
- [ ] Multiple store results → tap one chip → only that store's cards appear
- [ ] Tap the same chip again → all cards reappear
- [ ] Tap a different chip → switches to that store exclusively

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_