### PR TITLE
Propagate glass_eurocode back to appointment on reception scan

### DIFF
--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -192,6 +192,12 @@ exports.handler = async (event) => {
             [d.order_ref, d.appointment_id]
           );
         }
+        if (d.eurocode) {
+          await client.query(
+            `UPDATE appointments SET glass_eurocode = $1 WHERE id = $2 AND (glass_eurocode IS NULL OR glass_eurocode = '')`,
+            [d.eurocode, d.appointment_id]
+          );
+        }
       }
 
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };


### PR DESCRIPTION
## Summary
- When a reception scan is confirmed, `glass_eurocode` from the label is now written back to the appointment (if the field was empty) — same behavior as `order_ref` which was already being propagated
- This means the next scan of the same label will find the appointment directly by eurocode, without relying on notes or manual search

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_