### PR TITLE
Add 'Importar Encomendas' — update-only Excel import mode

### DIFF
--- a/excel-import-ui.js
+++ b/excel-import-ui.js
@@ -350,19 +350,23 @@ async function importData() {
     showToast('Nenhum dado válido para importar', 'error');
     return;
   }
-  
-  showLoading('Importando dados...', `A importar ${processedData.data.length} serviços...`);
-  
+
+  const isOrdersMode = window._importMode === 'orders';
+  const loadingLabel = isOrdersMode ? 'A actualizar encomendas...' : `A importar ${processedData.data.length} serviços...`;
+  showLoading(isOrdersMode ? 'Importando encomendas...' : 'Importando dados...', loadingLabel);
+
   try {
-    const results = await window.excelImporter.importData(processedData.data);
-    
+    const results = isOrdersMode
+      ? await window.excelImporter.importOrdersData(processedData.data)
+      : await window.excelImporter.importData(processedData.data);
+
     // Mostrar resultados
     showImportResults(results);
-    
+
     currentStep = 4;
     hideLoading();
     showStep(4);
-    
+
   } catch (error) {
     hideLoading();
     showToast(`Erro na importação: ${error.message}`, 'error');
@@ -382,10 +386,11 @@ function showImportResults(results) {
   detailsContainer.innerHTML = '';
   
   if (results.details.length > 0) {
-    const successList = results.details.filter(d => d.status === 'success');
+    const successList = results.details.filter(d => d.status === 'success' || d.status === 'updated');
     const errorList = results.details.filter(d => d.status === 'error');
     const skippedList = results.details.filter(d => d.status === 'skipped');
     const deletedList = results.details.filter(d => d.status === 'deleted');
+    const notFoundList = results.details.filter(d => d.status === 'notfound');
     
     if (deletedList.length > 0) {
       const deletedDiv = document.createElement('div');
@@ -397,12 +402,22 @@ function showImportResults(results) {
       detailsContainer.appendChild(deletedDiv);
     }
 
+    if (notFoundList.length > 0) {
+      const nfDiv = document.createElement('div');
+      nfDiv.innerHTML = `
+        <h5 style="color:#6b7280;">🔍 Matrículas não encontradas na plataforma (${notFoundList.length})</h5>
+        <div style="max-height:150px;overflow-y:auto;background:#f3f4f6;padding:10px;border-radius:4px;margin-bottom:15px;">
+          ${notFoundList.map(s => `<div>• ${s.plate}</div>`).join('')}
+        </div>`;
+      detailsContainer.appendChild(nfDiv);
+    }
+
     if (successList.length > 0) {
       const successDiv = document.createElement('div');
       successDiv.innerHTML = `
-        <h5 style="color: #28a745;">✅ Importados com Sucesso (${successList.length})</h5>
+        <h5 style="color: #28a745;">✅ Processos actualizados (${successList.length})</h5>
         <div style="max-height: 150px; overflow-y: auto; background: #d4edda; padding: 10px; border-radius: 4px; margin-bottom: 15px;">
-          ${successList.map(s => `<div>• ${s.plate}</div>`).join('')}
+          ${successList.map(s => `<div>• ${s.plate}${s.reason ? ' — ' + s.reason : ''}</div>`).join('')}
         </div>
       `;
       detailsContainer.appendChild(successDiv);

--- a/excel-import.js
+++ b/excel-import.js
@@ -567,5 +567,59 @@ class ExcelImporter {
   }
 }
 
+  // Importar APENAS encomendas — nunca cria nem apaga, só actualiza campos de encomenda
+  async importOrdersData(processedData) {
+    const results = {
+      success: 0,
+      errors: 0,
+      skipped: 0,
+      notFound: 0,
+      details: []
+    };
+
+    const existingAppointments = window.appointments || [];
+
+    for (const service of processedData) {
+      try {
+        const plateNormalized = String(service.plate).toUpperCase().trim();
+        const existing = existingAppointments.find(a =>
+          String(a.plate).toUpperCase().trim() === plateNormalized
+        );
+
+        if (!existing) {
+          results.notFound++;
+          results.details.push({ plate: service.plate, status: 'notfound', reason: 'Matrícula não encontrada na plataforma' });
+          continue;
+        }
+
+        const updates = {};
+        if (service.order_ref)     updates.order_ref     = service.order_ref;
+        if (service.reception_ref) updates.reception_ref = service.reception_ref;
+        if (service.glass_eurocode) updates.glass_eurocode = service.glass_eurocode;
+        // Derive status: ST if reception_ref, VE if order_ref only, else leave unchanged
+        if (service.reception_ref) updates.status = 'ST';
+        else if (service.order_ref && (!existing.status || existing.status === 'NE')) updates.status = 'VE';
+
+        if (Object.keys(updates).length === 0) {
+          results.skipped++;
+          results.details.push({ plate: service.plate, status: 'skipped', reason: 'Sem dados novos' });
+          continue;
+        }
+
+        await window.apiClient.updateAppointment(existing.id, { ...existing, ...updates });
+        const reasons = Object.entries(updates).map(([k, v]) => `${k}=${v}`).join(', ');
+        results.success++;
+        results.details.push({ plate: service.plate, status: 'updated', reason: reasons });
+
+      } catch (error) {
+        results.errors++;
+        results.details.push({ plate: service.plate, status: 'error', error: error.message });
+      }
+    }
+
+    return results;
+  }
+}
+
 // Instância global
 window.excelImporter = new ExcelImporter();

--- a/index.html
+++ b/index.html
@@ -221,6 +221,7 @@
       </div>
       <div class="unscheduled-actions">
         <button id="importExcelBtn" class="action-btn secondary">📊 Importar Excel</button>
+        <button id="importOrdersBtn" class="action-btn secondary">📦 Importar Encomendas</button>
         <button id="clearAllUnscheduledBtn" class="action-btn danger">🗑️ Limpar Todos</button>
         <select id="filterStatus" class="filter-select">
           <option value="">Todos os estados</option>
@@ -707,8 +708,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-03g"></script>
-  <script src="script-tail.js?v=2026-06-03g"></script>
+  <script src="script.js?v=2026-06-05a"></script>
+  <script src="script-tail.js?v=2026-06-05a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
@@ -719,8 +720,8 @@
   <script src="excel-templates.js?v=2026-04-09"></script>
   <script src="template-personalizado.js?v=2026-04-09"></script>
   <script src="template-expressglass-completo.js?v=2026-04-09"></script>
-  <script src="excel-import.js?v=2026-04-09"></script>
-  <script src="excel-import-ui.js?v=2026-04-09"></script>
+  <script src="excel-import.js?v=2026-06-05a"></script>
+  <script src="excel-import-ui.js?v=2026-06-05a"></script>
   <script src="glass-alert.js?v=2026-04-09"></script>
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
   <script src="incomplete-services-alert.js?v=2026-06-01c"></script>

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -192,6 +192,12 @@ exports.handler = async (event) => {
             [d.order_ref, d.appointment_id]
           );
         }
+        if (d.eurocode) {
+          await client.query(
+            `UPDATE appointments SET glass_eurocode = $1 WHERE id = $2 AND (glass_eurocode IS NULL OR glass_eurocode = '')`,
+            [d.eurocode, d.appointment_id]
+          );
+        }
       }
 
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };

--- a/script-tail.js
+++ b/script-tail.js
@@ -1477,6 +1477,13 @@ cancelEdit?.();
 
   // --- Importar Excel ---
   document.getElementById('importExcelBtn')?.addEventListener('click', () => {
+    window._importMode = 'normal';
+    openExcelImportModal();
+  });
+
+  // --- Importar Encomendas (só actualiza, nunca cria/apaga) ---
+  document.getElementById('importOrdersBtn')?.addEventListener('click', () => {
+    window._importMode = 'orders';
     openExcelImportModal();
   });
   


### PR DESCRIPTION
## Summary
- Adds **📦 Importar Encomendas** button alongside the existing Excel import button
- Same Excel format, but this mode **never creates new appointments and never deletes** anything
- Matches rows by plate (matrícula), updates `order_ref`, `glass_eurocode`, `reception_ref`, and derives `status` (ST if reception_ref, VE if order_ref only)
- Results summary shows: updated plates, skipped (no new data), not found (plate not in platform), errors

## Test plan
- [ ] Click "📦 Importar Encomendas", upload the orders Excel — verify only existing plates are updated, no new rows created, no rows deleted
- [ ] Plates not found in the platform appear in the "not found" summary
- [ ] `order_ref` and `glass_eurocode` are written to existing appointments
- [ ] Normal "📊 Importar Excel" still creates/deletes as before

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_