### PR TITLE
feat: Importar Encomendas also updates glass eurocode from ref column

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1250,15 +1250,16 @@ async function startSyncOrders() {
   const encCol   = importHeaders.findIndex(h => norm(h) === 'numeros_encomendas');
   const recCol   = importHeaders.findIndex(h => norm(h) === 'numeros_rececao_mercadorias');
   const euroCol  = importHeaders.findIndex(h => norm(h) === 'eurocode');
+  const refCol   = importHeaders.findIndex(h => norm(h) === 'ref');
 
-  console.log('[SyncOrders] Colunas detectadas:', { plateCol, encCol, recCol, euroCol, headers: importHeaders });
+  console.log('[SyncOrders] Colunas detectadas:', { plateCol, encCol, recCol, euroCol, refCol, headers: importHeaders });
 
   if (plateCol < 0) {
     showToast(`❌ Coluna "matricula" não encontrada.\nColunas no Excel: ${importHeaders.map((h,i)=>`[${i}] ${h}`).join(', ')}`, 'error');
     return;
   }
-  if (encCol < 0) {
-    showToast(`⚠️ Coluna "numeros_encomendas" não encontrada. Colunas: ${importHeaders.join(', ')}`, 'error');
+  if (encCol < 0 && refCol < 0 && euroCol < 0) {
+    showToast(`⚠️ Nenhuma coluna de encomenda/eurocode encontrada. Colunas: ${importHeaders.join(', ')}`, 'error');
     return;
   }
 
@@ -1310,10 +1311,20 @@ async function startSyncOrders() {
     const orderRef  = encCol >= 0 && row[encCol]  ? String(row[encCol]).trim().replace(/\.0$/, '')  : null;
     const recRef    = recCol >= 0 && row[recCol]   ? String(row[recCol]).trim().replace(/\.0$/, '')  : null;
     const eurocode  = euroCol >= 0 && row[euroCol] ? String(row[euroCol]).trim() : null;
+    const refVal    = refCol  >= 0 && row[refCol]  ? String(row[refCol]).trim()  : null;
 
     if (orderRef)  updates.order_ref      = orderRef;
     if (recRef)    updates.reception_ref  = recRef;
     if (eurocode)  updates.glass_eurocode = eurocode;
+    if (refVal) {
+      // ref column contains glass code(s) shown on card — preserve JSON structure if extra is already JSON
+      const existExtra = existing.extra || '';
+      let extraParsed = null;
+      try { extraParsed = JSON.parse(existExtra); } catch(e) {}
+      updates.extra = (extraParsed && typeof extraParsed === 'object')
+        ? JSON.stringify({ ...extraParsed, eurocode: refVal })
+        : refVal;
+    }
     if (recRef)    updates.status         = 'ST';
     else if (orderRef && (!existing.status || existing.status === 'NE')) updates.status = 'VE';
 
@@ -1329,7 +1340,7 @@ async function startSyncOrders() {
       const json = await resp.json();
       if (json.success || json.data) {
         updated++;
-        console.log(`[SyncOrders] ✅ ${plate} → order_ref=${json.data?.order_ref}`);
+        console.log(`[SyncOrders] ✅ ${plate} → order_ref=${json.data?.order_ref} extra=${json.data?.extra} glass_eurocode=${json.data?.glass_eurocode}`);
       } else {
         errors++;
         console.error(`[SyncOrders] ❌ ${plate} error:`, json);

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05c"></script>
+  <script src="admin-script.js?v=2026-06-05d"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Summary

- Detect `ref` column in the appointments Excel (the same Excel used for all imports)
- Update the `extra` field (the glass code displayed on the card) from the `ref` column — handles records with multiple eurocodes e.g. `5439ASMV;5439AGSBL` (stored as-is, preserving any JSON already in `extra` such as photo_url/history)
- Relax the early-return guard: only abort if **all three** of `numeros_encomendas` / `eurocode` / `ref` columns are missing — so importing just eurocodes from an appointments Excel works without needing the orders column
- Log `extra` and `glass_eurocode` in the per-row success trace for easier debugging

## Test plan

- [ ] Load appointments Excel with `ref` column containing two eurocodes (e.g. `5439ASMV;5439AGSBL`)
- [ ] Click "📦 Importar Encomendas" — card should now show both eurocodes in the glass code area
- [ ] Verify DevTools Console shows `extra=5439ASMV;5439AGSBL` in the success log
- [ ] Verify records with existing JSON in `extra` (photo_url etc.) are preserved

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_