### PR TITLE
fix: pass _portalId in PUT body so admin import stops getting 403

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1283,7 +1283,11 @@ async function startSyncOrders() {
       document.getElementById('importProgressText').textContent = `A carregar portal ${pi + 1}/${portalList.length}...`;
       const resp = await authClient.authenticatedFetch(`/.netlify/functions/appointments?portal_id=${portalList[pi].id}`);
       const json = await resp.json();
-      if (json.success && json.data) allAppts.push(...json.data);
+      if (json.success && json.data) {
+        // Tag each appointment with its portal so the PUT body can include _portalId
+        json.data.forEach(a => a._portalId = portalList[pi].id);
+        allAppts.push(...json.data);
+      }
     }
   } catch (e) {
     showToast('Erro ao carregar processos: ' + e.message, 'error');
@@ -1337,7 +1341,7 @@ async function startSyncOrders() {
       const resp = await authClient.authenticatedFetch(`/.netlify/functions/appointments/${existing.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...existing, ...updates })
+        body: JSON.stringify({ ...existing, ...updates, _portalId: existing._portalId })
       });
       const json = await resp.json();
       if (json.success || json.data) {

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05f"></script>
+  <script src="admin-script.js?v=2026-06-05g"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Root cause

Admin users have no `portalId` in their JWT. The appointments endpoint checks `if (!portalId)` at the top of the handler — before it even reaches the PUT auth logic — and returns 403 "Utilizador sem portal atribuído" for all 34 updates.

## Fix

When fetching appointments portal-by-portal in `startSyncOrders()`, tag each returned appointment with `_portalId = portalList[pi].id`. Then include it in the PUT body. The backend already reads `_portalId` from the body for admin users and uses it to set `portalId`, bypassing the early-return guard.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_