### PR TITLE
fix: show sample of Excel values read for matched plates in import result

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1301,6 +1301,7 @@ async function startSyncOrders() {
   const notFoundPlates = [];
   const updatedDetails = []; // { plate, order_ref, reception_ref, extra }
   const errorDetails = [];   // { plate, msg }
+  const matchedSample = [];  // first 5 matched rows: { plate, encVal, recVal, refVal, euroVal }
 
   const rows = importExcelData.filter(row => row[plateCol]);
   for (let i = 0; i < rows.length; i++) {
@@ -1318,6 +1319,13 @@ async function startSyncOrders() {
     const recRef    = recCol >= 0 && row[recCol]   ? String(row[recCol]).trim().replace(/\.0$/, '')  : null;
     const eurocode  = euroCol >= 0 && row[euroCol] ? String(row[euroCol]).trim() : null;
     const refVal    = refCol  >= 0 && row[refCol]  ? String(row[refCol]).trim()  : null;
+
+    if (matchedSample.length < 5) matchedSample.push({
+      plate,
+      enc: encCol >= 0 ? (row[encCol] != null ? String(row[encCol]) : '(vazio)') : '(col N/A)',
+      rec: recCol >= 0 ? (row[recCol] != null ? String(row[recCol]) : '(vazio)') : '(col N/A)',
+      ref: refCol >= 0 ? (row[refCol] != null ? String(row[refCol]) : '(vazio)') : '(col N/A)',
+    });
 
     if (orderRef)  updates.order_ref      = orderRef;
     if (recRef)    updates.reception_ref  = recRef;
@@ -1393,6 +1401,12 @@ async function startSyncOrders() {
       <strong>Actualizados (${updatedDetails.length}):</strong>
       <div style="margin-top:6px;display:flex;flex-direction:column;gap:3px;max-height:160px;overflow-y:auto;">
         ${updatedDetails.map(d => `<span><strong>${d.plate}</strong> → ${[d.order_ref ? '📦 '+d.order_ref : '', d.reception_ref ? '✅ '+d.reception_ref : '', d.extra ? '🔲 '+d.extra : ''].filter(Boolean).join(', ') || '(sem dados)'}</span>`).join('')}
+      </div>
+    </div>` : ''}
+    ${matchedSample.length ? `<div style="margin-top:10px;padding:10px 14px;background:#f5f3ff;border-radius:8px;font-size:11px;color:#5b21b6;font-family:monospace;">
+      <strong>Amostra de matrículas encontradas (primeiras ${matchedSample.length}):</strong>
+      <div style="margin-top:6px;display:flex;flex-direction:column;gap:3px;">
+        ${matchedSample.map(d => `<span><strong>${d.plate}</strong> → encomenda: <em>${d.enc}</em> | receção: <em>${d.rec}</em> | ref: <em>${d.ref}</em></span>`).join('')}
       </div>
     </div>` : ''}
     ${errorDetails.length ? `<div style="margin-top:10px;padding:10px 14px;background:#fef2f2;border-radius:8px;font-size:12px;color:#dc2626;">

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05g"></script>
+  <script src="admin-script.js?v=2026-06-05h"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Summary

Adds a purple diagnostic box in the import result showing the first 5 matched plates with the raw values read from `encomenda`, `receção`, and `ref` columns. Makes it immediately visible whether `numeros_encomendas` column (index 27) is empty or actually has the order number for those rows.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_