### PR TITLE
fix: remove sinistro from matched sample display

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1403,7 +1403,7 @@ async function startSyncOrders() {
     ${matchedSample.length ? `<div style="margin-top:10px;padding:10px 14px;background:#f5f3ff;border-radius:8px;font-size:11px;color:#5b21b6;font-family:monospace;">
       <strong>Amostra de matrículas encontradas (primeiras ${matchedSample.length}):</strong>
       <div style="margin-top:6px;display:flex;flex-direction:column;gap:3px;">
-        ${matchedSample.map(d => `<span><strong>${d.plate}</strong> → sinistro: <em>${d.sinistro}</em> | encomenda: <em>${d.enc}</em> | receção: <em>${d.rec}</em> | ref: <em>${d.ref}</em></span>`).join('')}
+        ${matchedSample.map(d => `<span><strong>${d.plate}</strong> → encomenda: <em>${d.enc}</em> | receção: <em>${d.rec}</em> | ref: <em>${d.ref}</em></span>`).join('')}
       </div>
     </div>` : ''}
     ${errorDetails.length ? `<div style="margin-top:10px;padding:10px 14px;background:#fef2f2;border-radius:8px;font-size:12px;color:#dc2626;">

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05j"></script>
+  <script src="admin-script.js?v=2026-06-05k"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
Remove sinistro field from the matched sample display — the field was removed from the data but the HTML template still referenced d.sinistro causing \"sinistro: undefined\" to show.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_