### PR TITLE
fix: normalizePlate extracts XX-XX-XX from prefixed strings

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -760,10 +760,13 @@ function excelDateToISO(serial) {
   return new Date(epoch.getTime() + Math.floor(serial) * 86400000).toISOString();
 }
 
-// Normalizar matrícula
+// Normalizar matrícula — extrai padrão XX-XX-XX de strings como "TORIZA 36-57-VU"
 function normalizePlate(plate) {
   if (!plate) return '';
-  let n = String(plate).replace(/\s+/g, '').toUpperCase();
+  const s = String(plate).trim().toUpperCase();
+  const m = s.match(/\b([A-Z0-9]{2}-[A-Z0-9]{2}-[A-Z0-9]{2})\b/);
+  if (m) return m[1];
+  let n = s.replace(/\s+/g, '');
   if (!n.includes('-') && n.length === 6) {
     n = n.slice(0,2) + '-' + n.slice(2,4) + '-' + n.slice(4,6);
   }

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05k"></script>
+  <script src="admin-script.js?v=2026-06-05l"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
Plates in the Excel have prefixes like \"TORIZA 36-57-VU\" or \"CUSA 94-BS-34\". The old normalizePlate stripped spaces but kept the prefix, so the lookup \"TORIZA36-57-VU\" never matched \"36-57-VU\" in the system — those rows ended up in the 279 not-found.\n\nNow extracts the XX-XX-XX pattern first; falls back to the old logic for non-standard plates like \"R-078101\".

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_