### PR TITLE
feat: prefix order_ref with Enc.Axial

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1331,7 +1331,7 @@ async function startSyncOrders() {
 
     for (const existing of existingList) {
       const updates = {};
-      if (orderRef) updates.order_ref = orderRef;
+      if (orderRef) updates.order_ref = 'Enc.Axial ' + orderRef;
       if (recRef)      updates.reception_ref  = recRef;
       if (eurocode)    updates.glass_eurocode = eurocode;
       if (refVal) {

--- a/admin.html
+++ b/admin.html
@@ -579,7 +579,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05n"></script>
+  <script src="admin-script.js?v=2026-06-05o"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
order_ref is now stored as \"Enc.Axial 49988\" instead of \"49988\", so the card shows 📦 Enc.Axial 49988.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_