### PR TITLE
Add normalize Enc.Axial prefix button for bare order_refs

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1425,6 +1425,63 @@ async function startSyncOrders() {
   document.getElementById('importResults').style.display = 'block';
   showToast(`Encomendas importadas: ${updated} actualizados, ${notFound} não encontrados`, updated > 0 ? 'success' : 'info');
 }
+// Normaliza order_refs existentes que são apenas números (sem prefixo "Enc.Axial")
+async function fixEncAxialPrefix() {
+  if (!confirm('🔧 NORMALIZAR PREFIXO "Enc.Axial"\n\nVai adicionar "Enc.Axial " a todos os order_refs que são apenas números (sem prefixo).\n\nTens a certeza?')) return;
+
+  const btn = document.getElementById('btnFixEncAxial');
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 A normalizar...'; }
+
+  try {
+    const portalsResp = await window.authClient.authenticatedFetch('/.netlify/functions/portals');
+    const portalsData = await portalsResp.json();
+    const portalList = portalsData.portals || portalsData || [];
+
+    let allAppts = [];
+    for (const portal of portalList) {
+      try {
+        const resp = await window.authClient.authenticatedFetch(`/.netlify/functions/appointments?portal_id=${portal.id}&limit=9999`);
+        const json = await resp.json();
+        if (json.data) {
+          json.data.forEach(a => { a._portalId = portal.id; });
+          allAppts.push(...json.data);
+        }
+      } catch(e) { console.warn(`[fixEncAxial] portal ${portal.id}:`, e.message); }
+    }
+
+    const toFix = allAppts.filter(a => {
+      if (!a.order_ref) return false;
+      const v = String(a.order_ref).trim();
+      if (v.toLowerCase().startsWith('enc.axial')) return false;
+      return /^\d+$/.test(v);
+    });
+
+    if (!toFix.length) {
+      showToast('✅ Todos os order_refs já têm o prefixo Enc.Axial', 'success');
+      return;
+    }
+
+    let fixed = 0, errors = 0;
+    for (const a of toFix) {
+      try {
+        const resp = await window.authClient.authenticatedFetch(`/.netlify/functions/appointments/${a.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...a, order_ref: 'Enc.Axial ' + a.order_ref.trim(), _portalId: a._portalId })
+        });
+        if (resp.ok) fixed++;
+        else errors++;
+      } catch(e) { errors++; }
+    }
+
+    showToast(`✅ ${fixed} order_refs corrigidos${errors ? `, ${errors} erros` : ''}`, fixed > 0 ? 'success' : 'error');
+  } catch(e) {
+    showToast('❌ Erro: ' + e.message, 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '🔧 Normalizar Enc.Axial'; }
+  }
+}
+
 function generatePassword() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
   let pass = '';

--- a/admin.html
+++ b/admin.html
@@ -114,7 +114,10 @@
             <div style="font-weight:700;font-size:14px;color:#1e40af;">📦 Importar Encomendas</div>
             <div style="font-size:12px;color:#6b7280;margin-top:2px;">Carrega um Excel e actualiza order_ref / eurocode / receção nos processos existentes. Nunca cria nem apaga.</div>
           </div>
-          <button style="background:#0369a1;color:#fff;border:none;padding:10px 20px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;white-space:nowrap;" id="btnSyncOrders" onclick="startSyncOrders()">📦 Importar Encomendas</button>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;">
+            <button style="background:#0369a1;color:#fff;border:none;padding:10px 20px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;white-space:nowrap;" id="btnSyncOrders" onclick="startSyncOrders()">📦 Importar Encomendas</button>
+            <button style="background:#6b7280;color:#fff;border:none;padding:10px 16px;border-radius:8px;font-weight:700;font-size:13px;cursor:pointer;white-space:nowrap;" id="btnFixEncAxial" onclick="fixEncAxialPrefix()" title="Adiciona prefixo Enc.Axial a order_refs que são apenas números">🔧 Normalizar Enc.Axial</button>
+          </div>
         </div>
 
         <div class="import-upload-area" id="importUploadArea">
@@ -579,7 +582,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-05o"></script>
+  <script src="admin-script.js?v=2026-06-06a"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Summary
- Adds `fixEncAxialPrefix()` function that scans all portals for appointments with a bare numeric `order_ref` (e.g. `49380`) and prepends `"Enc.Axial "` to them
- Adds a "🔧 Normalizar Enc.Axial" button in the admin import section next to "📦 Importar Encomendas"
- Fixes AE-09-0T in Famalicão (and any other plates) that got their order_ref saved without prefix during the first import run (with old cached code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_