### PR TITLE
Move Enc.Axial number into stock semaphore column

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-05b"></script>
-  <script src="script-tail.js?v=2026-06-06b"></script>
+  <script src="script-tail.js?v=2026-06-06c"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -39,16 +39,20 @@ const telBtn = phone ? `
   const textColor = textColorForBg(base);
 
   // Semáforo de stock: três luzes (NE=vermelho, VE=amarelo, ST=verde), ativa iluminada
+  // Número de encomenda (sem prefixo "Enc.Axial") e receção mostrados abaixo do semáforo
   const _st = a.status || 'NE';
   const _lights = [
     { s: 'NE', on: '#f87171', glow: 'rgba(248,113,113,0.7)' },
     { s: 'VE', on: '#fbbf24', glow: 'rgba(251,191,36,0.7)'  },
     { s: 'ST', on: '#4ade80', glow: 'rgba(74,222,128,0.7)'  },
   ];
+  const _orderNum = a.order_ref ? String(a.order_ref).replace(/^enc\.axial\s*/i, '').trim() : null;
   const stockSemaphore = `
-    <div style="display:flex;flex-direction:column;align-items:center;gap:3px;margin-top:4px;background:rgba(0,0,0,0.35);border-radius:16px;padding:6px 5px 4px;">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:3px;margin-top:4px;background:rgba(0,0,0,0.35);border-radius:16px;padding:6px 5px 4px;max-width:44px;">
       ${_lights.map(l => `<div style="width:14px;height:14px;border-radius:50%;background:${_st===l.s ? l.on : 'rgba(255,255,255,0.12)'};${_st===l.s ? `box-shadow:0 0 7px 2px ${l.glow};` : ''}"></div>`).join('')}
       <span style="font-size:7px;font-weight:900;color:rgba(255,255,255,0.7);letter-spacing:0.4px;margin-top:1px;">STOCK</span>
+      ${_orderNum ? `<span style="font-size:8px;font-weight:800;color:rgba(255,255,255,0.95);text-align:center;word-break:break-all;line-height:1.3;margin-top:2px;">📦 ${_orderNum}</span>` : ''}
+      ${a.reception_ref ? `<span style="font-size:8px;font-weight:800;color:rgba(255,255,255,0.95);text-align:center;word-break:break-all;line-height:1.3;">✅ ${String(a.reception_ref).slice(0,8)}</span>` : ''}
     </div>`;
 
   // Hierarquia visual: matrícula em destaque, carro secundário
@@ -78,11 +82,7 @@ const telBtn = phone ? `
   if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
   const _mRole = window.authClient?.getUser?.()?.role;
   const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
-  const mEncRecFooter = (a.order_ref || a.reception_ref) ? `
-    <div style="margin:4px 0 0;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);display:flex;gap:8px;flex-wrap:wrap;">
-      ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
-      ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
-    </div>` : '';
+  const mEncRecFooter = ''; // movido para o semáforo de stock (coluna direita)
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   const compSalesBadge = a.comp_sales_desc
     ? (a.comp_sales_faturado


### PR DESCRIPTION
## Summary
- Order number (📦 49993) and reception ref (✅) now appear below the traffic lights, inside the semaphore housing on the right column
- "Enc.Axial " prefix is stripped for display (number only, saves space)
- Reception ref truncated to 8 chars to fit the column
- Main card content area no longer shows the enc/rec footer row

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_