### PR TITLE
Vary semaphore label by status: S/STOCK / ENC. / STOCK

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-05b"></script>
-  <script src="script-tail.js?v=2026-06-06e"></script>
+  <script src="script-tail.js?v=2026-06-06f"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -46,13 +46,14 @@ const telBtn = phone ? `
     { s: 'VE', on: '#fbbf24', glow: 'rgba(251,191,36,0.7)'  },
     { s: 'ST', on: '#4ade80', glow: 'rgba(74,222,128,0.7)'  },
   ];
+  const _semLabel = { NE: 'S/STOCK', VE: 'ENC.', ST: 'STOCK' }[_st] || 'S/STOCK';
   const _numBtns = [wazeBtn, mapsBtn, telBtn].filter(Boolean).length;
   const _semTop = 10 + _numBtns * 36;
   const stockSemaphore = `
     <div style="position:absolute;top:${_semTop}px;right:10px;display:flex;flex-direction:column;align-items:flex-end;gap:3px;z-index:5;">
       <div style="display:flex;flex-direction:column;align-items:center;gap:3px;background:rgba(0,0,0,0.35);border-radius:16px;padding:6px 5px 4px;">
         ${_lights.map(l => `<div style="width:14px;height:14px;border-radius:50%;background:${_st===l.s ? l.on : 'rgba(255,255,255,0.12)'};${_st===l.s ? `box-shadow:0 0 7px 2px ${l.glow};` : ''}"></div>`).join('')}
-        <span style="font-size:7px;font-weight:900;color:rgba(255,255,255,0.7);letter-spacing:0.4px;margin-top:1px;">STOCK</span>
+        <span style="font-size:7px;font-weight:900;color:rgba(255,255,255,0.7);letter-spacing:0.4px;margin-top:1px;">${_semLabel}</span>
       </div>
       ${a.order_ref ? `<div style="white-space:nowrap;font-size:9px;font-weight:800;color:rgba(255,255,255,0.92);text-shadow:0 1px 2px rgba(0,0,0,.5);">📦 ${a.order_ref}</div>` : ''}
       ${a.reception_ref ? `<div style="white-space:nowrap;font-size:9px;font-weight:800;color:rgba(255,255,255,0.92);text-shadow:0 1px 2px rgba(0,0,0,.5);">✅ ${a.reception_ref}</div>` : ''}


### PR DESCRIPTION
## Summary
- Semaphore label now varies with glass status instead of always showing "STOCK"
- 🔴 NE → "S/STOCK"
- 🟡 VE → "ENC."
- 🟢 ST → "STOCK"

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_