### PR TITLE
fix: use 'danificado' and remove carrier presence from return email

### DIFF
--- a/index.html
+++ b/index.html
@@ -2194,7 +2194,7 @@
     const bodyLines = [
       'Bom dia,',
       '',
-      `Recebemos o vidro ${toBold(eurocode)} partido, na presença da transportadora${guidaPart}, relacionado a encomenda ${toBold(order)}.`,
+      `Recebemos o vidro ${toBold(eurocode)} danificado${guidaPart}, relacionado a encomenda ${toBold(order)}.`,
       'Devolução feita em PHC.'
     ];
     window.open(`mailto:?subject=${encodeURIComponent('Devolução - ')}&body=${encodeURIComponent(bodyLines.join('\r\n'))}`, '_blank');


### PR DESCRIPTION
- Change \"partido\" → \"danificado\"\n- Remove \"na presença da transportadora\"\n\nhttps://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_