### PR TITLE
feat: add OCR loading overlay while identifying label photo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1549,7 +1549,19 @@
     const compressed = await _compressImage(raw, 1200, 0.72);
     window._grReturnLabelPhoto = compressed.split(',')[1];
     const preview = document.getElementById('grReturnLabelPreview');
-    if (preview) preview.innerHTML = `<img src="${compressed}" style="width:100%;max-height:120px;object-fit:cover;border-radius:8px;border:2px solid #16a34a;">`;
+    if (preview) preview.innerHTML = `
+      <div style="position:relative;">
+        <img src="${compressed}" style="width:100%;max-height:120px;object-fit:cover;border-radius:8px;border:2px solid #16a34a;">
+        <div id="grOcrOverlay" style="position:absolute;inset:0;background:rgba(15,23,42,0.65);border-radius:8px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;">
+          <div style="width:28px;height:28px;border:3px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:grSpin 0.8s linear infinite;"></div>
+          <span style="color:#fff;font-size:12px;font-weight:700;letter-spacing:.5px;">A identificar…</span>
+        </div>
+      </div>
+      <style>@keyframes grSpin{to{transform:rotate(360deg)}}</style>`;
+    const ecField = document.getElementById('grReturnEurocode');
+    const orField = document.getElementById('grReturnOrderRef');
+    if (ecField) { ecField.value = ''; ecField.placeholder = 'A identificar…'; }
+    if (orField) { orField.value = ''; orField.placeholder = 'A identificar…'; }
     try {
       const res = await fetch(API + '/glass-label-ocr', {
         method: 'POST', headers: authHeaders(),
@@ -1558,15 +1570,18 @@
       const json = await res.json();
       if (json.success && json.data) {
         if (json.data.eurocode) {
-          const f = document.getElementById('grReturnEurocode');
-          if (f) f.value = json.data.eurocode;
+          if (ecField) ecField.value = json.data.eurocode;
         }
         if (json.data.order_ref) {
-          const o = document.getElementById('grReturnOrderRef');
-          if (o && !o.value) o.value = json.data.order_ref;
+          if (orField && !orField.value) orField.value = json.data.order_ref;
         }
       }
     } catch (_) {}
+    // Remove spinner
+    const overlay = document.getElementById('grOcrOverlay');
+    if (overlay) overlay.remove();
+    if (ecField) ecField.placeholder = 'ex: 6577AGACMVZ';
+    if (orField) orField.placeholder = 'ex: 49380';
   }
 
   async function _onDamagePhoto(input) {


### PR DESCRIPTION
While the OCR API analyses the label photo:\n- Spinner overlay appears on top of the photo preview\n- Fields show placeholder \"A identificar…\"\n- Overlay and placeholders are removed once the result arrives (success or error)\n\nhttps://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_