### PR TITLE
Fix appointment suggestion in damage/return flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1874,7 +1874,7 @@
       return;
     }
 
-    const safeRawForCard = (rawText||'').substring(0,200).replace(/'/g,"\\'").replace(/"/g,'&quot;');
+    const safeRawForCard = (rawText||'').substring(0,200).replace(/[\n\r\t]/g,' ').replace(/'/g,"\\'").replace(/"/g,'\\"');
 
     // Store appts globally for filter re-render
     const storeNames = [...new Set(appts.map(a => a.portal_name || window.portalConfig?.name || '—'))];
@@ -1920,7 +1920,7 @@
           ${a.glass_eurocode ? `<div style="font-size:11px;color:#64748b;font-family:monospace;margin-top:3px;">🔢 ${a.glass_eurocode}</div>` : ''}
           ${a.notes && a.notes !== a.glass_eurocode ? `<div style="font-size:11px;color:#94a3b8;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">📝 ${a.notes}</div>` : ''}
           ${recBadge}
-          <div style="margin-top:6px;font-size:11px;font-weight:700;color:#2563eb;">Selecionar →</div>
+          <div style="margin-top:10px;text-align:center;"><button style="background:#2563eb;color:#fff;font-weight:800;font-size:16px;padding:12px 0;border-radius:10px;border:none;cursor:pointer;width:100%;letter-spacing:.3px;">Selecionar →</button></div>
         </div>`;
       }).join('');
     }
@@ -1974,7 +1974,7 @@
       : window._grAllAppts;
     const list = document.getElementById('grCardsList');
     if (!list) return;
-    const safeRawForCard = (window._grRawText||'').substring(0,200).replace(/'/g,"\\'").replace(/"/g,'&quot;');
+    const safeRawForCard = (window._grRawText||'').substring(0,200).replace(/[\n\r\t]/g,' ').replace(/'/g,"\\'").replace(/"/g,'\\"');
     const orderRef = window._grOrderRef || '';
     const eurocode = window._grEurocode || '';
     const recepMap = window._grRecepMap || {};
@@ -2010,7 +2010,7 @@
         ${a.glass_eurocode ? `<div style="font-size:11px;color:#64748b;font-family:monospace;margin-top:3px;">🔢 ${a.glass_eurocode}</div>` : ''}
         ${a.notes && a.notes !== a.glass_eurocode ? `<div style="font-size:11px;color:#94a3b8;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">📝 ${a.notes}</div>` : ''}
         ${recBadge}
-        <div style="margin-top:6px;font-size:11px;font-weight:700;color:#2563eb;">Selecionar →</div>
+        <div style="margin-top:10px;text-align:center;"><button style="background:#2563eb;color:#fff;font-weight:800;font-size:16px;padding:12px 0;border-radius:10px;border:none;cursor:pointer;width:100%;letter-spacing:.3px;">Selecionar →</button></div>
       </div>`;
     }).join('');
   }

--- a/index.html
+++ b/index.html
@@ -1474,6 +1474,7 @@
       <div style="background:${isPartido ? '#fef2f2' : '#fffbeb'};border:2px solid ${isPartido ? '#dc2626' : '#f59e0b'};border-radius:10px;padding:10px 14px;margin-bottom:14px;">
         <p style="font-size:13px;font-weight:700;color:${isPartido ? '#dc2626' : '#92400e'};margin:0;">${isPartido ? '💔 Partido' : '❌ Errado / Cancelado'}</p>
       </div>
+      ${_glassTypeSelectorHtml()}
       <p style="color:#374151;font-size:13px;font-weight:600;margin-bottom:8px;">1. Foto da etiqueta (Eurocode)</p>
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px;">
         <label style="display:flex;align-items:center;justify-content:center;gap:6px;background:#1d4ed8;color:#fff;font-weight:700;font-size:13px;padding:12px 8px;border-radius:12px;cursor:pointer;text-align:center;">
@@ -1572,7 +1573,7 @@
       const json = await res.json();
       if (json.success && json.data) {
         if (json.data.eurocode) {
-          if (ecField) ecField.value = json.data.eurocode;
+          if (ecField) ecField.value = _prefixedEurocode(json.data.eurocode);
         }
         if (json.data.order_ref) {
           if (orField && !orField.value) orField.value = json.data.order_ref;
@@ -1618,7 +1619,7 @@
 
   async function _submitReturn() {
     const reason = window._grReturnReason;
-    const eurocode = (document.getElementById('grReturnEurocode')?.value || '').trim();
+    const eurocode = _prefixedEurocode((document.getElementById('grReturnEurocode')?.value || '').trim());
     const labelPhoto = window._grReturnLabelPhoto || null;
     const damagePhotos = window._grReturnDamagePhotos || [];
     const orderRef = (document.getElementById('grReturnOrderRef')?.value || '').trim() || null;
@@ -1656,8 +1657,51 @@
     document.getElementById('grScanModal').style.display = 'none';
   }
 
+  function _glassTypeSelectorHtml() {
+    const t = window._grGlassType || 'rede';
+    const btn = (key, label) => {
+      const active = key === t;
+      const colors = { rede: '#0f172a', complementar: '#f59e0b', oem: '#7c3aed' };
+      const bg = active ? colors[key] : '#fff';
+      const color = active ? '#fff' : '#374151';
+      const border = active ? colors[key] : '#e2e8f0';
+      return `<button id="grType_${key}" onclick="window.glassReception._selectGlassType('${key}')"
+        style="padding:9px 4px;border-radius:8px;border:2px solid ${border};background:${bg};color:${color};font-size:11px;font-weight:700;cursor:pointer;">${label}</button>`;
+    };
+    return `
+      <div style="margin-bottom:14px;">
+        <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:6px;">TIPO DE VIDRO</label>
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;">
+          ${btn('rede',         '🔵 Rede')}
+          ${btn('complementar', '# Complementar')}
+          ${btn('oem',          '✳ OEM')}
+        </div>
+      </div>`;
+  }
+
+  function _selectGlassType(type) {
+    window._grGlassType = type;
+    const colors = { rede: '#0f172a', complementar: '#f59e0b', oem: '#7c3aed' };
+    ['rede', 'complementar', 'oem'].forEach(k => {
+      const btn = document.getElementById('grType_' + k);
+      if (!btn) return;
+      const active = k === type;
+      btn.style.background = active ? colors[k] : '#fff';
+      btn.style.color = active ? '#fff' : '#374151';
+      btn.style.borderColor = active ? colors[k] : '#e2e8f0';
+    });
+  }
+
+  function _prefixedEurocode(ec) {
+    if (!ec) return ec;
+    const clean = String(ec).replace(/^[#*]/, '');
+    const t = window._grGlassType || 'rede';
+    return (t === 'complementar' ? '#' : t === 'oem' ? '*' : '') + clean;
+  }
+
   function renderStep1() {
     document.getElementById('grScanBody').innerHTML = `
+      ${_glassTypeSelectorHtml()}
       <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Tira uma foto à etiqueta do vidro ou escolhe uma imagem da galeria.</p>
       <div style="display:flex;flex-direction:column;gap:12px;">
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
@@ -1777,6 +1821,7 @@
   function renderMatches(appts, orderRef, eurocode, rawText, photoBase64, plate, recepMap) {
     recepMap = recepMap || {};
     const body = document.getElementById('grScanBody');
+    const prefEuro = _prefixedEurocode(eurocode);
 
     const infoHtml = `
       <div style="background:#f8fafc;border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:12px;color:#64748b;">
@@ -1991,7 +2036,7 @@
         ${orderRef ? `<div style="margin-top:8px;font-size:11px;color:#94a3b8;">📦 Encomenda: ${orderRef}</div>` : ''}
         ${eurocode ? `<div style="font-size:11px;color:#94a3b8;font-family:monospace;">🔢 ${eurocode}</div>` : ''}
       </div>
-      <button onclick="window.glassReception._confirmReception('${appointmentId}','${(plate||'').replace(/'/g,"\\'")}','${(orderRef||'').replace(/'/g,"\\'")}','${(eurocode||'').replace(/'/g,"\\'")}','${(rawText||'').replace(/'/g,"\\'")}')"
+      <button onclick="window.glassReception._confirmReception('${appointmentId}','${(plate||'').replace(/'/g,"\\'")}','${(orderRef||'').replace(/'/g,"\\'")}','${(prefEuro||'').replace(/'/g,"\\'")}','${(rawText||'').replace(/'/g,"\\'")}')"
         style="width:100%;background:#16a34a;color:#fff;border:none;border-radius:10px;padding:14px;font-size:15px;font-weight:800;cursor:pointer;margin-bottom:10px;">
         ✅ Confirmar receção
       </button>
@@ -2742,7 +2787,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _markReceived, _rejectReception, _reportAxial, _printReturn, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _markReceived, _rejectReception, _reportAxial, _printReturn, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/index.html
+++ b/index.html
@@ -2386,6 +2386,7 @@
       const qp = new URLSearchParams();
       if (eurocode) qp.set('search_eurocode', eurocode.trim());
       if (orderRef) qp.set('search_order_ref', orderRef.trim());
+      qp.set('include_executed', 'true');
       const res = await fetch(API + '/appointments?' + qp.toString(), { headers: authHeaders() });
       const json = await res.json();
       if (json.success) {
@@ -2394,7 +2395,10 @@
       }
     } catch (_) {}
 
-    if (!results.length) return; // no match — silent, user can fill manually
+    if (!results.length) {
+      if (card) card.innerHTML = `<p style="font-size:12px;color:#94a3b8;text-align:center;padding:8px;">Nenhum processo encontrado — preenche os dados manualmente.</p>`;
+      return;
+    }
     const best = results[0];
     const plateStr = (best.plate || '').toUpperCase();
     const carStr   = best.car || '—';

--- a/index.html
+++ b/index.html
@@ -1454,7 +1454,7 @@
           style="display:flex;align-items:center;gap:14px;background:#dc2626;color:#fff;font-weight:800;font-size:15px;padding:18px 20px;border-radius:14px;border:none;cursor:pointer;text-align:left;width:100%;">
           <span style="font-size:28px;">💔</span>
           <div>
-            <div>Partido</div>
+            <div>Danificado</div>
             <div style="font-size:11px;font-weight:400;opacity:.8;margin-top:2px;">Vidro chegou danificado (mín. 2 fotos)</div>
           </div>
         </button>
@@ -1472,7 +1472,7 @@
     const isPartido = reason === 'partido';
     document.getElementById('grScanBody').innerHTML = `
       <div style="background:${isPartido ? '#fef2f2' : '#fffbeb'};border:2px solid ${isPartido ? '#dc2626' : '#f59e0b'};border-radius:10px;padding:10px 14px;margin-bottom:14px;">
-        <p style="font-size:13px;font-weight:700;color:${isPartido ? '#dc2626' : '#92400e'};margin:0;">${isPartido ? '💔 Partido' : '❌ Errado / Cancelado'}</p>
+        <p style="font-size:13px;font-weight:700;color:${isPartido ? '#dc2626' : '#92400e'};margin:0;">${isPartido ? '💔 Danificado' : '❌ Errado / Cancelado'}</p>
       </div>
       ${_glassTypeSelectorHtml()}
       <p style="color:#374151;font-size:13px;font-weight:600;margin-bottom:8px;">1. Foto da etiqueta (Eurocode)</p>
@@ -1644,7 +1644,7 @@
         <div style="text-align:center;padding:24px 0;">
           <div style="font-size:48px;margin-bottom:12px;">${reason === 'partido' ? '💔' : '↩️'}</div>
           <p style="font-size:16px;font-weight:800;color:#dc2626;margin-bottom:6px;">Devolução registada!</p>
-          <p style="font-size:13px;color:#64748b;margin-bottom:20px;">${reason === 'partido' ? 'Vidro partido registado com fotos do dano.' : 'Vidro errado/cancelado registado para devolução.'}</p>
+          <p style="font-size:13px;color:#64748b;margin-bottom:20px;">${reason === 'partido' ? 'Vidro danificado registado com fotos do dano.' : 'Vidro errado/cancelado registado para devolução.'}</p>
           <button onclick="window.glassReception.closeScan()" style="background:#0f172a;color:#fff;font-weight:700;padding:12px 28px;border-radius:10px;border:none;cursor:pointer;">Fechar</button>
         </div>`;
     } catch (e) {
@@ -2255,7 +2255,7 @@
           <div style="flex:1;min-width:0;">
             <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:4px;">
               <span style="font-family:monospace;font-weight:800;font-size:14px;background:#0f172a;color:#fff;padding:3px 10px;border-radius:6px;">${(r.eurocode || '—').toUpperCase()}</span>
-              <span style="background:${isPartido ? '#fef2f2' : '#fffbeb'};color:${isPartido ? '#dc2626' : '#92400e'};font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;">${isPartido ? '💔 Partido' : r.return_reason === 'desistencia' ? '🚫 Desistência' : r.return_reason === 'outro' ? '❓ Outro' : '❌ Errado'}</span>
+              <span style="background:${isPartido ? '#fef2f2' : '#fffbeb'};color:${isPartido ? '#dc2626' : '#92400e'};font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;">${isPartido ? '💔 Danificado' : r.return_reason === 'desistencia' ? '🚫 Desistência' : r.return_reason === 'outro' ? '❓ Outro' : '❌ Errado'}</span>
               <span style="font-size:11px;color:#64748b;margin-left:auto;">${fmtDate(r.created_at)}</span>
             </div>
             <div style="display:flex;gap:12px;font-size:12px;color:#64748b;flex-wrap:wrap;">
@@ -2333,7 +2333,7 @@
   function _printReturn(id) {
     const r = window._grReturnItemsMap?.[id];
     if (!r) return;
-    const reasonLabels = { errado: 'Errado', desistencia: 'Desistência', outro: 'Outro', partido: 'Partido / Danificado', errado_cancelado: 'Errado / Cancelado' };
+    const reasonLabels = { errado: 'Errado', desistencia: 'Desistência', outro: 'Outro', partido: 'Danificado', errado_cancelado: 'Errado / Cancelado' };
     const reasonText = reasonLabels[r.return_reason] || r.return_reason || '—';
     const photos = _parsePhotos(r.damage_photos);
     const photoHtml = photos.length ? photos.map(b64 =>
@@ -2376,7 +2376,6 @@
 
     // Local search first
     let results = (window.appointments || []).filter(a => {
-      if (a.executed === true) return false;
       const matchOrder = orderRef && a.order_ref && a.order_ref.trim().toLowerCase() === orderRef.trim().toLowerCase();
       const matchEuro  = ecNorm && a.glass_eurocode && normEc(a.glass_eurocode) === ecNorm;
       return matchOrder || matchEuro;

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -148,8 +148,8 @@ exports.handler = async (event) => {
           FROM appointments a
           LEFT JOIN portals p ON p.id = a.portal_id
           WHERE a.portal_id = ANY($1)
-            AND a.executed IS NOT TRUE
-          AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '60 days')
+            ${params.include_executed !== 'true' ? 'AND a.executed IS NOT TRUE' : ''}
+            AND (a.date IS NULL OR a.date >= CURRENT_DATE - INTERVAL '180 days')
             AND (${conditions.join(' OR ')})
           ORDER BY a.date ASC NULLS LAST, a.created_at ASC
           LIMIT 50

--- a/script-tail.js
+++ b/script-tail.js
@@ -2125,6 +2125,7 @@ function sugerirDataParaLocalidade(locality) {
     var dow = d.getDay();
     if (dow === 0 || dow === 6) continue;
     var iso = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+    if (typeof isDayBlocked === 'function' && isDayBlocked(iso)) continue;
     var dia = porDia[iso] || { count: 0, localidades: [] };
     if (dia.count >= MAX_SERVICOS) continue;
     var temMesma = dia.localidades.some(function(l) { return l && l.toLowerCase() === locality.toLowerCase(); });


### PR DESCRIPTION
## Summary
- **Root cause**: the backend appointments search had `AND a.executed IS NOT TRUE` — so any appointment already marked executed was invisible to the suggestion card
- Backend now accepts `include_executed=true` param to bypass that filter; also extended the date window from 60 → 180 days so older appointments are found
- Frontend passes `include_executed=true` in `_doReturnSearch`
- Frontend now shows "Nenhum processo encontrado — preenche os dados manualmente" when search runs but finds nothing (previously silent)

## Test plan
- [ ] Scan damage label → if matching appointment exists (even executed), the "Processo encontrado" card appears
- [ ] If no appointment matches by eurocode or order_ref, the "Nenhum processo encontrado" hint is shown below the label preview

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_