### PR TITLE
Add re-search button after correcting eurocode in return/damage form

### DIFF
--- a/index.html
+++ b/index.html
@@ -1494,6 +1494,9 @@
         <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">Nº ENCOMENDA AXIAL</label>
         <input id="grReturnOrderRef" type="text" placeholder="ex: 49380" style="width:100%;box-sizing:border-box;padding:10px 12px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:14px;font-family:monospace;">
       </div>
+      <div style="margin-bottom:12px;text-align:right;">
+        <button onclick="window.glassReception._retryReturnSearch()" style="background:#f1f5f9;border:1.5px solid #cbd5e1;border-radius:8px;padding:7px 14px;font-size:12px;font-weight:700;color:#2563eb;cursor:pointer;">🔍 Procurar processo</button>
+      </div>
       ${isPartido ? `
       <div style="margin-bottom:12px;">
         <label style="font-size:11px;font-weight:700;color:#64748b;display:block;margin-bottom:4px;">Nº GUIA TRANSPORTE</label>
@@ -2367,6 +2370,12 @@
     w.document.close();
   }
 
+  function _retryReturnSearch() {
+    const ec = (document.getElementById('grReturnEurocode')?.value || '').trim();
+    const or = (document.getElementById('grReturnOrderRef')?.value || '').trim();
+    _doReturnSearch(ec, or);
+  }
+
   async function _doReturnSearch(eurocode, orderRef) {
     if (!eurocode && !orderRef) return;
     const card = document.getElementById('grReturnMatchCard');
@@ -2790,7 +2799,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _markReceived, _rejectReception, _reportAxial, _printReturn, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _markReceived, _rejectReception, _reportAxial, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/index.html
+++ b/index.html
@@ -1906,7 +1906,7 @@
         return `
         <div style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
              onmouseenter="this.style.borderColor='#2563eb'" onmouseleave="this.style.borderColor='#e2e8f0'"
-             onclick="window.glassReception._showConfirm('${safeId}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${safeOrderRef2}','${safeEuro2}','${safeRawForCard}')">
+             onclick="window.glassReception._showConfirm('${safeId}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${safeOrderRef2}','${safeEuro2}')">
           <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap;">
             <span style="font-family:monospace;font-weight:800;font-size:15px;background:#0f172a;color:#fff;padding:4px 10px;border-radius:6px;">${(a.plate||'').toUpperCase()}</span>
             <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
@@ -1996,7 +1996,7 @@
       return `
       <div style="border:2px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;"
            onmouseenter="this.style.borderColor='#2563eb'" onmouseleave="this.style.borderColor='#e2e8f0'"
-           onclick="window.glassReception._showConfirm('${String(a.id)}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${orderRef.replace(/'/g,"\\'")}','${eurocode.replace(/'/g,"\\'")}','${safeRawForCard}')">
+           onclick="window.glassReception._showConfirm('${String(a.id)}','${(a.plate||'').replace(/'/g,"\\'")}','${(a.car||'').replace(/'/g,"\\'")}','${storeName.replace(/'/g,"\\'")}','${(a.service||'').replace(/'/g,"\\'")}','${a.date||''}',${!!a.executed},'${orderRef.replace(/'/g,"\\'")}','${eurocode.replace(/'/g,"\\'")}')">
         <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap;">
           <span style="font-family:monospace;font-weight:800;font-size:15px;background:#0f172a;color:#fff;padding:4px 10px;border-radius:6px;">${(a.plate||'').toUpperCase()}</span>
           <span style="font-size:13px;font-weight:600;color:#374151;">${a.car||'—'}</span>
@@ -2015,7 +2015,7 @@
     }).join('');
   }
 
-  function _showConfirm(appointmentId, plate, car, storeName, service, date, executed, orderRef, eurocode, rawText) {
+  function _showConfirm(appointmentId, plate, car, storeName, service, date, executed, orderRef, eurocode) {
     const body = document.getElementById('grScanBody');
     const executedBadge = executed
       ? '<span style="background:#dcfce7;color:#166534;font-size:12px;font-weight:700;padding:3px 10px;border-radius:10px;">✅ Já realizado</span>'
@@ -2036,7 +2036,7 @@
         ${orderRef ? `<div style="margin-top:8px;font-size:11px;color:#94a3b8;">📦 Encomenda: ${orderRef}</div>` : ''}
         ${eurocode ? `<div style="font-size:11px;color:#94a3b8;font-family:monospace;">🔢 ${eurocode}</div>` : ''}
       </div>
-      <button onclick="window.glassReception._confirmReception('${appointmentId}','${(plate||'').replace(/'/g,"\\'")}','${(orderRef||'').replace(/'/g,"\\'")}','${(prefEuro||'').replace(/'/g,"\\'")}','${(rawText||'').replace(/'/g,"\\'")}')"
+      <button onclick="window.glassReception._confirmReception('${appointmentId}','${(plate||'').replace(/'/g,"\\'")}','${(orderRef||'').replace(/'/g,"\\'")}','${(eurocode||'').replace(/'/g,"\\'")}') "
         style="width:100%;background:#16a34a;color:#fff;border:none;border-radius:10px;padding:14px;font-size:15px;font-weight:800;cursor:pointer;margin-bottom:10px;">
         ✅ Confirmar receção
       </button>
@@ -2046,13 +2046,13 @@
     `;
   }
 
-  async function _confirmReception(appointmentId, plate, orderRef, eurocode, rawText) {
+  async function _confirmReception(appointmentId, plate, orderRef, eurocode) {
     document.getElementById('grScanBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A registar receção…</p>`;
     try {
       const res = await fetch(API + '/glass-reception', {
         method: 'POST',
         headers: authHeaders(),
-        body: JSON.stringify({ appointment_id: appointmentId, order_ref: orderRef, eurocode, raw_label_text: rawText })
+        body: JSON.stringify({ appointment_id: appointmentId, order_ref: orderRef, eurocode, raw_label_text: window._grRawText || null })
       });
       const json = await res.json();
       if (!json.success) throw new Error(json.error);


### PR DESCRIPTION
## Summary
- Added a small "🔍 Procurar processo" button below the order ref field in the return/damage form
- Tapping it calls `_retryReturnSearch()` which reads the current eurocode and order ref field values and re-runs the appointment search, refreshing the match card
- Useful when OCR extracts the wrong eurocode and the user corrects it manually

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_