### PR TITLE
Hide glass reception FAB and checkin bar on Pesados portal

### DIFF
--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -247,6 +247,11 @@
     const role = window.authClient?.getUser?.()?.role;
     if (role === 'coordenador' || role === 'admin') {
       buildBotWidget();
+      // Hide glass reception FAB on pesados portals — doesn't apply there
+      if (window.portalConfig?.portalType === 'pesados') {
+        const btn = document.getElementById('recBotBtn');
+        if (btn) btn.style.display = 'none';
+      }
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -2885,7 +2885,7 @@
     if (!bar) return;
 
     const type = window.portalConfig?.portalType || '';
-    if (!['sm', 'pesados'].includes(type)) { bar.style.display = 'none'; return; }
+    if (type !== 'sm') { bar.style.display = 'none'; return; }
     bar.style.display = 'block';
 
     const hasIn  = !!(rec?.checkin_at);
@@ -3040,7 +3040,7 @@
   // Init: load today's record when the page is ready (and only for SM/pesados)
   function init() {
     const type = window.portalConfig?.portalType || '';
-    if (!['sm', 'pesados'].includes(type)) return;
+    if (type !== 'sm') return;
     load();
   }
 


### PR DESCRIPTION
## Summary
- Hide `📦 Receção de Vidros` FAB button on Pesados portal (glass reception doesn't apply to heavy vehicles coordination)
- Remove Pesados from team checkin bar — it's a coordination portal, not a mobile team

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_