### PR TITLE
Remove Vista Pesados panel

### DIFF
--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -247,6 +247,11 @@
     const role = window.authClient?.getUser?.()?.role;
     if (role === 'coordenador' || role === 'admin') {
       buildBotWidget();
+      // Hide glass reception FAB on pesados portals — doesn't apply there
+      if (window.portalConfig?.portalType === 'pesados') {
+        const btn = document.getElementById('recBotBtn');
+        if (btn) btn.style.display = 'none';
+      }
     }
   }
 

--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -247,11 +247,6 @@
     const role = window.authClient?.getUser?.()?.role;
     if (role === 'coordenador' || role === 'admin') {
       buildBotWidget();
-      // Hide glass reception FAB on pesados portals — doesn't apply there
-      if (window.portalConfig?.portalType === 'pesados') {
-        const btn = document.getElementById('recBotBtn');
-        if (btn) btn.style.display = 'none';
-      }
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -815,7 +815,6 @@
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
   <script src="incomplete-services-alert.js?v=2026-06-01c"></script>
   <script src="agenda-bot.js?v=2026-04-09"></script>
-  <script src="pesados-coord.js?v=2026-04-17"></script>
   <script src="rota-do-dia-map.js?v=2026-05-14o"></script>
   <script src="timeline-rota.js?v=2026-05-14g"></script>
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
@@ -2885,7 +2884,7 @@
     if (!bar) return;
 
     const type = window.portalConfig?.portalType || '';
-    if (type !== 'sm') { bar.style.display = 'none'; return; }
+    if (!['sm', 'pesados'].includes(type)) { bar.style.display = 'none'; return; }
     bar.style.display = 'block';
 
     const hasIn  = !!(rec?.checkin_at);
@@ -3040,7 +3039,7 @@
   // Init: load today's record when the page is ready (and only for SM/pesados)
   function init() {
     const type = window.portalConfig?.portalType || '';
-    if (type !== 'sm') return;
+    if (!['sm', 'pesados'].includes(type)) return;
     load();
   }
 

--- a/index.html
+++ b/index.html
@@ -2885,7 +2885,7 @@
     if (!bar) return;
 
     const type = window.portalConfig?.portalType || '';
-    if (!['sm', 'pesados'].includes(type)) { bar.style.display = 'none'; return; }
+    if (type !== 'sm') { bar.style.display = 'none'; return; }
     bar.style.display = 'block';
 
     const hasIn  = !!(rec?.checkin_at);
@@ -3040,7 +3040,7 @@
   // Init: load today's record when the page is ready (and only for SM/pesados)
   function init() {
     const type = window.portalConfig?.portalType || '';
-    if (!['sm', 'pesados'].includes(type)) return;
+    if (type !== 'sm') return;
     load();
   }
 


### PR DESCRIPTION
## Summary
- Remove `pesados-coord.js` script — the "🚛 Vista Pesados" weekly grid panel has no utility
- Restore checkin bar and glass reception FAB for pesados portal type (reverts previous incorrect change)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_