### PR TITLE
Fix checkin bar visibility: retry init + sticky position

### DIFF
--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -247,11 +247,6 @@
     const role = window.authClient?.getUser?.()?.role;
     if (role === 'coordenador' || role === 'admin') {
       buildBotWidget();
-      // Hide glass reception FAB on pesados portals — doesn't apply there
-      if (window.portalConfig?.portalType === 'pesados') {
-        const btn = document.getElementById('recBotBtn');
-        if (btn) btn.style.display = 'none';
-      }
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -2884,7 +2884,7 @@
     if (!bar) return;
 
     const type = window.portalConfig?.portalType || '';
-    if (type !== 'sm') { bar.style.display = 'none'; return; }
+    if (!['sm', 'pesados'].includes(type)) { bar.style.display = 'none'; return; }
     bar.style.display = 'block';
 
     const hasIn  = !!(rec?.checkin_at);
@@ -3039,7 +3039,7 @@
   // Init: load today's record when the page is ready (and only for SM/pesados)
   function init() {
     const type = window.portalConfig?.portalType || '';
-    if (type !== 'sm') return;
+    if (!['sm', 'pesados'].includes(type)) return;
     load();
   }
 

--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
         </div>
       </div>
       <!-- Team checkin bar (SM/pesados portals only) -->
-      <div id="teamCheckinBar" style="display:none;padding:8px 12px;background:#f8fafc;border-bottom:1px solid #e2e8f0;"></div>
+      <div id="teamCheckinBar" style="display:none;padding:8px 12px;background:#f8fafc;border-bottom:1px solid #e2e8f0;position:sticky;top:0;z-index:100;"></div>
       <!-- Guia AT upload (coordinator/admin only) -->
       <div id="guiaATUploadArea" style="padding:6px 14px 0; display:none; flex-direction:column; gap:6px;">
         <input type="file" id="guiaATFileInput" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
@@ -3036,17 +3036,18 @@
     }
   }
 
-  // Init: load today's record when the page is ready (and only for SM/pesados)
+  // Init: retry until portalConfig is available (SM/pesados only)
   function init() {
     const type = window.portalConfig?.portalType || '';
+    if (!type) { setTimeout(init, 500); return; } // portalConfig not ready yet
     if (!['sm', 'pesados'].includes(type)) return;
     load();
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => setTimeout(init, 800));
+    document.addEventListener('DOMContentLoaded', () => setTimeout(init, 500));
   } else {
-    setTimeout(init, 800);
+    setTimeout(init, 500);
   }
 
   window.teamCheckin = { load, doCheckin, doCheckout, openAnalytics };


### PR DESCRIPTION
## Summary
- Init retries every 500ms until `window.portalConfig` is available (was failing silently if portal config loaded after the 800ms timeout)
- Bar is now `position:sticky;top:0` so it stays visible while scrolling through appointments

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_