### PR TITLE
Style analytics button to match check-in/check-out size

### DIFF
--- a/index.html
+++ b/index.html
@@ -2923,7 +2923,7 @@
         }
         <div style="flex:1;display:flex;align-items:center;justify-content:center;gap:6px;">
           ${netHrs != null ? `<span style="font-size:12px;color:#7c3aed;font-weight:700;background:#f5f3ff;padding:2px 8px;border-radius:6px;">${fmtHours(netHrs)} líq.</span>` : ''}
-          <button onclick="window.teamCheckin.openAnalytics()" style="background:none;border:none;cursor:pointer;font-size:18px;flex-shrink:0;" title="Ver histórico">📊</button>
+          <button onclick="window.teamCheckin.openAnalytics()" style="background:#e0e7ff;color:#4338ca;font-weight:700;font-size:12px;padding:7px 14px;border-radius:8px;border:none;cursor:pointer;white-space:nowrap;">📊 Relatório</button>
         </div>
         ${hasOut
           ? `<span style="font-size:12px;color:#1d4ed8;font-weight:700;white-space:nowrap;">🏁 ${fmt(rec.checkout_at)}${autoOut ? ' <span style="color:#94a3b8;font-weight:400;">(auto)</span>' : ''}</span>`


### PR DESCRIPTION
Makes the 📊 Relatório button the same height and padding as the Check-in and Check-out buttons. Uses an indigo tint to distinguish it visually without competing with the green and dark action buttons.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_