### PR TITLE
Accumulate multiple Guia AT per day instead of replacing

### DIFF
--- a/netlify/functions/transport-guide.js
+++ b/netlify/functions/transport-guide.js
@@ -119,10 +119,13 @@ exports.handler = async (event) => {
          FROM transport_guides
          WHERE portal_id = $1 AND guide_date = $2
            AND guide_date >= CURRENT_DATE - INTERVAL '1 day'
-         ORDER BY uploaded_at DESC LIMIT 1`,
+         ORDER BY uploaded_at DESC`,
         [portalId, date]
       );
-      return { statusCode: 200, headers, body: JSON.stringify({ success: true, guide: res.rows[0] || null }) };
+      if (!res.rows.length) return { statusCode: 200, headers, body: JSON.stringify({ success: true, guide: null }) };
+      const mergedEc = [...new Set(res.rows.flatMap(r => r.eurocodes || []))];
+      const latest = res.rows[0];
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, guide: { ...latest, eurocodes: mergedEc }, guide_count: res.rows.length }) };
     }
 
     if (event.httpMethod === 'POST') {
@@ -172,10 +175,10 @@ exports.handler = async (event) => {
       const eurocodes = [...new Set(autoEurocodes)];
       const storedFileType = file_type || 'application/pdf';
 
-      // Delete existing guide for same date + cleanup guides older than 2 days
+      // Only cleanup guides older than 1 day — never delete same-date guides
       await client.query(
-        "DELETE FROM transport_guides WHERE portal_id = $1 AND (guide_date = $2 OR guide_date < CURRENT_DATE - INTERVAL '1 day')",
-        [portalId, guideDate]
+        "DELETE FROM transport_guides WHERE portal_id = $1 AND guide_date < CURRENT_DATE - INTERVAL '1 day'",
+        [portalId]
       );
       const res = await client.query(
         `INSERT INTO transport_guides (portal_id, guide_date, pdf_data, eurocodes, uploaded_by, file_type)
@@ -183,9 +186,15 @@ exports.handler = async (event) => {
          RETURNING id, guide_date, eurocodes, uploaded_at, file_type`,
         [portalId, guideDate, pdf_data, eurocodes, user.userId, storedFileType]
       );
+      // Merge eurocodes from all guides for this date
+      const allRows = await client.query(
+        `SELECT eurocodes FROM transport_guides WHERE portal_id = $1 AND guide_date = $2`,
+        [portalId, guideDate]
+      );
+      const allEurocodes = [...new Set(allRows.rows.flatMap(r => r.eurocodes || []))];
       return {
         statusCode: 200, headers,
-        body: JSON.stringify({ success: true, guide: { ...res.rows[0], pdf_data }, eurocodes_found: eurocodes })
+        body: JSON.stringify({ success: true, guide: { ...res.rows[0], pdf_data, eurocodes: allEurocodes }, eurocodes_found: eurocodes, all_eurocodes: allEurocodes, guide_count: allRows.rows.length })
       };
     }
 

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -280,13 +280,19 @@
       const res = await authFetch(API, { method: 'POST', body: JSON.stringify(payload) });
       const data = await res.json();
       if (data.success) {
-        guides[uploadDate === 'tomorrow' ? 'tomorrow' : 'today'] = data.guide;
+        const key = uploadDate === 'tomorrow' ? 'tomorrow' : 'today';
+        guides[key] = data.guide;
+        guides[key === 'tomorrow' ? 'tomorrowCount' : 'todayCount'] = data.guide_count || 1;
         todayGuide = guides.today || guides.tomorrow;
         injectBadges();
         updateUploadBtn();
         const n = data.eurocodes_found.length;
+        const total = (data.all_eurocodes || data.eurocodes_found || []).length;
+        const count = data.guide_count || 1;
         if (n === 0) {
           showToast('⚠️ Guia carregada mas 0 Eurocodes encontrados — introduz os códigos manualmente no campo ao lado.', 'error');
+        } else if (count > 1) {
+          showToast(`✅ Guia ${count} carregada — ${n} novo(s) Eurocode(s). Total acumulado: ${total} código(s).`, 'success');
         } else {
           showToast(`✅ Guia AT carregada — ${n} Eurocode(s): ${data.eurocodes_found.join(', ')}`, 'success');
         }
@@ -321,9 +327,13 @@
     const hasToday = !!guides.today;
     const hasTomorrow = !!guides.tomorrow;
     const loaded = hasToday || hasTomorrow;
-    const label = hasToday && hasTomorrow ? 'Guia AT ✓✓'
-                : hasToday ? 'Guia AT ✓'
-                : hasTomorrow ? 'Guia AT +1 ✓'
+    const todayCount = guides.todayCount || (hasToday ? 1 : 0);
+    const tomorrowCount = guides.tomorrowCount || (hasTomorrow ? 1 : 0);
+    const todayLabel = todayCount > 1 ? `✓×${todayCount}` : (hasToday ? '✓' : '');
+    const tomorrowLabel = tomorrowCount > 1 ? `+1×${tomorrowCount}` : (hasTomorrow ? '+1✓' : '');
+    const label = hasToday && hasTomorrow ? `Guia AT ${todayLabel} ${tomorrowLabel}`.trim()
+                : hasToday ? `Guia AT ${todayLabel}`
+                : hasTomorrow ? `Guia AT ${tomorrowLabel}`
                 : 'Guia AT';
     const icon = loaded
       ? '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
@@ -353,8 +363,8 @@
       authFetch(`${API}?date=${tomorrowIso}${portalParam}`)
     ]);
     const [dToday, dTomorrow] = await Promise.all([resToday.json(), resTomorrow.json()]);
-    if (dToday.success && dToday.guide) guides.today = dToday.guide; else guides.today = null;
-    if (dTomorrow.success && dTomorrow.guide) guides.tomorrow = dTomorrow.guide; else guides.tomorrow = null;
+    if (dToday.success && dToday.guide) { guides.today = dToday.guide; guides.todayCount = dToday.guide_count || 1; } else { guides.today = null; guides.todayCount = 0; }
+    if (dTomorrow.success && dTomorrow.guide) { guides.tomorrow = dTomorrow.guide; guides.tomorrowCount = dTomorrow.guide_count || 1; } else { guides.tomorrow = null; guides.tomorrowCount = 0; }
     todayGuide = guides.today || guides.tomorrow;
     updateUploadBtn();
     if (guides.today || guides.tomorrow) scheduleInject();


### PR DESCRIPTION
## Problema
Ao carregar uma segunda Guia AT para o mesmo dia, o sistema apagava a primeira e substituía-a — perdendo os eurocodes da guia anterior.

## Solução
- **Backend**: O POST deixa de apagar a guia existente para a mesma data. Cada upload cria uma nova linha. O GET e o POST devolvem os eurocodes merged de todas as guias do dia.
- **Frontend**: Após upload, guarda os eurocodes acumulados (não apenas os da nova guia). O botão mostra a contagem quando há múltiplas guias (ex: `Guia AT ✓×3`). O toast indica quantos novos códigos foram encontrados e o total acumulado.

## Comportamento
- Podem ser carregadas N guias por dia — os eurocodes somam-se
- Os badges na agenda usam o conjunto completo de eurocodes de todas as guias
- Limpeza automática mantém-se: guias com mais de 1 dia são apagadas

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_