### PR TITLE
Split Guia AT into separate Hoje/Amanhã buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,9 +196,13 @@
         <!-- Guia AT upload (coordinator/admin only, desktop) -->
         <div id="guiaATUploadAreaDesk" style="display:none; align-items:center; gap:6px;">
           <input type="file" id="guiaATFileInputDesk" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
-          <button id="guiaATUploadBtnDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this)">
+          <button id="guiaATUploadBtnHojeDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'today')">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Guia AT
+            Hoje
+          </button>
+          <button id="guiaATUploadBtnAmanhaDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'tomorrow')">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            Amanhã
           </button>
           <button id="ecReminderBtnDesk" class="ec-rem-trigger-btn" onclick="ecReminder.showNow()" title="Ver Eurocodes de amanhã">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
@@ -293,9 +297,13 @@
       <div id="guiaATUploadArea" style="padding:6px 14px 0; display:none; flex-direction:column; gap:6px;">
         <input type="file" id="guiaATFileInput" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
-          <button id="guiaATUploadBtn" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this)">
+          <button id="guiaATUploadBtnHoje" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'today')">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Guia AT
+            Hoje
+          </button>
+          <button id="guiaATUploadBtnAmanha" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'tomorrow')">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            Amanhã
           </button>
           <button id="ecReminderBtn" class="ec-rem-trigger-btn" onclick="ecReminder.showNow()" title="Ver Eurocodes de amanhã">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
@@ -1005,10 +1013,7 @@
 
   <!-- Guia AT upload menu (shared, coordinator only) -->
   <div id="guiaATMenu" class="guia-at-menu" style="display:none" onclick="event.stopPropagation()">
-    <div class="guia-at-date-toggle">
-      <button id="guiaATDate_hoje" class="guia-at-date-opt active" onclick="guiaAT.setUploadDate('today')">Hoje</button>
-      <button id="guiaATDate_amanha" class="guia-at-date-opt" onclick="guiaAT.setUploadDate('tomorrow')">Amanhã</button>
-    </div>
+    <div id="guiaATMenuTitle" style="padding:6px 12px 4px;font-size:11px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:.04em;">Guia AT — Hoje</div>
     <div class="guia-at-menu-divider"></div>
     <button class="guia-at-menu-item" onclick="guiaAT.triggerFileInput()">
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -213,10 +213,13 @@
 
   let _menuBtn = null;
 
-  function toggleMenu(btn) {
+  function toggleMenu(btn, forDate) {
+    if (forDate) setUploadDate(forDate);
     const menu = document.getElementById('guiaATMenu');
     if (!menu) return;
     if (menu.style.display !== 'none') { closeMenu(); return; }
+    const title = document.getElementById('guiaATMenuTitle');
+    if (title) title.textContent = `Guia AT — ${uploadDate === 'tomorrow' ? 'Amanhã' : 'Hoje'}`;
 
     _menuBtn = btn;
     const rect = btn.getBoundingClientRect();
@@ -242,10 +245,12 @@
   }
 
   function triggerFileInput() {
+    const wasBtn = _menuBtn;
     closeMenu();
+    const isDesk = wasBtn?.id?.includes('Desk');
     const deskInput = document.getElementById('guiaATFileInputDesk');
     const mobileInput = document.getElementById('guiaATFileInput');
-    const input = (deskInput && document.getElementById('guiaATUploadAreaDesk')?.style.display !== 'none') ? deskInput : mobileInput;
+    const input = isDesk ? deskInput : (mobileInput || deskInput);
     if (input) input.click();
   }
 
@@ -324,25 +329,27 @@
   }
 
   function updateUploadBtn() {
-    const hasToday = !!guides.today;
-    const hasTomorrow = !!guides.tomorrow;
-    const loaded = hasToday || hasTomorrow;
-    const todayCount = guides.todayCount || (hasToday ? 1 : 0);
-    const tomorrowCount = guides.tomorrowCount || (hasTomorrow ? 1 : 0);
-    const todayLabel = todayCount > 1 ? `✓×${todayCount}` : (hasToday ? '✓' : '');
-    const tomorrowLabel = tomorrowCount > 1 ? `+1×${tomorrowCount}` : (hasTomorrow ? '+1✓' : '');
-    const label = hasToday && hasTomorrow ? `Guia AT ${todayLabel} ${tomorrowLabel}`.trim()
-                : hasToday ? `Guia AT ${todayLabel}`
-                : hasTomorrow ? `Guia AT ${tomorrowLabel}`
-                : 'Guia AT';
-    const icon = loaded
-      ? '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
-      : '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>';
-    const btns = [document.getElementById('guiaATUploadBtn'), document.getElementById('guiaATUploadBtnDesk')];
-    btns.forEach(btn => {
+    const uploadIcon = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>';
+    const docIcon = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>';
+
+    const todayCount = guides.todayCount || (guides.today ? 1 : 0);
+    const hojeLoaded = !!guides.today;
+    const hojeLabel = todayCount > 1 ? `Hoje ✓×${todayCount}` : hojeLoaded ? 'Hoje ✓' : 'Hoje';
+    ['guiaATUploadBtnHoje', 'guiaATUploadBtnHojeDesk'].forEach(id => {
+      const btn = document.getElementById(id);
       if (!btn) return;
-      btn.innerHTML = `${icon} ${label}`;
-      btn.classList.toggle('guia-at-loaded', loaded);
+      btn.innerHTML = `${hojeLoaded ? docIcon : uploadIcon} ${hojeLabel}`;
+      btn.classList.toggle('guia-at-loaded', hojeLoaded);
+    });
+
+    const tomorrowCount = guides.tomorrowCount || (guides.tomorrow ? 1 : 0);
+    const amanhaLoaded = !!guides.tomorrow;
+    const amanhaLabel = tomorrowCount > 1 ? `Amanhã ✓×${tomorrowCount}` : amanhaLoaded ? 'Amanhã ✓' : 'Amanhã';
+    ['guiaATUploadBtnAmanha', 'guiaATUploadBtnAmanhaDesk'].forEach(id => {
+      const btn = document.getElementById(id);
+      if (!btn) return;
+      btn.innerHTML = `${amanhaLoaded ? docIcon : uploadIcon} ${amanhaLabel}`;
+      btn.classList.toggle('guia-at-loaded', amanhaLoaded);
     });
   }
 


### PR DESCRIPTION
## O que muda

Em vez de um único botão "Guia AT" que misturava hoje e amanhã, passam a existir **dois botões separados**:

- **Hoje** — mostra o estado da guia de hoje (`Hoje`, `Hoje ✓`, `Hoje ✓×3`)
- **Amanhã** — mostra o estado da guia de amanhã (`Amanhã`, `Amanhã ✓`, `Amanhã ✓×2`)

Clicar em cada botão abre o menu de upload pré-selecionado para a data correspondente.

## Detalhes técnicos
- IDs novos: `guiaATUploadBtnHoje`, `guiaATUploadBtnAmanha` (mobile) e `*Desk` (desktop)
- `toggleMenu(btn, forDate)` aceita agora a data como parâmetro opcional
- O seletor Hoje/Amanhã foi removido do menu (substituído por título dinâmico)
- `updateUploadBtn()` atualiza cada botão de forma independente

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_