### PR TITLE
Add Hoje EC button alongside Amanhã button

### DIFF
--- a/eurocode-reminder.js
+++ b/eurocode-reminder.js
@@ -26,9 +26,12 @@
     localStorage.setItem(todayKey(), '1');
   }
 
-  function apiUrl() {
+  function apiUrl(forToday) {
     const portalId = window.activePortalId;
-    return API + (portalId ? `?portal_id=${portalId}` : '');
+    const parts = [];
+    if (portalId) parts.push(`portal_id=${portalId}`);
+    if (forToday) parts.push('date=today');
+    return API + (parts.length ? '?' + parts.join('&') : '');
   }
 
   async function checkAndShow() {
@@ -39,7 +42,7 @@
     try {
       const res = await authFetch(apiUrl());
       const data = await res.json();
-      if (data.success) renderPopup(data.portals, data.date);
+      if (data.success) renderPopup(data.portals, data.date, false);
     } catch (e) {
       console.error('Eurocode reminder:', e);
     }
@@ -50,7 +53,7 @@
     return `${d}/${m}/${y}`;
   }
 
-  function renderPopup(portals, date) {
+  function renderPopup(portals, date, forToday) {
     document.getElementById('ecReminderModal')?.remove();
 
     const empty = !portals.length || portals.every(p => !p.eurocodes.length);
@@ -82,7 +85,7 @@
         <div class="ec-rem-header">
           <span class="ec-rem-title">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-            Guia AT — Amanhã ${fmtDate(date)}
+            Guia AT — ${forToday ? 'Hoje' : 'Amanhã'} ${fmtDate(date)}
           </span>
           <button class="ec-rem-close" onclick="document.getElementById('ecReminderModal').remove()">✕</button>
         </div>
@@ -165,13 +168,23 @@
     try {
       const res = await authFetch(apiUrl());
       const data = await res.json();
-      if (data.success) renderPopup(data.portals, data.date);
+      if (data.success) renderPopup(data.portals, data.date, false);
     } catch (e) {
       console.error('Eurocode reminder:', e);
     }
   }
 
-  window.ecReminder = { copy: copyCode, print: printCodes, showNow };
+  async function showToday() {
+    try {
+      const res = await authFetch(apiUrl(true));
+      const data = await res.json();
+      if (data.success) renderPopup(data.portals, data.date, true);
+    } catch (e) {
+      console.error('Eurocode reminder today:', e);
+    }
+  }
+
+  window.ecReminder = { copy: copyCode, print: printCodes, showNow, showToday };
 
   // Start after portal is ready
   let _started = false;

--- a/index.html
+++ b/index.html
@@ -196,13 +196,13 @@
         <!-- Guia AT upload (coordinator/admin only, desktop) -->
         <div id="guiaATUploadAreaDesk" style="display:none; align-items:center; gap:6px;">
           <input type="file" id="guiaATFileInputDesk" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
-          <button id="guiaATUploadBtnHojeDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'today')">
+          <button id="guiaATUploadBtnDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this)">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Hoje
+            Guia AT
           </button>
-          <button id="guiaATUploadBtnAmanhaDesk" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'tomorrow')">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Amanhã
+          <button id="ecReminderBtnHojeDesk" class="ec-rem-trigger-btn" onclick="ecReminder.showToday()" title="Ver Eurocodes de hoje">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+            Hoje
           </button>
           <button id="ecReminderBtnDesk" class="ec-rem-trigger-btn" onclick="ecReminder.showNow()" title="Ver Eurocodes de amanhã">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
@@ -297,13 +297,13 @@
       <div id="guiaATUploadArea" style="padding:6px 14px 0; display:none; flex-direction:column; gap:6px;">
         <input type="file" id="guiaATFileInput" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
-          <button id="guiaATUploadBtnHoje" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'today')">
+          <button id="guiaATUploadBtn" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this)">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Hoje
+            Guia AT
           </button>
-          <button id="guiaATUploadBtnAmanha" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this,'tomorrow')">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Amanhã
+          <button id="ecReminderBtnHoje" class="ec-rem-trigger-btn" onclick="ecReminder.showToday()" title="Ver Eurocodes de hoje">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+            Hoje
           </button>
           <button id="ecReminderBtn" class="ec-rem-trigger-btn" onclick="ecReminder.showNow()" title="Ver Eurocodes de amanhã">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
@@ -1013,7 +1013,10 @@
 
   <!-- Guia AT upload menu (shared, coordinator only) -->
   <div id="guiaATMenu" class="guia-at-menu" style="display:none" onclick="event.stopPropagation()">
-    <div id="guiaATMenuTitle" style="padding:6px 12px 4px;font-size:11px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:.04em;">Guia AT — Hoje</div>
+    <div class="guia-at-date-toggle">
+      <button id="guiaATDate_hoje" class="guia-at-date-opt active" onclick="guiaAT.setUploadDate('today')">Hoje</button>
+      <button id="guiaATDate_amanha" class="guia-at-date-opt" onclick="guiaAT.setUploadDate('tomorrow')">Amanhã</button>
+    </div>
     <div class="guia-at-menu-divider"></div>
     <button class="guia-at-menu-item" onclick="guiaAT.triggerFileInput()">
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>

--- a/netlify/functions/tomorrow-eurocodes.js
+++ b/netlify/functions/tomorrow-eurocodes.js
@@ -53,6 +53,10 @@ exports.handler = async (event) => {
     // Prefer active portal from frontend; fall back to JWT portalId
     const portalId = (p.portal_id ? parseInt(p.portal_id) : null) || user.portalId;
 
+    // date param: 'today' uses today, anything else (default) uses tomorrow
+    const useToday = p.date === 'today';
+    const targetDate = useToday ? 'CURRENT_DATE' : '(CURRENT_DATE + INTERVAL \'1 day\')::date';
+
     let rows;
     if (user.role === 'admin' && !portalId) {
       // Admin sem portal específico — mostra todos os SM
@@ -60,7 +64,7 @@ exports.handler = async (event) => {
         SELECT a.portal_id, p.name AS portal_name, a.extra, a.notes, a.plate, a.car
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
-        WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
+        WHERE a.date::date = ${targetDate}
           AND COALESCE(p.portal_type, '') NOT IN ('loja', 'mycar')
           AND (
             (a.extra IS NOT NULL AND a.extra != '')
@@ -75,7 +79,7 @@ exports.handler = async (event) => {
         SELECT a.portal_id, p.name AS portal_name, a.extra, a.notes, a.plate, a.car
         FROM appointments a
         JOIN portals p ON p.id = a.portal_id
-        WHERE a.date::date = (CURRENT_DATE + INTERVAL '1 day')::date
+        WHERE a.date::date = ${targetDate}
           AND a.portal_id = $1
           AND COALESCE(p.portal_type, '') NOT IN ('loja', 'mycar')
           AND (
@@ -97,17 +101,17 @@ exports.handler = async (event) => {
       }
       byPortal[row.portal_id].eurocodes.push(ec);
     }
-    const portals = Object.values(byPortal).map(p => ({
-      ...p,
-      eurocodes: [...new Set(p.eurocodes)]
+    const portals = Object.values(byPortal).map(pp => ({
+      ...pp,
+      eurocodes: [...new Set(pp.eurocodes)]
     }));
 
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
+    const refDate = new Date();
+    if (!useToday) refDate.setDate(refDate.getDate() + 1);
 
     return {
       statusCode: 200, headers,
-      body: JSON.stringify({ success: true, date: tomorrow.toISOString().split('T')[0], portals })
+      body: JSON.stringify({ success: true, date: refDate.toISOString().split('T')[0], portals })
     };
   } catch (err) {
     console.error('tomorrow-eurocodes error:', err);

--- a/transport-guide.js
+++ b/transport-guide.js
@@ -213,13 +213,10 @@
 
   let _menuBtn = null;
 
-  function toggleMenu(btn, forDate) {
-    if (forDate) setUploadDate(forDate);
+  function toggleMenu(btn) {
     const menu = document.getElementById('guiaATMenu');
     if (!menu) return;
     if (menu.style.display !== 'none') { closeMenu(); return; }
-    const title = document.getElementById('guiaATMenuTitle');
-    if (title) title.textContent = `Guia AT — ${uploadDate === 'tomorrow' ? 'Amanhã' : 'Hoje'}`;
 
     _menuBtn = btn;
     const rect = btn.getBoundingClientRect();
@@ -245,12 +242,10 @@
   }
 
   function triggerFileInput() {
-    const wasBtn = _menuBtn;
     closeMenu();
-    const isDesk = wasBtn?.id?.includes('Desk');
     const deskInput = document.getElementById('guiaATFileInputDesk');
     const mobileInput = document.getElementById('guiaATFileInput');
-    const input = isDesk ? deskInput : (mobileInput || deskInput);
+    const input = (deskInput && document.getElementById('guiaATUploadAreaDesk')?.style.display !== 'none') ? deskInput : mobileInput;
     if (input) input.click();
   }
 
@@ -329,27 +324,25 @@
   }
 
   function updateUploadBtn() {
-    const uploadIcon = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>';
-    const docIcon = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>';
-
-    const todayCount = guides.todayCount || (guides.today ? 1 : 0);
-    const hojeLoaded = !!guides.today;
-    const hojeLabel = todayCount > 1 ? `Hoje ✓×${todayCount}` : hojeLoaded ? 'Hoje ✓' : 'Hoje';
-    ['guiaATUploadBtnHoje', 'guiaATUploadBtnHojeDesk'].forEach(id => {
-      const btn = document.getElementById(id);
+    const hasToday = !!guides.today;
+    const hasTomorrow = !!guides.tomorrow;
+    const loaded = hasToday || hasTomorrow;
+    const todayCount = guides.todayCount || (hasToday ? 1 : 0);
+    const tomorrowCount = guides.tomorrowCount || (hasTomorrow ? 1 : 0);
+    const todayLabel = todayCount > 1 ? `✓×${todayCount}` : (hasToday ? '✓' : '');
+    const tomorrowLabel = tomorrowCount > 1 ? `+1×${tomorrowCount}` : (hasTomorrow ? '+1✓' : '');
+    const label = hasToday && hasTomorrow ? `Guia AT ${todayLabel} ${tomorrowLabel}`.trim()
+                : hasToday ? `Guia AT ${todayLabel}`
+                : hasTomorrow ? `Guia AT ${tomorrowLabel}`
+                : 'Guia AT';
+    const icon = loaded
+      ? '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>'
+      : '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>';
+    const btns = [document.getElementById('guiaATUploadBtn'), document.getElementById('guiaATUploadBtnDesk')];
+    btns.forEach(btn => {
       if (!btn) return;
-      btn.innerHTML = `${hojeLoaded ? docIcon : uploadIcon} ${hojeLabel}`;
-      btn.classList.toggle('guia-at-loaded', hojeLoaded);
-    });
-
-    const tomorrowCount = guides.tomorrowCount || (guides.tomorrow ? 1 : 0);
-    const amanhaLoaded = !!guides.tomorrow;
-    const amanhaLabel = tomorrowCount > 1 ? `Amanhã ✓×${tomorrowCount}` : amanhaLoaded ? 'Amanhã ✓' : 'Amanhã';
-    ['guiaATUploadBtnAmanha', 'guiaATUploadBtnAmanhaDesk'].forEach(id => {
-      const btn = document.getElementById(id);
-      if (!btn) return;
-      btn.innerHTML = `${amanhaLoaded ? docIcon : uploadIcon} ${amanhaLabel}`;
-      btn.classList.toggle('guia-at-loaded', amanhaLoaded);
+      btn.innerHTML = `${icon} ${label}`;
+      btn.classList.toggle('guia-at-loaded', loaded);
     });
   }
 


### PR DESCRIPTION
## O que muda

Adiciona um botão **"Hoje"** antes do botão "Amanhã" existente, tanto no toolbar mobile como no desktop.

- Clicar em **Hoje** abre o mesmo modal do "Amanhã" mas com os Eurocodes dos serviços de hoje
- O título do modal indica dinamicamente "Hoje" ou "Amanhã"
- O botão "Guia AT" (upload) **não foi alterado** — fica exactamente como estava
- Reverte as alterações incorrectas do PR #245 que tinham dividido o Guia AT em dois botões

## Detalhes técnicos
- `tomorrow-eurocodes` API aceita agora `?date=today` para retornar dados de hoje
- `ecReminder.showToday()` chama a API com `date=today`
- `ecReminder.showNow()` continua a funcionar como antes (amanhã)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_