### PR TITLE
Fix: bump eurocode-reminder.js cache version so Hoje button works

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,7 +1032,7 @@
   </div>
 
   <script src="transport-guide.js?v=2026-05-28a"></script>
-  <script src="eurocode-reminder.js?v=2026-05-19a"></script>
+  <script src="eurocode-reminder.js?v=2026-06-09a"></script>
   <script>
 // ===== HISTÓRICO DE SERVIÇOS (inline) =====
 (function () {


### PR DESCRIPTION
O browser estava a servir a versão antiga do `eurocode-reminder.js` (v=2026-05-19a) sem o `showToday`, ignorando o ficheiro actualizado. Actualiza o cache-bust para `v=2026-06-09a`.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_