### PR TITLE
Bump script-tail.js cache version for button alignment fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-05b"></script>
-  <script src="script-tail.js?v=2026-06-06h"></script>
+  <script src="script-tail.js?v=2026-06-09a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>


### PR DESCRIPTION
O browser estava a servir o `script-tail.js` antigo (v=2026-06-06h) ignorando a correção de alinhamento dos botões. Bumpa para `v=2026-06-09a`.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_