### PR TITLE
Fix coordinator reports portal dropdown empty

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -75,17 +75,15 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
-  const portalIds = user.portalIds || [];
-  if (!portalIds.length) return;
-  try {
-    const resp = await authClient.authenticatedFetch('/.netlify/functions/portals');
-    const data = await resp.json();
-    if (data.success) {
-      portals = data.data.filter(p => portalIds.includes(p.id));
-      window._adminPortals = portals;
-      populateReportPortalSelect(portals);
-    }
-  } catch(e) { console.error('Erro ao carregar portais:', e); }
+  // Use portals stored in session at login (avoids calling admin-only /portals API)
+  let list = user.portals || [];
+  if (user?.portal?.id && !list.find(p => p.id === user.portal.id)) {
+    list = [user.portal, ...list];
+  }
+  if (!list.length) return;
+  portals = list;
+  window._adminPortals = list;
+  populateReportPortalSelect(list);
 }
 
 function populateReportPortalSelect(portalList) {

--- a/reports-widget.js
+++ b/reports-widget.js
@@ -23,18 +23,27 @@ async function _rwLoadPortals() {
   if (!sel || sel.options.length > 1) return; // already loaded
   try {
     const user = window.authClient?.getUser();
-    const resp = await window.authClient.authenticatedFetch('/.netlify/functions/portals');
-    const data = await resp.json();
-    if (!data.success) return;
-    let list = data.data || [];
-    if (user?.role !== 'admin') {
-      const ids = user?.portalIds || (user?.portalId ? [user.portalId] : []);
-      list = list.filter(p => ids.includes(p.id));
+    let list = [];
+
+    if (user?.role === 'admin') {
+      // Admin: fetch all portals from API
+      const resp = await window.authClient.authenticatedFetch('/.netlify/functions/portals');
+      const data = await resp.json();
+      if (!data.success) return;
+      list = data.data || [];
+    } else {
+      // Coordinator/other: use portals stored in session at login time
+      list = user?.portals || [];
+      // Include primary portal if missing from list
+      if (user?.portal?.id && !list.find(p => p.id === user.portal.id)) {
+        list = [user.portal, ...list];
+      }
     }
+
     sel.innerHTML = '<option value="">Selecionar portal</option>' +
       list.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
     // Pre-select if only one
-    if (list.length === 1) sel.value = list[0].id;
+    if (list.length === 1) sel.value = String(list[0].id);
   } catch(e) { console.error('reports-widget: loadPortals', e); }
 }
 


### PR DESCRIPTION
## Problema
O dropdown de portais nos Relatórios aparecia vazio para coordinadores. A API `/.netlify/functions/portals` só aceita admins — coordinadores recebiam 403.

## Solução
Em vez de chamar a API (admin-only), usa `user.portals` que já está guardado na sessão desde o login. Esta lista é preenchida pelo `auth-login.js` com os portais atribuídos ao coordinador.

Corrigido em `reports-widget.js` (painel de relatórios do `index.html`) e `admin-script.js`.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_