### PR TITLE
Fix glass reception data leak across portals for coordinators

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -75,17 +75,15 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
-  const portalIds = user.portalIds || [];
-  if (!portalIds.length) return;
-  try {
-    const resp = await authClient.authenticatedFetch('/.netlify/functions/portals');
-    const data = await resp.json();
-    if (data.success) {
-      portals = data.data.filter(p => portalIds.includes(p.id));
-      window._adminPortals = portals;
-      populateReportPortalSelect(portals);
-    }
-  } catch(e) { console.error('Erro ao carregar portais:', e); }
+  // Use portals stored in session at login (avoids calling admin-only /portals API)
+  let list = user.portals || [];
+  if (user?.portal?.id && !list.find(p => p.id === user.portal.id)) {
+    list = [user.portal, ...list];
+  }
+  if (!list.length) return;
+  portals = list;
+  window._adminPortals = list;
+  populateReportPortalSelect(list);
 }
 
 function populateReportPortalSelect(portalList) {

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -169,8 +169,13 @@ exports.handler = async (event) => {
 
       if (p.status) { q += ` AND gr.status = $${idx++}`; vals.push(p.status); }
 
-      // Técnicos só vêem do seu portal
-      if (user.role === 'user') { q += ` AND gr.portal_id = $${idx++}`; vals.push(user.portalId); }
+      // Portal access control — same logic as history/returns queries
+      if (user.role === 'user') {
+        q += ` AND gr.portal_id = $${idx++}`; vals.push(user.portalId);
+      } else if (user.role !== 'admin') {
+        const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+        if (ids.length) { q += ` AND gr.portal_id = ANY($${idx++})`; vals.push(ids); }
+      }
 
       q += ` ORDER BY gr.created_at DESC LIMIT 300`;
 

--- a/reports-widget.js
+++ b/reports-widget.js
@@ -23,18 +23,27 @@ async function _rwLoadPortals() {
   if (!sel || sel.options.length > 1) return; // already loaded
   try {
     const user = window.authClient?.getUser();
-    const resp = await window.authClient.authenticatedFetch('/.netlify/functions/portals');
-    const data = await resp.json();
-    if (!data.success) return;
-    let list = data.data || [];
-    if (user?.role !== 'admin') {
-      const ids = user?.portalIds || (user?.portalId ? [user.portalId] : []);
-      list = list.filter(p => ids.includes(p.id));
+    let list = [];
+
+    if (user?.role === 'admin') {
+      // Admin: fetch all portals from API
+      const resp = await window.authClient.authenticatedFetch('/.netlify/functions/portals');
+      const data = await resp.json();
+      if (!data.success) return;
+      list = data.data || [];
+    } else {
+      // Coordinator/other: use portals stored in session at login time
+      list = user?.portals || [];
+      // Include primary portal if missing from list
+      if (user?.portal?.id && !list.find(p => p.id === user.portal.id)) {
+        list = [user.portal, ...list];
+      }
     }
+
     sel.innerHTML = '<option value="">Selecionar portal</option>' +
       list.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
     // Pre-select if only one
-    if (list.length === 1) sel.value = list[0].id;
+    if (list.length === 1) sel.value = String(list[0].id);
   } catch(e) { console.error('reports-widget: loadPortals', e); }
 }
 


### PR DESCRIPTION
## Problema de segurança
Na query de listagem de receções pendentes, o filtro de portal só era aplicado para `role=user`. Coordinadores (`coordenador`) não tinham qualquer filtro — viam receções de **todos os portais** da base de dados.

## Causa
Linha 173 de `glass-reception.js`:
```js
// ANTES — só filtrava técnicos
if (user.role === 'user') { q += ` AND gr.portal_id = ...` }
```

## Correção
Aplicado o mesmo padrão `ANY($ids)` já usado nas queries de histórico e devoluções:
```js
if (user.role === 'user') { ... }
else if (user.role !== 'admin') {
  const ids = user.portalIds?.length ? user.portalIds : ...
  if (ids.length) { q += ` AND gr.portal_id = ANY($${idx++})` }
}
```

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_