### PR TITLE
Fix team check-in section missing from coordinator reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,7 +819,7 @@
   <script src="excel-import.js?v=2026-06-05a"></script>
   <script src="excel-import-ui.js?v=2026-06-05a"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-  <script src="reports-widget.js?v=2026-06-05b"></script>
+  <script src="reports-widget.js?v=2026-06-09a"></script>
   <script src="glass-alert.js?v=2026-04-09"></script>
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
   <script src="incomplete-services-alert.js?v=2026-06-01c"></script>

--- a/reports-widget.js
+++ b/reports-widget.js
@@ -396,7 +396,12 @@ function _rwRenderReport(data) {
         </div>`;
       teamSec.style.display = 'block';
     } else {
-      teamSec.style.display = 'none';
+      teamSec.innerHTML = `
+        <div style="border-top:2px solid #7c3aed;padding-top:24px;margin-top:32px;">
+          <h3 style="font-size:16px;font-weight:700;color:#7c3aed;margin-bottom:12px;">⏱️ Equipa — Tempos e Rentabilidade</h3>
+          <p style="color:#94a3b8;font-size:13px;">Sem registos de check-in/check-out para o período selecionado.</p>
+        </div>`;
+      teamSec.style.display = 'block';
     }
   }
 


### PR DESCRIPTION
## Problema
A secção "Equipa — Tempos e Rentabilidade" não aparecia nos relatórios do coordenador por duas razões:

1. **Cache**: `reports-widget.js` tinha version tag `v=2026-06-05b` — o browser servia a versão antiga sem a secção de equipa. Bumpa para `v=2026-06-09a`.

2. **Sem dados**: a secção só aparecia quando existiam check-ins para o período (`teamStats.length > 0`). Quando não há registos, a secção ficava completamente oculta sem qualquer indicação. Agora mostra sempre com mensagem "Sem registos de check-in/check-out para o período selecionado."

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_