### PR TITLE
fix: restrict check-in monitor to SM portals only

### DIFF
--- a/netlify/functions/checkins-monitor.js
+++ b/netlify/functions/checkins-monitor.js
@@ -54,7 +54,7 @@ exports.handler = async (event) => {
         tc.notes
       FROM portals p
       LEFT JOIN team_checkins tc ON tc.portal_id = p.id AND tc.date = $1
-      WHERE COALESCE(p.portal_type, 'sm') NOT IN ('mycar')
+      WHERE COALESCE(p.portal_type, 'sm') = 'sm'
         ${portalFilter}
       ORDER BY
         CASE


### PR DESCRIPTION
Fix check-in monitor to only show SM portals (excludes loja, mycar, etc).

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_