### PR TITLE
fix: round minutes to avoid float in net hours display

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -698,10 +698,10 @@
 
     function netHours(checkin, checkout) {
       if (!checkin || !checkout) return null;
-      const mins = (new Date(checkout) - new Date(checkin)) / 60000 - 60; // deduct 1h lunch
-      if (mins <= 0) return null;
-      const h = Math.floor(mins / 60);
-      const m = mins % 60;
+      const totalMins = Math.round((new Date(checkout) - new Date(checkin)) / 60000) - 60;
+      if (totalMins <= 0) return null;
+      const h = Math.floor(totalMins / 60);
+      const m = totalMins % 60;
       return h + 'h' + (m > 0 ? String(m).padStart(2, '0') : '');
     }
 


### PR DESCRIPTION
Fix float minutes in net hours badge (e.g. `5h25.804...` → `5h26`). Use `Math.round` on total minutes before splitting into hours/minutes.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_