### PR TITLE
feat: add fuel cost per service to team check-in report

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1866,10 +1866,16 @@ function _renderTeamSection(teamStats) {
   const totalKm = teamStats.reduce((s,r) => s + parseFloat(r.km_day||0), 0);
   const servicesPerHour = totalNetHrs > 0 ? totalServices / totalNetHrs : 0;
 
+  const fuelPer100 = parseFloat(document.getElementById('fuelConsumption')?.value) || 7.5;
+  const fuelPricePerLtr = parseFloat(document.getElementById('fuelPrice')?.value) || 1.65;
+  const calcFuelCost = km => km * fuelPer100 / 100 * fuelPricePerLtr;
+  const totalFuelCost = calcFuelCost(totalKm);
+  const avgCostPerService = totalServices > 0 ? totalFuelCost / totalServices : 0;
+
   sec.innerHTML = `
     <div style="border-top:2px solid #7c3aed;padding-top:24px;margin-top:32px;">
       <h3 style="font-size:16px;font-weight:700;color:#7c3aed;margin-bottom:16px;">⏱️ Equipa — Tempos e Rentabilidade</h3>
-      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:20px;">
+      <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:20px;">
         <div style="background:#f5f3ff;border-radius:10px;padding:14px;text-align:center;">
           <div style="font-size:11px;font-weight:700;color:#7c3aed;margin-bottom:4px;">DIAS REGISTADOS</div>
           <div style="font-size:26px;font-weight:900;color:#7c3aed;">${teamStats.length}</div>
@@ -1886,6 +1892,11 @@ function _renderTeamSection(teamStats) {
           <div style="font-size:11px;font-weight:700;color:#ea580c;margin-bottom:4px;">SERV./HORA</div>
           <div style="font-size:26px;font-weight:900;color:#ea580c;">${servicesPerHour.toFixed(2)}</div>
         </div>
+        <div style="background:#fdf4ff;border-radius:10px;padding:14px;text-align:center;">
+          <div style="font-size:11px;font-weight:700;color:#9333ea;margin-bottom:4px;">CUSTO/SERVIÇO</div>
+          <div style="font-size:26px;font-weight:900;color:#9333ea;">${avgCostPerService.toFixed(2)}€</div>
+          <div style="font-size:10px;color:#94a3b8;margin-top:2px;">${totalFuelCost.toFixed(2)}€ total combust.</div>
+        </div>
       </div>
       <table style="width:100%;border-collapse:collapse;font-size:13px;">
         <thead><tr style="background:#f5f3ff;">
@@ -1896,6 +1907,8 @@ function _renderTeamSection(teamStats) {
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">Serviços</th>
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">KM</th>
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">Serv./hora</th>
+          <th style="padding:9px 10px;text-align:center;font-weight:700;color:#9333ea;border-bottom:2px solid #e2e8f0;">Custo combust.</th>
+          <th style="padding:9px 10px;text-align:center;font-weight:700;color:#9333ea;border-bottom:2px solid #e2e8f0;">€/serviço</th>
         </tr></thead>
         <tbody>
           ${teamStats.map((r,i) => {
@@ -1903,14 +1916,19 @@ function _renderTeamSection(teamStats) {
             const net = hrsRaw != null ? Math.max(0, hrsRaw - 1) : null;
             const svcs = parseInt(r.services_done||0);
             const sph = net > 0 ? (svcs / net).toFixed(2) : '—';
+            const km = parseFloat(r.km_day||0);
+            const fuelCost = calcFuelCost(km);
+            const cps = svcs > 0 ? (fuelCost / svcs).toFixed(2) + '€' : '—';
             return `<tr style="border-bottom:1px solid #f1f5f9;${i%2===0?'background:#fafafa':''}">
               <td style="padding:8px 10px;font-weight:600;">${fmtD(r.date)}</td>
               <td style="padding:8px 10px;text-align:center;color:${r.checkin_auto?'#94a3b8':'#16a34a'};font-weight:600;">${fmtT(r.checkin_at)}${r.checkin_auto?' *':''}</td>
               <td style="padding:8px 10px;text-align:center;color:${r.checkout_auto?'#94a3b8':'#1d4ed8'};font-weight:600;">${fmtT(r.checkout_at)}${r.checkout_auto?' *':''}</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;color:#7c3aed;">${fmtH(net)}</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;">${svcs}</td>
-              <td style="padding:8px 10px;text-align:center;">${parseFloat(r.km_day||0).toFixed(0)} km</td>
+              <td style="padding:8px 10px;text-align:center;">${km.toFixed(0)} km</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;color:#ea580c;">${sph}</td>
+              <td style="padding:8px 10px;text-align:center;color:#9333ea;">${fuelCost.toFixed(2)}€</td>
+              <td style="padding:8px 10px;text-align:center;font-weight:700;color:#9333ea;">${cps}</td>
             </tr>`;
           }).join('')}
           <tr style="background:#f5f3ff;font-weight:700;border-top:2px solid #e2e8f0;">
@@ -1920,10 +1938,12 @@ function _renderTeamSection(teamStats) {
             <td style="padding:8px 10px;text-align:center;">${totalServices}</td>
             <td style="padding:8px 10px;text-align:center;">${totalKm.toFixed(0)} km</td>
             <td style="padding:8px 10px;text-align:center;color:#ea580c;">${servicesPerHour.toFixed(2)}</td>
+            <td style="padding:8px 10px;text-align:center;color:#9333ea;">${totalFuelCost.toFixed(2)}€</td>
+            <td style="padding:8px 10px;text-align:center;font-weight:700;color:#9333ea;">${avgCostPerService.toFixed(2)}€</td>
           </tr>
         </tbody>
       </table>
-      <p style="font-size:11px;color:#94a3b8;margin-top:8px;">* preenchido automaticamente · Horas líquidas = horas brutas − 1h almoço</p>
+      <p style="font-size:11px;color:#94a3b8;margin-top:8px;">* preenchido automaticamente · Horas líquidas = horas brutas − 1h almoço · Custo = combustível (${fuelPer100}L/100km × ${fuelPricePerLtr}€/L)</p>
     </div>`;
   sec.style.display = 'block';
 }

--- a/admin.html
+++ b/admin.html
@@ -603,7 +603,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-09b"></script>
+  <script src="admin-script.js?v=2026-06-09c"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Summary

- Adds 5th KPI card **CUSTO/SERVIÇO** to the "Equipa — Tempos e Rentabilidade" report section
- Adds two new table columns: **Custo combust.** (daily fuel cost) and **€/serviço** (cost divided by services done that day)
- Uses the configured fuel rates from Settings (L/100km × €/L), so values match what technicians see in the day summary card
- Shows total fuel cost and average cost/service in the TOTAL row
- Footer note shows the rates used (e.g. "Custo = combustível (7.5L/100km × 1.65€/L)")

## Test plan

- [ ] Open admin report for a portal with check-in data (e.g. Braga SM, June 2026)
- [ ] Confirm "Equipa — Tempos e Rentabilidade" shows 5 KPI cards including CUSTO/SERVIÇO
- [ ] Confirm table has Custo combust. and €/serviço columns with correct values
- [ ] Change fuel price in Settings, regenerate report, verify numbers update

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_