### PR TITLE
fix: auto-normalize order_ref to Enc.Axial prefix on all write paths

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1866,10 +1866,16 @@ function _renderTeamSection(teamStats) {
   const totalKm = teamStats.reduce((s,r) => s + parseFloat(r.km_day||0), 0);
   const servicesPerHour = totalNetHrs > 0 ? totalServices / totalNetHrs : 0;
 
+  const fuelPer100 = parseFloat(document.getElementById('fuelConsumption')?.value) || 7.5;
+  const fuelPricePerLtr = parseFloat(document.getElementById('fuelPrice')?.value) || 1.65;
+  const calcFuelCost = km => km * fuelPer100 / 100 * fuelPricePerLtr;
+  const totalFuelCost = calcFuelCost(totalKm);
+  const avgCostPerService = totalServices > 0 ? totalFuelCost / totalServices : 0;
+
   sec.innerHTML = `
     <div style="border-top:2px solid #7c3aed;padding-top:24px;margin-top:32px;">
       <h3 style="font-size:16px;font-weight:700;color:#7c3aed;margin-bottom:16px;">⏱️ Equipa — Tempos e Rentabilidade</h3>
-      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:20px;">
+      <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:20px;">
         <div style="background:#f5f3ff;border-radius:10px;padding:14px;text-align:center;">
           <div style="font-size:11px;font-weight:700;color:#7c3aed;margin-bottom:4px;">DIAS REGISTADOS</div>
           <div style="font-size:26px;font-weight:900;color:#7c3aed;">${teamStats.length}</div>
@@ -1886,6 +1892,11 @@ function _renderTeamSection(teamStats) {
           <div style="font-size:11px;font-weight:700;color:#ea580c;margin-bottom:4px;">SERV./HORA</div>
           <div style="font-size:26px;font-weight:900;color:#ea580c;">${servicesPerHour.toFixed(2)}</div>
         </div>
+        <div style="background:#fdf4ff;border-radius:10px;padding:14px;text-align:center;">
+          <div style="font-size:11px;font-weight:700;color:#9333ea;margin-bottom:4px;">CUSTO/SERVIÇO</div>
+          <div style="font-size:26px;font-weight:900;color:#9333ea;">${avgCostPerService.toFixed(2)}€</div>
+          <div style="font-size:10px;color:#94a3b8;margin-top:2px;">${totalFuelCost.toFixed(2)}€ total combust.</div>
+        </div>
       </div>
       <table style="width:100%;border-collapse:collapse;font-size:13px;">
         <thead><tr style="background:#f5f3ff;">
@@ -1896,6 +1907,8 @@ function _renderTeamSection(teamStats) {
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">Serviços</th>
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">KM</th>
           <th style="padding:9px 10px;text-align:center;font-weight:700;color:#7c3aed;border-bottom:2px solid #e2e8f0;">Serv./hora</th>
+          <th style="padding:9px 10px;text-align:center;font-weight:700;color:#9333ea;border-bottom:2px solid #e2e8f0;">Custo combust.</th>
+          <th style="padding:9px 10px;text-align:center;font-weight:700;color:#9333ea;border-bottom:2px solid #e2e8f0;">€/serviço</th>
         </tr></thead>
         <tbody>
           ${teamStats.map((r,i) => {
@@ -1903,14 +1916,19 @@ function _renderTeamSection(teamStats) {
             const net = hrsRaw != null ? Math.max(0, hrsRaw - 1) : null;
             const svcs = parseInt(r.services_done||0);
             const sph = net > 0 ? (svcs / net).toFixed(2) : '—';
+            const km = parseFloat(r.km_day||0);
+            const fuelCost = calcFuelCost(km);
+            const cps = svcs > 0 ? (fuelCost / svcs).toFixed(2) + '€' : '—';
             return `<tr style="border-bottom:1px solid #f1f5f9;${i%2===0?'background:#fafafa':''}">
               <td style="padding:8px 10px;font-weight:600;">${fmtD(r.date)}</td>
               <td style="padding:8px 10px;text-align:center;color:${r.checkin_auto?'#94a3b8':'#16a34a'};font-weight:600;">${fmtT(r.checkin_at)}${r.checkin_auto?' *':''}</td>
               <td style="padding:8px 10px;text-align:center;color:${r.checkout_auto?'#94a3b8':'#1d4ed8'};font-weight:600;">${fmtT(r.checkout_at)}${r.checkout_auto?' *':''}</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;color:#7c3aed;">${fmtH(net)}</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;">${svcs}</td>
-              <td style="padding:8px 10px;text-align:center;">${parseFloat(r.km_day||0).toFixed(0)} km</td>
+              <td style="padding:8px 10px;text-align:center;">${km.toFixed(0)} km</td>
               <td style="padding:8px 10px;text-align:center;font-weight:700;color:#ea580c;">${sph}</td>
+              <td style="padding:8px 10px;text-align:center;color:#9333ea;">${fuelCost.toFixed(2)}€</td>
+              <td style="padding:8px 10px;text-align:center;font-weight:700;color:#9333ea;">${cps}</td>
             </tr>`;
           }).join('')}
           <tr style="background:#f5f3ff;font-weight:700;border-top:2px solid #e2e8f0;">
@@ -1920,10 +1938,12 @@ function _renderTeamSection(teamStats) {
             <td style="padding:8px 10px;text-align:center;">${totalServices}</td>
             <td style="padding:8px 10px;text-align:center;">${totalKm.toFixed(0)} km</td>
             <td style="padding:8px 10px;text-align:center;color:#ea580c;">${servicesPerHour.toFixed(2)}</td>
+            <td style="padding:8px 10px;text-align:center;color:#9333ea;">${totalFuelCost.toFixed(2)}€</td>
+            <td style="padding:8px 10px;text-align:center;font-weight:700;color:#9333ea;">${avgCostPerService.toFixed(2)}€</td>
           </tr>
         </tbody>
       </table>
-      <p style="font-size:11px;color:#94a3b8;margin-top:8px;">* preenchido automaticamente · Horas líquidas = horas brutas − 1h almoço</p>
+      <p style="font-size:11px;color:#94a3b8;margin-top:8px;">* preenchido automaticamente · Horas líquidas = horas brutas − 1h almoço · Custo = combustível (${fuelPer100}L/100km × ${fuelPricePerLtr}€/L)</p>
     </div>`;
   sec.style.display = 'block';
 }

--- a/admin.html
+++ b/admin.html
@@ -603,7 +603,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-09b"></script>
+  <script src="admin-script.js?v=2026-06-09c"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -9,6 +9,15 @@ const pool = new Pool({
 
 const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
 
+function normalizeOrderRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('enc.axial')) return s;
+  if (/^\d+$/.test(s)) return `Enc.Axial ${s}`;
+  return s;
+}
+
 function getUserFromToken(event) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -250,7 +259,7 @@ exports.handler = async (event) => {
         data.foreign_plate === true,
         data.extra_services ? JSON.stringify(data.extra_services) : null,
         data.n_obra || null,
-        data.order_ref || null,
+        normalizeOrderRef(data.order_ref),
         data.glass_eurocode || data.eurocode || null,
         portalId, createdAt, new Date().toISOString(),
         data.comp_sales_desc || null,
@@ -344,7 +353,7 @@ exports.handler = async (event) => {
         data.comp_sales_nif !== undefined ? (data.comp_sales_nif || null) : null,
         data.comp_sales_name !== undefined ? (data.comp_sales_name || null) : null,
         data.comp_sales_faturado !== undefined ? (!!data.comp_sales_faturado) : false,
-        data.order_ref !== undefined ? (data.order_ref || null) : null,
+        data.order_ref !== undefined ? normalizeOrderRef(data.order_ref) : null,
         data.glass_eurocode !== undefined ? (data.glass_eurocode || null) : null
       ];
       const { rows } = await pool.query(q, v);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -5,6 +5,15 @@ const jwt = require('jsonwebtoken');
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
 const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
 
+function normalizeOrderRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('enc.axial')) return s;
+  if (/^\d+$/.test(s)) return `Enc.Axial ${s}`;
+  return s;
+}
+
 function verifyToken(event) {
   const h = event.headers.authorization || event.headers.Authorization || '';
   if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -212,7 +221,7 @@ exports.handler = async (event) => {
         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
         RETURNING *
       `, [
-        d.order_ref || null, d.eurocode || null, d.raw_label_text || null,
+        normalizeOrderRef(d.order_ref), d.eurocode || null, d.raw_label_text || null,
         d.appointment_id || null,
         user.userId || user.id, user.username,
         resolvedPortalId, resolvedPortalName,
@@ -233,7 +242,7 @@ exports.handler = async (event) => {
         if (d.order_ref) {
           await client.query(
             `UPDATE appointments SET order_ref = $1 WHERE id = $2 AND (order_ref IS NULL OR order_ref = '')`,
-            [d.order_ref, d.appointment_id]
+            [normalizeOrderRef(d.order_ref), d.appointment_id]
           );
         }
         if (d.eurocode) {

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -9,6 +9,15 @@ const pool = new Pool({
 
 const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
 
+function normalizeOrderRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('enc.axial')) return s;
+  if (/^\d+$/.test(s)) return `Enc.Axial ${s}`;
+  return s;
+}
+
 function verifyAdmin(event) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -109,7 +118,7 @@ exports.handler = async (event) => {
           // Actualizar order_ref se Excel tem valor e BD está vazio
           if (svc.order_ref && !row.order_ref) {
             updateFields.push(`order_ref = $${idx++}`);
-            updateVals.push(svc.order_ref);
+            updateVals.push(normalizeOrderRef(svc.order_ref));
           }
           // Actualizar reception_ref se Excel tem valor e BD está vazio
           if (svc.reception_ref && !row.reception_ref) {
@@ -189,7 +198,7 @@ exports.handler = async (event) => {
               false,          // confirmed
               svc.damage_details || null,
               svc.n_obra || null,
-              svc.order_ref || null,
+              normalizeOrderRef(svc.order_ref),
               svc.reception_ref || null,
               svc.portal_id,
               svc.createdAt || new Date().toISOString(),

--- a/netlify/functions/sync-enc.js
+++ b/netlify/functions/sync-enc.js
@@ -8,6 +8,15 @@ const jwt = require('jsonwebtoken');
 const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
 const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
 
+function normalizeOrderRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('enc.axial')) return s;
+  if (/^\d+$/.test(s)) return `Enc.Axial ${s}`;
+  return s;
+}
+
 function verifyToken(event) {
   const h = event.headers.authorization || event.headers.Authorization || '';
   if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -67,7 +76,7 @@ exports.handler = async (event) => {
       let idx = 1;
 
       if (enc && !apt.order_ref) {
-        updates.push(`order_ref = $${idx++}`); vals.push(String(enc));
+        updates.push(`order_ref = $${idx++}`); vals.push(normalizeOrderRef(enc));
       }
       if (rec && !apt.reception_ref) {
         updates.push(`reception_ref = $${idx++}`); vals.push(String(rec));

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -9,6 +9,15 @@ const pool = new Pool({
 
 const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
 
+function normalizeOrderRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('enc.axial')) return s;
+  if (/^\d+$/.test(s)) return `Enc.Axial ${s}`;
+  return s;
+}
+
 function norm(plate) {
   return String(plate || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
 }
@@ -94,13 +103,13 @@ exports.handler = async (event) => {
             await pool.query(
               `UPDATE appointments SET date=$1, period=$2, car=$3, notes=$4, extra=$5, phone=$6, client_name=$7, n_obra=COALESCE($10,n_obra), auto_imported=true, confirmed=false, updated_at=$8,
                order_ref=COALESCE($11,order_ref), reception_ref=COALESCE($12,reception_ref) WHERE id=$9`,
-              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null, svc.order_ref||null, svc.reception_ref||null]
+              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null, normalizeOrderRef(svc.order_ref), svc.reception_ref||null]
             );
           } else {
             await pool.query(
               `UPDATE appointments SET car=$1, notes=$2, extra=$3, phone=$4, client_name=$5, n_obra=COALESCE($7,n_obra), updated_at=$6,
                order_ref=COALESCE($9,order_ref), reception_ref=COALESCE($10,reception_ref) WHERE id=$8`,
-              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id, svc.order_ref||null, svc.reception_ref||null]
+              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id, normalizeOrderRef(svc.order_ref), svc.reception_ref||null]
             );
           }
           results.updated++;
@@ -120,7 +129,7 @@ exports.handler = async (event) => {
               svc.client_name||null, svc.n_obra||null,
               !!svc.date, portal_id,
               svc.createdAt||now, now,
-              svc.order_ref||null, svc.reception_ref||null
+              normalizeOrderRef(svc.order_ref), svc.reception_ref||null
             ]
           );
           results.created++;


### PR DESCRIPTION
## Summary

- Added `normalizeOrderRef()` helper to 5 backend functions that write `order_ref`
- Bare numeric values (e.g. `68850`, `51270`) are now automatically prefixed with `Enc.Axial ` on save
- Values already starting with `Enc.Axial` are left unchanged (no double-prefix)
- No more need to run "🔧 Normalizar Enc.Axial" manually

**Affected files:** `appointments.js`, `sync-portal.js`, `import-services.js`, `sync-enc.js`, `glass-reception.js`

## Test plan

- [ ] Import an Excel with a bare numeric order_ref (e.g. `68850`) — confirm it saves as `Enc.Axial 68850`
- [ ] Edit an appointment and set order_ref to a number — confirm it saves with prefix
- [ ] Confirm existing `Enc.Axial XXXXX` values are not double-prefixed

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_