### PR TITLE
fix: auto-normalize reception_ref to Rec. prefix on all write paths

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -18,6 +18,15 @@ function normalizeOrderRef(v) {
   return s;
 }
 
+function normalizeReceptionRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('rec.')) return s;
+  if (/^\d+$/.test(s)) return `Rec.${s}`;
+  return s;
+}
+
 function getUserFromToken(event) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -348,7 +357,7 @@ exports.handler = async (event) => {
         data.glass_removed_date !== undefined ? (data.glass_removed_date || null) : (existing.glass_removed_date || null),
         data.n_obra !== undefined ? (data.n_obra || null) : null,
         new Date().toISOString(), id, effectivePortalId, notDoneAtVal,
-        data.reception_ref !== undefined ? (data.reception_ref || null) : null,
+        data.reception_ref !== undefined ? normalizeReceptionRef(data.reception_ref) : null,
         data.comp_sales_desc !== undefined ? (data.comp_sales_desc || null) : null,
         data.comp_sales_nif !== undefined ? (data.comp_sales_nif || null) : null,
         data.comp_sales_name !== undefined ? (data.comp_sales_name || null) : null,

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -14,6 +14,15 @@ function normalizeOrderRef(v) {
   return s;
 }
 
+function normalizeReceptionRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('rec.')) return s;
+  if (/^\d+$/.test(s)) return `Rec.${s}`;
+  return s;
+}
+
 function verifyToken(event) {
   const h = event.headers.authorization || event.headers.Authorization || '';
   if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -233,7 +242,7 @@ exports.handler = async (event) => {
         d.carrier_guide || null
       ]);
 
-      // When glass is matched to an appointment: set status ST (received) and propagate order_ref
+      // When glass is matched to an appointment: set status ST (received) and propagate refs
       if (d.appointment_id && !d.is_return) {
         await client.query(
           `UPDATE appointments SET status = 'ST', updated_at = NOW() WHERE id = $1`,

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -18,6 +18,15 @@ function normalizeOrderRef(v) {
   return s;
 }
 
+function normalizeReceptionRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('rec.')) return s;
+  if (/^\d+$/.test(s)) return `Rec.${s}`;
+  return s;
+}
+
 function verifyAdmin(event) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -123,7 +132,7 @@ exports.handler = async (event) => {
           // Actualizar reception_ref se Excel tem valor e BD está vazio
           if (svc.reception_ref && !row.reception_ref) {
             updateFields.push(`reception_ref = $${idx++}`);
-            updateVals.push(svc.reception_ref);
+            updateVals.push(normalizeReceptionRef(svc.reception_ref));
           }
           // Status upgrade baseado em enc/rec
           const newStatusUpgrade = svc.reception_ref && row.status !== 'ST' ? 'ST'
@@ -199,7 +208,7 @@ exports.handler = async (event) => {
               svc.damage_details || null,
               svc.n_obra || null,
               normalizeOrderRef(svc.order_ref),
-              svc.reception_ref || null,
+              normalizeReceptionRef(svc.reception_ref),
               svc.portal_id,
               svc.createdAt || new Date().toISOString(),
               new Date().toISOString()

--- a/netlify/functions/sync-enc.js
+++ b/netlify/functions/sync-enc.js
@@ -17,6 +17,15 @@ function normalizeOrderRef(v) {
   return s;
 }
 
+function normalizeReceptionRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('rec.')) return s;
+  if (/^\d+$/.test(s)) return `Rec.${s}`;
+  return s;
+}
+
 function verifyToken(event) {
   const h = event.headers.authorization || event.headers.Authorization || '';
   if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
@@ -79,7 +88,7 @@ exports.handler = async (event) => {
         updates.push(`order_ref = $${idx++}`); vals.push(normalizeOrderRef(enc));
       }
       if (rec && !apt.reception_ref) {
-        updates.push(`reception_ref = $${idx++}`); vals.push(String(rec));
+        updates.push(`reception_ref = $${idx++}`); vals.push(normalizeReceptionRef(rec));
       }
       if (ref && !apt.glass_eurocode) {
         updates.push(`glass_eurocode = $${idx++}`); vals.push(String(ref));

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -18,6 +18,15 @@ function normalizeOrderRef(v) {
   return s;
 }
 
+function normalizeReceptionRef(v) {
+  if (!v) return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  if (s.toLowerCase().startsWith('rec.')) return s;
+  if (/^\d+$/.test(s)) return `Rec.${s}`;
+  return s;
+}
+
 function norm(plate) {
   return String(plate || '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
 }
@@ -103,13 +112,13 @@ exports.handler = async (event) => {
             await pool.query(
               `UPDATE appointments SET date=$1, period=$2, car=$3, notes=$4, extra=$5, phone=$6, client_name=$7, n_obra=COALESCE($10,n_obra), auto_imported=true, confirmed=false, updated_at=$8,
                order_ref=COALESCE($11,order_ref), reception_ref=COALESCE($12,reception_ref) WHERE id=$9`,
-              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null, normalizeOrderRef(svc.order_ref), svc.reception_ref||null]
+              [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null, normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)]
             );
           } else {
             await pool.query(
               `UPDATE appointments SET car=$1, notes=$2, extra=$3, phone=$4, client_name=$5, n_obra=COALESCE($7,n_obra), updated_at=$6,
                order_ref=COALESCE($9,order_ref), reception_ref=COALESCE($10,reception_ref) WHERE id=$8`,
-              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id, normalizeOrderRef(svc.order_ref), svc.reception_ref||null]
+              [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id, normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)]
             );
           }
           results.updated++;
@@ -129,7 +138,7 @@ exports.handler = async (event) => {
               svc.client_name||null, svc.n_obra||null,
               !!svc.date, portal_id,
               svc.createdAt||now, now,
-              normalizeOrderRef(svc.order_ref), svc.reception_ref||null
+              normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)
             ]
           );
           results.created++;


### PR DESCRIPTION
## Summary

- Added `normalizeReceptionRef()` to all backend functions that write `reception_ref`
- Bare numeric values from PHC/Excel (e.g. `5548`) are automatically prefixed with `Rec.` on save → `Rec.5548`
- Values already starting with `Rec.` are left unchanged (no double-prefix)
- Glass reception (Flash Glass flow) unchanged — normalization only applies to Excel import paths

**Affected files:** `appointments.js`, `sync-portal.js`, `import-services.js`, `sync-enc.js`, `glass-reception.js`

## Test plan

- [ ] Import an Excel with a bare numeric reception number (e.g. `5548`) — confirm it saves as `Rec.5548` and appears under `Enc.Axial XXXXX` on the card with `✅ Rec.5548`
- [ ] Confirm existing `Rec.XXXXX` values are not double-prefixed

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_