### PR TITLE
Alertas de vidros, pesquisa global, logging de erros e cache busting automático

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2287,3 +2287,174 @@ function downloadReportPDF() {
   window.print();
 }
 
+
+// ===== PESQUISA GLOBAL =====
+async function runGlobalSearch() {
+  const q = document.getElementById('gsQuery').value.trim();
+  const out = document.getElementById('gsResults');
+  if (q.length < 3) {
+    out.innerHTML = '<p style="color:#dc2626;text-align:center;padding:20px;">Introduza pelo menos 3 caracteres.</p>';
+    return;
+  }
+  out.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:30px;">⏳ A pesquisar...</p>';
+  try {
+    const res = await authClient.authenticatedFetch('/.netlify/functions/global-search?q=' + encodeURIComponent(q));
+    const json = await res.json();
+    if (!json.success) throw new Error(json.error);
+    _renderGlobalSearch(json.data);
+  } catch (e) {
+    out.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+  }
+}
+
+function _renderGlobalSearch(data) {
+  const out = document.getElementById('gsResults');
+  const { appointments = [], receptions = [], mycar = [] } = data;
+  const total = appointments.length + receptions.length + mycar.length;
+  if (!total) {
+    out.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:30px;">Sem resultados.</p>';
+    return;
+  }
+
+  const fmtD = d => d ? new Date(d).toLocaleDateString('pt-PT') : '—';
+  const statusBadge = s => {
+    const map = { NE: ['#fef2f2', '#dc2626', 'Não encomendado'], VE: ['#fffbeb', '#d97706', 'Encomendado'], ST: ['#f0fdf4', '#16a34a', 'Stock'] };
+    const [bg, col, label] = map[s] || ['#f8fafc', '#64748b', s || '—'];
+    return `<span style="background:${bg};color:${col};font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;white-space:nowrap;">${label}</span>`;
+  };
+  const th = t => `<th style="padding:8px 10px;text-align:left;white-space:nowrap;">${t}</th>`;
+  const td = (t, extra) => `<td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;${extra || ''}">${t}</td>`;
+  const section = (title, count, inner) => `
+    <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:16px;margin-bottom:18px;">
+      <div style="font-weight:700;font-size:14px;color:#1e293b;margin-bottom:12px;">${title} <span style="color:#64748b;font-weight:600;">(${count})</span></div>
+      ${count ? `<div style="overflow-x:auto;"><table style="width:100%;border-collapse:collapse;font-size:13px;">${inner}</table></div>` : '<p style="color:#94a3b8;font-size:13px;margin:0;">Sem resultados.</p>'}
+    </div>`;
+
+  const aptRows = appointments.map((a, i) => `
+    <tr style="background:${i % 2 ? '#f8fafc' : '#fff'};">
+      ${td(fmtD(a.date))}
+      ${td((a.plate || '—').toUpperCase(), 'font-family:monospace;font-weight:700;white-space:nowrap;')}
+      ${td(a.car || '—')}
+      ${td(a.portal_name || '—', 'white-space:nowrap;')}
+      ${td(a.service || '—')}
+      ${td(statusBadge(a.status))}
+      ${td(a.executed ? '✅' : '—', 'text-align:center;')}
+      ${td(a.order_ref || '—', 'white-space:nowrap;')}
+      ${td(a.reception_ref || '—', 'white-space:nowrap;')}
+    </tr>`).join('');
+
+  const recRows = receptions.map((r, i) => `
+    <tr style="background:${i % 2 ? '#f8fafc' : '#fff'};">
+      ${td(fmtD(r.created_at))}
+      ${td(r.is_return ? '↩️ Devolução' : '📦 Receção', 'white-space:nowrap;')}
+      ${td((r.apt_plate || '—').toUpperCase(), 'font-family:monospace;font-weight:700;white-space:nowrap;')}
+      ${td(r.apt_car || '—')}
+      ${td(r.portal_label || '—', 'white-space:nowrap;')}
+      ${td(r.eurocode || '—', 'font-family:monospace;')}
+      ${td(r.order_ref || '—', 'white-space:nowrap;')}
+      ${td(r.technician_name || '—', 'white-space:nowrap;')}
+    </tr>`).join('');
+
+  const mycarRows = mycar.map((m, i) => `
+    <tr style="background:${i % 2 ? '#f8fafc' : '#fff'};">
+      ${td(fmtD(m.data_servico || m.created_at))}
+      ${td((m.matricula || '—').toUpperCase(), 'font-family:monospace;font-weight:700;white-space:nowrap;')}
+      ${td(m.car || '—')}
+      ${td(m.n_obra || '—', 'white-space:nowrap;')}
+      ${td(m.status || '—')}
+    </tr>`).join('');
+
+  out.innerHTML =
+    section('📅 Agendamentos', appointments.length,
+      `<thead><tr style="background:#0f172a;color:#fff;">${['Data','Matrícula','Carro','Portal','Serviço','Estado','Real.','Encomenda','Receção'].map(th).join('')}</tr></thead><tbody>${aptRows}</tbody>`) +
+    section('🪟 Receções de Vidro', receptions.length,
+      `<thead><tr style="background:#0f172a;color:#fff;">${['Data','Tipo','Matrícula','Carro','Loja','Eurocode','Encomenda','Técnico'].map(th).join('')}</tr></thead><tbody>${recRows}</tbody>`) +
+    section('🚗 Mural MyCar', mycar.length,
+      `<thead><tr style="background:#0f172a;color:#fff;">${['Data','Matrícula','Carro','Nº Obra','Estado'].map(th).join('')}</tr></thead><tbody>${mycarRows}</tbody>`);
+}
+
+// ===== ALERTAS DE VIDROS =====
+let _alertsLoaded = false;
+
+async function loadGlassAlerts(force) {
+  if (_alertsLoaded && !force) return;
+  const out = document.getElementById('alertsContent');
+  if (!out) return;
+  out.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:30px;">⏳ A carregar...</p>';
+  try {
+    const res = await authClient.authenticatedFetch('/.netlify/functions/glass-alerts');
+    const json = await res.json();
+    if (!json.success) throw new Error(json.error);
+    _alertsLoaded = true;
+    _renderGlassAlerts(json.data);
+    _updateAlertsBadge(json.data);
+  } catch (e) {
+    out.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+  }
+}
+
+function _updateAlertsBadge(data) {
+  const badge = document.getElementById('alertsBadge');
+  if (!badge) return;
+  const total = (data.stalled_stock?.length || 0) + (data.pending_orders?.length || 0);
+  badge.textContent = total;
+  badge.style.display = total ? 'inline' : 'none';
+}
+
+function _renderGlassAlerts(data) {
+  const out = document.getElementById('alertsContent');
+  const { stalled_stock = [], pending_orders = [], stock_days = 5, order_days = 7 } = data;
+
+  const fmtD = d => d ? new Date(d).toLocaleDateString('pt-PT') : '—';
+  const daysBadge = n => {
+    const col = n >= 14 ? '#dc2626' : n >= 7 ? '#d97706' : '#64748b';
+    return `<span style="color:${col};font-weight:800;">${n} dia${n !== 1 ? 's' : ''}</span>`;
+  };
+  const th = t => `<th style="padding:8px 10px;text-align:left;white-space:nowrap;">${t}</th>`;
+  const td = (t, extra) => `<td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;${extra || ''}">${t}</td>`;
+
+  const renderRows = rows => rows.map((a, i) => `
+    <tr style="background:${i % 2 ? '#f8fafc' : '#fff'};">
+      ${td((a.plate || '—').toUpperCase(), 'font-family:monospace;font-weight:700;white-space:nowrap;')}
+      ${td(a.car || '—')}
+      ${td(a.portal_name || '—', 'white-space:nowrap;')}
+      ${td(a.locality || '—', 'white-space:nowrap;')}
+      ${td(a.order_ref || '—', 'white-space:nowrap;')}
+      ${td(a.reception_ref || '—', 'white-space:nowrap;')}
+      ${td(fmtD(a.updated_at), 'white-space:nowrap;')}
+      ${td(daysBadge(a.days_waiting), 'white-space:nowrap;')}
+    </tr>`).join('');
+
+  const section = (icon, title, desc, rows, emptyMsg, accentBg, accentBorder) => `
+    <div style="background:#fff;border:1px solid ${rows.length ? accentBorder : '#e2e8f0'};border-radius:12px;padding:16px;margin-bottom:18px;${rows.length ? 'background:' + accentBg + ';' : ''}">
+      <div style="font-weight:700;font-size:15px;color:#1e293b;margin-bottom:4px;">${icon} ${title} <span style="color:#64748b;font-weight:600;">(${rows.length})</span></div>
+      <p style="color:#64748b;font-size:12px;margin:0 0 12px;">${desc}</p>
+      ${rows.length
+        ? `<div style="overflow-x:auto;"><table style="width:100%;border-collapse:collapse;font-size:13px;background:#fff;border-radius:8px;">
+             <thead><tr style="background:#0f172a;color:#fff;">${['Matrícula','Carro','Portal','Localidade','Encomenda','Receção','Últ. atualização','Em espera'].map(th).join('')}</tr></thead>
+             <tbody>${renderRows(rows)}</tbody></table></div>`
+        : `<p style="color:#16a34a;font-size:13px;font-weight:600;margin:0;">✅ ${emptyMsg}</p>`}
+    </div>`;
+
+  out.innerHTML =
+    section('📦', 'Vidros em stock sem agendamento', `Vidros recebidos (ST) sem data de serviço marcada há mais de ${stock_days} dias.`, stalled_stock, 'Nenhum vidro parado em stock.', '#fffbeb', '#fde68a') +
+    section('⏳', 'Encomendas sem receção', `Vidros encomendados (VE) sem receção registada há mais de ${order_days} dias.`, pending_orders, 'Nenhuma encomenda pendente há demasiado tempo.', '#fff1f2', '#fecdd3');
+}
+
+// Lazy-load das novas tabs + badge de alertas ao arrancar
+document.querySelectorAll('.nav-tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    if (tab.dataset.tab === 'alerts') loadGlassAlerts();
+    if (tab.dataset.tab === 'search') setTimeout(() => document.getElementById('gsQuery')?.focus(), 50);
+  });
+});
+
+(async () => {
+  // Aguardar auth estar pronta antes de carregar o badge
+  if (!window.authClient?.isAuthenticated?.()) return;
+  try {
+    const res = await authClient.authenticatedFetch('/.netlify/functions/glass-alerts');
+    const json = await res.json();
+    if (json.success) _updateAlertsBadge(json.data);
+  } catch (e) { /* badge é opcional */ }
+})();

--- a/admin.html
+++ b/admin.html
@@ -34,6 +34,8 @@
       <button class="nav-tab" data-tab="audit">🔍 Auditoria</button>
       <button class="nav-tab" data-tab="flashglass">📸 Flash Glass</button>
       <button class="nav-tab" data-tab="checkins">⏱️ Check-in</button>
+      <button class="nav-tab" data-tab="search">🔎 Pesquisa</button>
+      <button class="nav-tab" data-tab="alerts">🚨 Alertas <span id="alertsBadge" style="display:none;background:#dc2626;color:#fff;font-size:11px;font-weight:800;padding:1px 7px;border-radius:10px;margin-left:4px;vertical-align:middle;"></span></button>
     </nav>
 
     <!-- Tab Content: Portais -->
@@ -426,6 +428,27 @@
       <div id="ciGrid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px;">
         <div style="color:#94a3b8;grid-column:1/-1;text-align:center;padding:40px;">Clique em Atualizar para carregar.</div>
       </div>
+    </div>
+
+    <!-- Tab: Pesquisa Global -->
+    <div id="searchTab" class="tab-content">
+      <h2 style="margin-bottom:6px;">🔎 Pesquisa Global</h2>
+      <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Procura por matrícula, encomenda, eurocode ou nº de obra em agendamentos, receções de vidro e mural MyCar.</p>
+      <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px;">
+        <input type="text" id="gsQuery" placeholder="Ex: 12-AB-34, 51621, Rec.5548..." style="flex:1;min-width:240px;max-width:420px;padding:10px 14px;border:1px solid #d1d5db;border-radius:8px;font-size:15px;" onkeydown="if(event.key==='Enter')runGlobalSearch()">
+        <button onclick="runGlobalSearch()" style="background:#2563eb;color:#fff;border:none;padding:10px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">🔎 Pesquisar</button>
+      </div>
+      <div id="gsResults"><p style="color:#94a3b8;text-align:center;padding:30px;">Introduza pelo menos 3 caracteres e pesquise.</p></div>
+    </div>
+
+    <!-- Tab: Alertas de Vidros -->
+    <div id="alertsTab" class="tab-content">
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px;margin-bottom:6px;">
+        <h2 style="margin:0;">🚨 Alertas de Vidros</h2>
+        <button onclick="loadGlassAlerts(true)" style="background:#2563eb;color:#fff;border:none;padding:9px 18px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">🔄 Atualizar</button>
+      </div>
+      <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Vidros em stock sem serviço agendado e encomendas sem receção há demasiado tempo.</p>
+      <div id="alertsContent"><p style="color:#94a3b8;text-align:center;padding:30px;">A carregar...</p></div>
     </div>
 
 </div><!-- fim admin-container -->

--- a/cache-bust.js
+++ b/cache-bust.js
@@ -1,0 +1,22 @@
+// cache-bust.js — corre no build do Netlify (ver netlify.toml).
+// Substitui todos os parâmetros ?v=... nos ficheiros HTML pelo hash do commit,
+// para que cada deploy invalide automaticamente a cache dos browsers.
+const fs = require('fs');
+const path = require('path');
+
+const hash = (process.env.COMMIT_REF || String(Date.now())).slice(0, 10);
+const root = __dirname;
+const htmlFiles = fs.readdirSync(root).filter(f => f.endsWith('.html'));
+
+let changed = 0;
+for (const f of htmlFiles) {
+  const file = path.join(root, f);
+  const src = fs.readFileSync(file, 'utf8');
+  const out = src.replace(/\?v=[A-Za-z0-9._-]+/g, `?v=${hash}`);
+  if (out !== src) {
+    fs.writeFileSync(file, out);
+    changed++;
+    console.log(`cache-bust: ${f} → ?v=${hash}`);
+  }
+}
+console.log(`cache-bust: ${changed} ficheiro(s) atualizado(s)`);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   publish = "."
   functions = "netlify/functions"
+  command = "node cache-bust.js"
 
 [build.environment]
   NODE_VERSION = "20"

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -96,7 +96,7 @@ exports.handler = async (event) => {
     } else if (user.role === 'coordenador' || user.role === 'coordinator' || user.role === 'comercial') {
       let requestedId = params.portal_id ? parseInt(params.portal_id) : null;
       if (!requestedId && event.body) {
-        try { requestedId = JSON.parse(event.body)._portalId; } catch(e) {}
+        try { requestedId = JSON.parse(event.body)._portalId; } catch(e) { console.warn('appointments _portalId parse warning:', e.message); }
       }
       if (requestedId) {
         const allowed = user.portalIds || (user.portalId ? [user.portalId] : []);

--- a/netlify/functions/blocked-days.js
+++ b/netlify/functions/blocked-days.js
@@ -102,7 +102,7 @@ async function ensureTable() {
       FROM blocked_days
       GROUP BY date, COALESCE(portal_id::text, '__NULL__')
     )
-  `).catch(() => {});
+  `).catch(e => console.warn('blocked-days dedup warning:', e.message));
 }
 
 async function seedHolidays() {
@@ -122,7 +122,7 @@ async function seedHolidays() {
         WHERE NOT EXISTS (
           SELECT 1 FROM blocked_days WHERE date = $1 AND portal_id IS NULL
         )
-      `, [h.date, h.reason]).catch(() => {});
+      `, [h.date, h.reason]).catch(e => console.warn('blocked-days seed warning:', e.message));
     }
   }
 }
@@ -187,7 +187,7 @@ exports.handler = async (event) => {
         await pool.query(
           `DELETE FROM blocked_days WHERE date = $1 AND portal_id IS NULL`,
           [date]
-        ).catch(() => {});
+        ).catch(e => console.warn('blocked-days delete warning:', e.message));
         const res = await pool.query(
           `INSERT INTO blocked_days (date, portal_id, reason, is_holiday) VALUES ($1, NULL, $2, $3) RETURNING *`,
           [date, reason || 'Dia bloqueado', is_holiday || false]

--- a/netlify/functions/commercial-request.js
+++ b/netlify/functions/commercial-request.js
@@ -216,7 +216,7 @@ exports.handler = async (event) => {
             try {
               const locs = typeof p.localities === 'string' ? JSON.parse(p.localities) : (p.localities || {});
               servesLocality = Object.keys(locs).some(k => k.toLowerCase() === reqLocality);
-            } catch (e) { /* ignore */ }
+            } catch (e) { console.warn('commercial-request localities parse warning:', e.message); }
           }
           return {
             id: p.id,

--- a/netlify/functions/fuel-price.js
+++ b/netlify/functions/fuel-price.js
@@ -137,6 +137,7 @@ exports.handler = async (event) => {
           date: new Date().toISOString()
         };
       } catch (e) {
+        console.warn('fuel-price fallback to default:', e.message);
         result = { price: 1.65, source: 'default', date: new Date().toISOString() };
       }
     }

--- a/netlify/functions/glass-alerts.js
+++ b/netlify/functions/glass-alerts.js
@@ -1,0 +1,91 @@
+// netlify/functions/glass-alerts.js
+// Alertas operacionais de vidros:
+//  - stalled_stock: vidro em stock (ST) sem data de serviço há mais de N dias
+//  - pending_orders: vidro encomendado (VE) sem receção há mais de N dias
+// Admin vê tudo; coordenadores vêem apenas os seus portais.
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'GET') return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'GET only' }) };
+
+  let user;
+  try {
+    const token = (event.headers.authorization || event.headers.Authorization || '').replace('Bearer ', '');
+    user = jwt.verify(token, JWT_SECRET);
+    if (!['admin', 'coordenador', 'coordinator'].includes(user.role)) throw new Error('Acesso negado');
+  } catch (e) {
+    return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Não autorizado' }) };
+  }
+
+  const p = event.queryStringParameters || {};
+  const stockDays = Math.max(1, parseInt(p.stock_days) || 5);
+  const orderDays = Math.max(1, parseInt(p.order_days) || 7);
+
+  // Restrição de portais para coordenadores
+  let portalFilter = '';
+  const baseVals = [];
+  if (user.role !== 'admin') {
+    const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+    if (!ids.length) return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: { stalled_stock: [], pending_orders: [] } }) };
+    portalFilter = ' AND a.portal_id = ANY($2)';
+    baseVals.push(ids);
+  }
+
+  const cols = `
+    a.id, a.plate, a.car, a.date, a.status, a.order_ref, a.reception_ref,
+    a.locality, a.updated_at, po.name AS portal_name,
+    GREATEST(0, FLOOR(EXTRACT(EPOCH FROM (NOW() - a.updated_at)) / 86400))::int AS days_waiting
+  `;
+
+  try {
+    // Vidro em stock sem serviço agendado
+    const { rows: stalledStock } = await pool.query(`
+      SELECT ${cols}
+      FROM appointments a
+      LEFT JOIN portals po ON po.id = a.portal_id
+      WHERE a.status = 'ST'
+        AND COALESCE(a.executed, false) = false
+        AND a.date IS NULL
+        AND a.updated_at < NOW() - ($1 || ' days')::interval
+        ${portalFilter}
+      ORDER BY a.updated_at ASC
+      LIMIT 200
+    `, [stockDays, ...baseVals]);
+
+    // Vidro encomendado sem receção
+    const { rows: pendingOrders } = await pool.query(`
+      SELECT ${cols}
+      FROM appointments a
+      LEFT JOIN portals po ON po.id = a.portal_id
+      WHERE a.status = 'VE'
+        AND COALESCE(a.executed, false) = false
+        AND a.updated_at < NOW() - ($1 || ' days')::interval
+        ${portalFilter}
+      ORDER BY a.updated_at ASC
+      LIMIT 200
+    `, [orderDays, ...baseVals]);
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        success: true,
+        data: { stalled_stock: stalledStock, pending_orders: pendingOrders, stock_days: stockDays, order_days: orderDays }
+      })
+    };
+  } catch (e) {
+    console.error('glass-alerts error:', e.message);
+    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: e.message }) };
+  }
+};

--- a/netlify/functions/global-search.js
+++ b/netlify/functions/global-search.js
@@ -1,0 +1,100 @@
+// netlify/functions/global-search.js
+// Pesquisa global por matrícula (ou ref. encomenda/eurocode) em:
+//  - appointments (agendamentos)
+//  - glass_receptions (receções/devoluções de vidro)
+//  - mycar_services (mural MyCar)
+// Admin vê tudo; coordenadores vêem apenas os seus portais.
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'GET') return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'GET only' }) };
+
+  let user;
+  try {
+    const token = (event.headers.authorization || event.headers.Authorization || '').replace('Bearer ', '');
+    user = jwt.verify(token, JWT_SECRET);
+    if (!['admin', 'coordenador', 'coordinator'].includes(user.role)) throw new Error('Acesso negado');
+  } catch (e) {
+    return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Não autorizado' }) };
+  }
+
+  const q = (event.queryStringParameters?.q || '').trim();
+  if (q.length < 3) {
+    return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'Mínimo 3 caracteres' }) };
+  }
+
+  const plateNorm = '%' + q.toUpperCase().replace(/[^A-Z0-9]/g, '') + '%';
+  const textLike = '%' + q.toLowerCase() + '%';
+
+  // Restrição de portais para coordenadores
+  const coordIds = user.role === 'admin'
+    ? null
+    : (user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []));
+  if (coordIds && !coordIds.length) {
+    return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: { appointments: [], receptions: [], mycar: [] } }) };
+  }
+
+  try {
+    // Agendamentos
+    let aq = `
+      SELECT a.id, a.plate, a.car, a.date, a.period, a.status, a.service, a.locality,
+             a.order_ref, a.reception_ref, a.n_obra, a.client_name, a.executed,
+             po.name AS portal_name
+      FROM appointments a
+      LEFT JOIN portals po ON po.id = a.portal_id
+      WHERE (UPPER(REGEXP_REPLACE(a.plate, '[^A-Z0-9]', '', 'g')) LIKE $1
+             OR LOWER(a.order_ref) LIKE $2 OR LOWER(a.n_obra) LIKE $2)
+    `;
+    const aVals = [plateNorm, textLike];
+    if (coordIds) { aq += ` AND a.portal_id = ANY($3)`; aVals.push(coordIds); }
+    aq += ` ORDER BY a.date DESC NULLS LAST, a.created_at DESC LIMIT 50`;
+    const { rows: appointments } = await pool.query(aq, aVals);
+
+    // Receções de vidro
+    let rq = `
+      SELECT gr.id, gr.created_at, gr.eurocode, gr.order_ref, gr.status,
+             gr.is_return, gr.return_reason, gr.technician_name,
+             a.plate AS apt_plate, a.car AS apt_car, po.name AS portal_label
+      FROM glass_receptions gr
+      LEFT JOIN appointments a ON a.id = gr.appointment_id
+      LEFT JOIN portals po ON po.id = gr.portal_id
+      WHERE (UPPER(REGEXP_REPLACE(COALESCE(a.plate,''), '[^A-Z0-9]', '', 'g')) LIKE $1
+             OR LOWER(gr.eurocode) LIKE $2 OR LOWER(gr.order_ref) LIKE $2)
+    `;
+    const rVals = [plateNorm, textLike];
+    if (coordIds) { rq += ` AND gr.portal_id = ANY($3)`; rVals.push(coordIds); }
+    rq += ` ORDER BY gr.created_at DESC LIMIT 50`;
+    const { rows: receptions } = await pool.query(rq, rVals);
+
+    // Mural MyCar
+    let mycar = [];
+    try {
+      const { rows } = await pool.query(`
+        SELECT id, matricula, car, data_servico, status, n_obra, created_at
+        FROM mycar_services
+        WHERE UPPER(REGEXP_REPLACE(matricula, '[^A-Z0-9]', '', 'g')) LIKE $1
+           OR LOWER(n_obra) LIKE $2
+        ORDER BY created_at DESC LIMIT 50
+      `, [plateNorm, textLike]);
+      mycar = rows;
+    } catch (e) {
+      console.warn('global-search mycar query:', e.message);
+    }
+
+    return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: { appointments, receptions, mycar } }) };
+  } catch (e) {
+    console.error('global-search error:', e.message);
+    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: e.message }) };
+  }
+};

--- a/netlify/functions/transport-guide.js
+++ b/netlify/functions/transport-guide.js
@@ -158,6 +158,7 @@ exports.handler = async (event) => {
           const parsed = await pdfParse(fileBuffer);
           autoEurocodes = extractEurocodes(parsed.text);
         } catch (e) {
+          console.warn('transport-guide PDF parse warning:', e.message);
           // image-only or corrupt PDF — fall through to manual
         }
       } else if (isImage) {

--- a/netlify/functions/users.js
+++ b/netlify/functions/users.js
@@ -278,7 +278,7 @@ const headers = {
         // Se mudou para outro role, limpar portais de consulta
         try {
           await pool.query('DELETE FROM consultable_portals WHERE user_id = $1', [id]);
-        } catch(e) { /* tabela pode não existir ainda */ }
+        } catch(e) { console.warn('consultable_portals cleanup warning:', e.message); }
       }
 
       await auditLog({ user_id: decoded.userId, username: decoded.username, action: 'user_updated',
@@ -291,7 +291,7 @@ const headers = {
     if (event.httpMethod === 'DELETE') {
       const id = (event.path || '').split('/').pop();
       await pool.query('DELETE FROM coordinator_portals WHERE user_id = $1', [id]);
-      try { await pool.query('DELETE FROM consultable_portals WHERE user_id = $1', [id]); } catch(e) {}
+      try { await pool.query('DELETE FROM consultable_portals WHERE user_id = $1', [id]); } catch(e) { console.warn('consultable_portals delete warning:', e.message); }
       const { rows } = await pool.query('DELETE FROM users WHERE id = $1 RETURNING id, username', [id]);
       if (rows.length === 0) {
         return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Utilizador não encontrado' }) };


### PR DESCRIPTION
## Melhorias da plataforma (pontos 2, 3, 6 e 7)

### 🚨 Alertas de vidros (tab nova no admin)
- Nova function `glass-alerts.js`: vidros em stock (ST) sem data de serviço há mais de 5 dias + encomendas (VE) sem receção há mais de 7 dias
- Badge com contagem na tab, atualizado ao abrir o admin
- Coordenadores só veriam os seus portais (restrição no backend)

### 🔎 Pesquisa global (tab nova no admin)
- Nova function `global-search.js`: pesquisa por matrícula, encomenda, eurocode ou nº de obra
- Resultados agrupados: Agendamentos, Receções de Vidro e Mural MyCar

### 🔇 Catches silenciosos
- Todos os `catch` vazios no backend passam a fazer `console.warn` com contexto (blocked-days, users, appointments, commercial-request, fuel-price, transport-guide)

### ♻️ Cache busting automático
- Novo `cache-bust.js` corre como build command no Netlify e substitui todos os `?v=...` nos HTML pelo hash do commit
- Deixa de ser preciso mudar versões à mão

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_