### PR TITLE
Skip plate history lookup for foreign plates (campo livre)

### DIFF
--- a/script-tail.js
+++ b/script-tail.js
@@ -1781,6 +1781,7 @@ document.addEventListener('DOMContentLoaded', function() {
   let autoFillTimer = null;
   el.addEventListener('input', (e) => {
     clearTimeout(autoFillTimer);
+    if (e.target._foreignMode) return;
     autoFillTimer = setTimeout(() => tryAutoFill(e.target.value), 400);
   });
 


### PR DESCRIPTION
## Summary
- When "Matrícula estrangeira (campo livre)" is checked, the plate field no longer triggers the history/autofill lookup
- The `blur` handler already had this guard (`_foreignMode` check); the `input` event timer was missing it — one-line fix

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_