### PR TITLE
Add coordinator gear button and restricted admin panel view

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -21,21 +21,23 @@
   // Mostrar nome do utilizador
   document.getElementById('userInfo').textContent = user.username;
 
-  // Coordenador: esconder tabs que não se aplicam
+  // Coordenador: esconder todas as tabs admin-only e activar relatórios
   if (user.role === 'coordenador') {
-    ['portals','users','import'].forEach(tab => {
-      const btn = document.querySelector(`.nav-tab[data-tab="${tab}"]`);
-      const content = document.getElementById(`${tab}Tab`);
-      if (btn) btn.style.display = 'none';
+    document.getElementById('userInfo').textContent = user.username + ' (Coord.)';
+    document.querySelectorAll('.admin-only-tab').forEach(btn => {
+      btn.style.display = 'none';
+      const content = document.getElementById(btn.dataset.tab + 'Tab');
       if (content) content.style.display = 'none';
     });
-    // Activar tab relatórios diretamente
     document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
     document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
     const rTab = document.querySelector('.nav-tab[data-tab="reports"]');
     const rContent = document.getElementById('reportsTab');
     if (rTab) rTab.classList.add('active');
     if (rContent) rContent.classList.add('active');
+    // Título do painel
+    const h1 = document.querySelector('.admin-header h1');
+    if (h1) h1.textContent = 'Painel de Coordenação';
   }
 
   // Admin: carregar dados iniciais

--- a/admin.html
+++ b/admin.html
@@ -26,13 +26,13 @@
 
     <!-- Navigation Tabs -->
     <nav class="admin-nav">
-      <button class="nav-tab active" data-tab="portals">🏢 Portais</button>
-      <button class="nav-tab" data-tab="users">👤 Utilizadores <span id="requestsBadge" style="display:none;background:#f59e0b;color:#fff;font-size:11px;font-weight:800;padding:1px 7px;border-radius:10px;margin-left:4px;vertical-align:middle;"></span></button>
-      <button class="nav-tab" data-tab="import">📥 Importar Excel</button>
-      <button class="nav-tab" data-tab="settings">⚙️ Configurações</button>
+      <button class="nav-tab active admin-only-tab" data-tab="portals">🏢 Portais</button>
+      <button class="nav-tab admin-only-tab" data-tab="users">👤 Utilizadores <span id="requestsBadge" style="display:none;background:#f59e0b;color:#fff;font-size:11px;font-weight:800;padding:1px 7px;border-radius:10px;margin-left:4px;vertical-align:middle;"></span></button>
+      <button class="nav-tab admin-only-tab" data-tab="import">📥 Importar Excel</button>
+      <button class="nav-tab admin-only-tab" data-tab="settings">⚙️ Configurações</button>
       <button class="nav-tab" data-tab="reports">📊 Relatórios</button>
-      <button class="nav-tab" data-tab="audit">🔍 Auditoria</button>
-      <button class="nav-tab" data-tab="flashglass">📸 Flash Glass</button>
+      <button class="nav-tab admin-only-tab" data-tab="audit">🔍 Auditoria</button>
+      <button class="nav-tab admin-only-tab" data-tab="flashglass">📸 Flash Glass</button>
       <button class="nav-tab" data-tab="checkins">⏱️ Check-in</button>
       <button class="nav-tab" data-tab="search">🔎 Pesquisa</button>
       <button class="nav-tab" data-tab="alerts">🚨 Alertas <span id="alertsBadge" style="display:none;background:#dc2626;color:#fff;font-size:11px;font-weight:800;padding:1px 7px;border-radius:10px;margin-left:4px;vertical-align:middle;"></span></button>

--- a/portal-init.js
+++ b/portal-init.js
@@ -150,6 +150,7 @@
 
   // Adicionar botão de logout no header
   addLogoutButton();
+  if (user.role === 'coordenador') addCoordPanelButton();
 
   // Controlo de visibilidade por role
   const role = user.role;
@@ -394,6 +395,22 @@ function addAdminBackButton() {
     window.location.href = '/admin.html';
   });
   headerActions.insertBefore(backBtn, headerActions.firstChild);
+}
+
+// Botão de painel para coordenadores
+function addCoordPanelButton() {
+  var headerActions = document.querySelector('.header-actions');
+  if (!headerActions) return;
+
+  var btn = document.createElement('button');
+  btn.className = 'header-btn';
+  btn.title = 'Painel de gestão';
+  btn.textContent = '⚙️';
+  btn.style.cssText = 'font-size:18px;';
+  btn.addEventListener('click', function() {
+    window.location.href = '/admin.html';
+  });
+  headerActions.insertBefore(btn, headerActions.firstChild);
 }
 
 // Atualizar dropdown de localidades


### PR DESCRIPTION
## Summary
- **portal-init.js**: adds ⚙️ gear button to the header for `coordenador` role, linking to `admin.html` (same UX as the admin back button)
- **admin.html**: marks admin-only tabs with `class="admin-only-tab"` — portais, utilizadores, importar, configurações, auditoria, flashglass
- **admin-script.js**: when role is `coordenador`, hides all `admin-only-tab` tabs and their content, defaults to **Relatórios** tab, changes title to "Painel de Coordenação"; portal dropdown is pre-populated with only their portals

Coordinators see only: 📊 Relatórios · ⏱️ Check-in · 🔎 Pesquisa · 🚨 Alertas — all already filtered to their portals via the JWT token.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_