### PR TITLE
Fix coordinator portal dropdown empty + mobile nav scrollbar

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -77,11 +77,23 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
-  // Use portals stored in session at login (avoids calling admin-only /portals API)
-  let list = user.portals || [];
-  if (user?.portal?.id && !list.find(p => p.id === user.portal.id)) {
-    list = [user.portal, ...list];
+  // Try cached portals first
+  let list = [];
+  if (user.portals?.length) {
+    list = user.portals;
+  } else if (user.portal?.id) {
+    list = [user.portal];
   }
+
+  // Fallback: fetch from API (always reliable, filters by coordinator's JWT)
+  if (!list.length) {
+    try {
+      const res = await authClient.authenticatedFetch('/.netlify/functions/glass-reception?list_portals=true');
+      const data = await res.json();
+      if (data.success && data.data?.length) list = data.data;
+    } catch (_) {}
+  }
+
   if (!list.length) return;
   portals = list;
   window._adminPortals = list;

--- a/admin-style.css
+++ b/admin-style.css
@@ -517,7 +517,10 @@ body {
     -webkit-overflow-scrolling: touch;
     flex-wrap: nowrap;
     gap: 0;
+    scrollbar-width: thin;
   }
+  .admin-nav::-webkit-scrollbar { height: 3px; }
+  .admin-nav::-webkit-scrollbar-thumb { background: #bfdbfe; border-radius: 2px; }
 
   .nav-tab {
     padding: 12px 14px;


### PR DESCRIPTION
## Summary
- **Portal dropdown fix**: `loadPortalsForReports()` now falls back to calling `/.netlify/functions/glass-reception?list_portals=true` when the cached user object has no `portals` array — handles coordinators with only a single `portal_id` in the users table (no `coordinator_portals` rows)
- **Mobile nav scrollbar**: added a thin blue scrollbar indicator on the admin-nav so the coordinator can see there are more tabs to swipe to on mobile

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_