### PR TITLE
Fix coordinator portal dropdown (check all portal sources)

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -77,20 +77,23 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
-  // Try cached portals first
-  let list = [];
-  if (user.portals?.length) {
-    list = user.portals;
-  } else if (user.portal?.id) {
-    list = [user.portal];
-  }
+  const seen = new Set();
+  const list = [];
+  const add = (arr) => {
+    if (!arr?.length) return;
+    arr.forEach(p => { if (p?.id && !seen.has(p.id)) { seen.add(p.id); list.push(p); } });
+  };
 
-  // Fallback: fetch from API (always reliable, filters by coordinator's JWT)
+  add(user.portals);
+  if (user.portal?.id) add([user.portal]);
+  add(user.consultablePortals);
+
+  // Fallback: DB query via API (covers cases where JWT cache is incomplete)
   if (!list.length) {
     try {
       const res = await authClient.authenticatedFetch('/.netlify/functions/glass-reception?list_portals=true');
       const data = await res.json();
-      if (data.success && data.data?.length) list = data.data;
+      if (data.success && data.data?.length) data.data.forEach(p => list.push(p));
     } catch (_) {}
   }
 

--- a/admin.html
+++ b/admin.html
@@ -626,7 +626,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-09c"></script>
+  <script src="admin-script.js?v=2026-06-12a"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -76,16 +76,23 @@ exports.handler = async (event) => {
 
       // ── List portals accessible to this user (for history dropdown) ──────────
       if (p.list_portals === 'true') {
-        let pq, pVals;
+        let pRows;
         if (user.role === 'admin') {
-          pq = `SELECT id, name FROM portals ORDER BY name`;
-          pVals = [];
+          ({ rows: pRows } = await client.query(`SELECT id, name FROM portals ORDER BY name`));
         } else {
-          const ids = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
-          pq = `SELECT id, name FROM portals WHERE id = ANY($1) ORDER BY name`;
-          pVals = [ids];
+          const uid = user.userId || user.id;
+          ({ rows: pRows } = await client.query(`
+            SELECT DISTINCT p.id, p.name FROM portals p
+            WHERE p.id IN (
+              SELECT portal_id FROM coordinator_portals WHERE user_id = $1
+              UNION
+              SELECT portal_id FROM consultable_portals WHERE user_id = $1
+              UNION
+              SELECT portal_id FROM users WHERE id = $1 AND portal_id IS NOT NULL
+            )
+            ORDER BY p.name
+          `, [uid]));
         }
-        const { rows: pRows } = await client.query(pq, pVals);
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: pRows }) };
       }
 


### PR DESCRIPTION
## Summary
- `loadPortalsForReports()` now merges portals from all three cached sources: `user.portals`, `user.portal`, and `user.consultablePortals`
- `glass-reception?list_portals=true` API fallback now queries `coordinator_portals`, `consultable_portals`, and `users.portal_id` directly from the DB by user ID — no longer relies on JWT `portalIds` field which may be empty
- Bumped `admin-script.js` cache-buster to `v=2026-06-12a` to clear stale browser cache

## Test plan
- [ ] Coordinator with `coordinator_portals` entries sees portals in dropdown
- [ ] Coordinator with only `consultable_portals` entries also sees portals
- [ ] Admin portal dropdown unaffected (uses full portal list as before)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_