### PR TITLE
Pré-selecionar portal único no painel do coordenador

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -77,6 +77,14 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
+
+  // Mês atual por omissão (a tab é ativada programaticamente, initReportFilters não corre)
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}`;
+  const fromEl = document.getElementById('reportFrom');
+  const toEl = document.getElementById('reportTo');
+  if (fromEl && !fromEl.value) fromEl.value = ym;
+  if (toEl && !toEl.value) toEl.value = ym;
   const seen = new Set();
   const list = [];
   const add = (arr) => {
@@ -115,6 +123,8 @@ function populateReportPortalSelect(portalList) {
   if (!sel) return;
   sel.innerHTML = '<option value="">Selecionar portal</option>' +
     portalList.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+  // Pré-selecionar quando só existe um portal
+  if (portalList.length === 1) sel.value = String(portalList[0].id);
 }
 
 // ===== GESTÃO DE PORTAIS =====


### PR DESCRIPTION
## Summary
- Quando o coordenador só tem um portal, esse portal fica pré-selecionado no dropdown (em vez de mostrar apenas "Selecionar portal" — que parecia vazio)
- Campos De/Até preenchidos por omissão com o mês atual no painel do coordenador

O texto "Selecionar portal" só é escrito quando a lista de portais carrega com sucesso — o dropdown estava provavelmente populado, mas fechado mostrava sempre o placeholder, parecendo "igual".

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_