### PR TITLE
Fix admin-coord-only.js: mostrar os 4 tabs do coordenador

### DIFF
--- a/admin-coord-only.js
+++ b/admin-coord-only.js
@@ -1,6 +1,5 @@
 // admin-coord-only.js
-// Para coordenadores no admin.html: esconder TUDO menos a tab Relatórios + botão Sair.
-// Esconde header (Vista Comercial, Agendas, etc), e todas as tabs menos Relatórios.
+// Para coordenadores no admin.html: esconder tabs de admin puro, manter Relatórios/Check-in/Pesquisa/Alertas.
 
 (function() {
   function aplicar() {
@@ -39,19 +38,21 @@
       }
     }
 
-    // 2) Esconder TODAS as tabs excepto Relatórios
+    // 2) Esconder tabs de admin puro; manter Relatórios, Check-in, Pesquisa, Alertas
+    const coordTabs = ['reports', 'checkins', 'search', 'alerts'];
     document.querySelectorAll('.nav-tab').forEach(tab => {
-      if (tab.dataset.tab !== 'reports') {
+      if (!coordTabs.includes(tab.dataset.tab)) {
         tab.style.display = 'none';
       }
     });
 
-    // 3) Esconder tab content de tudo menos reports
+    // 3) Esconder conteúdo de tabs admin puro
+    const coordContent = ['reportsTab', 'checkinsTab', 'searchTab', 'alertsTab'];
     document.querySelectorAll('.tab-content').forEach(t => {
-      if (t.id !== 'reportsTab') t.style.display = 'none';
+      if (!coordContent.includes(t.id)) t.style.display = 'none';
     });
 
-    console.log('✅ Modo coordenador: só Relatórios visível');
+    console.log('✅ Modo coordenador: Relatórios, Check-in, Pesquisa e Alertas visíveis');
   }
 
   if (document.readyState === 'loading') {

--- a/admin-script.js
+++ b/admin-script.js
@@ -77,6 +77,14 @@ navTabs.forEach(tab => {
 // ===== CARREGAR PORTAIS PARA RELATÓRIOS (coordenador) =====
 async function loadPortalsForReports() {
   const user = authClient.getUser();
+
+  // Mês atual por omissão (a tab é ativada programaticamente, initReportFilters não corre)
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}`;
+  const fromEl = document.getElementById('reportFrom');
+  const toEl = document.getElementById('reportTo');
+  if (fromEl && !fromEl.value) fromEl.value = ym;
+  if (toEl && !toEl.value) toEl.value = ym;
   const seen = new Set();
   const list = [];
   const add = (arr) => {
@@ -115,6 +123,8 @@ function populateReportPortalSelect(portalList) {
   if (!sel) return;
   sel.innerHTML = '<option value="">Selecionar portal</option>' +
     portalList.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+  // Pré-selecionar quando só existe um portal
+  if (portalList.length === 1) sel.value = String(portalList[0].id);
 }
 
 // ===== GESTÃO DE PORTAIS =====

--- a/admin-script.js
+++ b/admin-script.js
@@ -38,6 +38,12 @@
     // Título do painel
     const h1 = document.querySelector('.admin-header h1');
     if (h1) h1.textContent = 'Painel de Coordenação';
+    // Fazer tabs wrapping para que todos os 4 fiquem visíveis em mobile sem scroll
+    const adminNav = document.querySelector('.admin-nav');
+    if (adminNav) {
+      adminNav.style.flexWrap = 'wrap';
+      adminNav.style.padding = '0 8px';
+    }
   }
 
   // Admin: carregar dados iniciais


### PR DESCRIPTION
## Root cause
`admin-coord-only.js` tinha um `setTimeout(200ms)` que escondia **todos** os tabs excepto Relatórios — isto anulava o trabalho do `admin-script.js` que tentava mostrar Check-in, Pesquisa e Alertas.

## Fix
Alterado para apenas esconder os tabs de admin puro (portais, utilizadores, importar, configurações, auditoria, flashglass) e manter os 4 tabs do coordenador visíveis: Relatórios, Check-in, Pesquisa, Alertas.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_