### PR TITLE
Import Excel: preservar dados existentes e acrescentar notas novas

### DIFF
--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -108,16 +108,29 @@ exports.handler = async (event) => {
           const excelDate = svc.date ? String(svc.date).slice(0, 10) : null;
           const shouldUpdateDate = excelDate && excelDate >= todayISO && (!existingDate || existingDate < todayISO);
 
+          // Dados existentes nunca são apagados: campos simples só se preenchem
+          // quando vazios; notas/extra acrescentam o que o Excel traz de novo.
+          const mergeText = (col, idx) => `${col}=CASE
+               WHEN ${idx} IS NULL OR ${idx}='' THEN ${col}
+               WHEN ${col} IS NULL OR ${col}='' THEN ${idx}
+               WHEN POSITION(${idx} IN ${col}) > 0 THEN ${col}
+               ELSE ${col} || ' | ' || ${idx} END`;
           if (shouldUpdateDate) {
             await pool.query(
-              `UPDATE appointments SET date=$1, period=$2, car=COALESCE($3,car), notes=COALESCE($4,notes), extra=COALESCE($5,extra), phone=COALESCE($6,phone), client_name=COALESCE($7,client_name), n_obra=COALESCE($10,n_obra), auto_imported=true, confirmed=false, updated_at=$8,
-               order_ref=COALESCE($11,order_ref), reception_ref=COALESCE($12,reception_ref) WHERE id=$9`,
+              `UPDATE appointments SET date=$1, period=$2,
+               car=COALESCE(NULLIF(car,''),$3), ${mergeText('notes','$4')}, ${mergeText('extra','$5')},
+               phone=COALESCE(NULLIF(phone,''),$6), client_name=COALESCE(NULLIF(client_name,''),$7),
+               n_obra=COALESCE(NULLIF(n_obra,''),$10), auto_imported=true, confirmed=false, updated_at=$8,
+               order_ref=COALESCE(NULLIF(order_ref,''),$11), reception_ref=COALESCE(NULLIF(reception_ref,''),$12) WHERE id=$9`,
               [excelDate, svc.period||null, svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, existing.id, svc.n_obra||null, normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)]
             );
           } else {
             await pool.query(
-              `UPDATE appointments SET car=COALESCE($1,car), notes=COALESCE($2,notes), extra=COALESCE($3,extra), phone=COALESCE($4,phone), client_name=COALESCE($5,client_name), n_obra=COALESCE($7,n_obra), updated_at=$6,
-               order_ref=COALESCE($9,order_ref), reception_ref=COALESCE($10,reception_ref) WHERE id=$8`,
+              `UPDATE appointments SET
+               car=COALESCE(NULLIF(car,''),$1), ${mergeText('notes','$2')}, ${mergeText('extra','$3')},
+               phone=COALESCE(NULLIF(phone,''),$4), client_name=COALESCE(NULLIF(client_name,''),$5),
+               n_obra=COALESCE(NULLIF(n_obra,''),$7), updated_at=$6,
+               order_ref=COALESCE(NULLIF(order_ref,''),$9), reception_ref=COALESCE(NULLIF(reception_ref,''),$10) WHERE id=$8`,
               [svc.car||null, svc.notes||null, svc.extra||null, svc.phone||null, svc.client_name||null, now, svc.n_obra||null, existing.id, normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)]
             );
           }


### PR DESCRIPTION
## Comportamento do import Excel ao atualizar agendamentos existentes

- **Campos simples** (`car`, `phone`, `client_name`, `n_obra`, `order_ref`, `reception_ref`): só se preenchem quando estão vazios — o que está no agendamento tem sempre prioridade e nunca é substituído
- **Notas e extra**: o texto do Excel é **acrescentado** ao existente com separador ` | ` quando ainda lá não está (evita duplicados em imports repetidos)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_