### PR TITLE
Pesquisa Global (admin): aplicar config das matrículas ao campo

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2489,6 +2489,30 @@ document.querySelectorAll('.nav-tab').forEach(tab => {
   });
 });
 
+// Pesquisa Global: mesma config das matrículas (maiúsculas + hífens XX-XX-XX),
+// mas sem partir pesquisas de encomenda (só dígitos), eurocode (>6 alfanum.)
+// ou referências com pontuação (Rec.5548).
+(function () {
+  const el = document.getElementById('gsQuery');
+  if (!el) return;
+  el.addEventListener('input', () => {
+    const raw = el.value;
+    const upper = raw.toUpperCase();
+    const clean = upper.replace(/[^A-Z0-9]/g, '');
+    const plateLike = /^[A-Z0-9\s-]*$/.test(upper)
+      && clean.length <= 6
+      && /[A-Z]/.test(clean) && /\d/.test(clean);
+    if (plateLike) {
+      let v = clean;
+      if (v.length > 2) v = v.slice(0, 2) + '-' + v.slice(2);
+      if (v.length > 5) v = v.slice(0, 5) + '-' + v.slice(5);
+      el.value = v;
+    } else {
+      el.value = upper;
+    }
+  });
+})();
+
 (async () => {
   // Aguardar auth estar pronta antes de carregar o badge
   if (!window.authClient?.isAuthenticated?.()) return;

--- a/admin.html
+++ b/admin.html
@@ -626,7 +626,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-12a"></script>
+  <script src="admin-script.js?v=2026-06-12c"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;

--- a/netlify/functions/global-search.js
+++ b/netlify/functions/global-search.js
@@ -35,7 +35,10 @@ exports.handler = async (event) => {
   }
 
   const plateNorm = '%' + q.toUpperCase().replace(/[^A-Z0-9]/g, '') + '%';
-  const textLike = '%' + q.toLowerCase() + '%';
+  // Texto (encomenda/eurocode/nº obra): comparação sem pontuação, para que
+  // "51-621" ou "Rec.5548" encontrem "Enc.Axial 51621" / "Rec.5548".
+  const textLike = '%' + q.toLowerCase().replace(/[^a-z0-9]/g, '') + '%';
+  const normCol = col => `LOWER(REGEXP_REPLACE(COALESCE(${col},''), '[^a-zA-Z0-9]', '', 'g'))`;
 
   // Restrição de portais para coordenadores
   const coordIds = user.role === 'admin'
@@ -54,7 +57,7 @@ exports.handler = async (event) => {
       FROM appointments a
       LEFT JOIN portals po ON po.id = a.portal_id
       WHERE (UPPER(REGEXP_REPLACE(a.plate, '[^A-Z0-9]', '', 'g')) LIKE $1
-             OR LOWER(a.order_ref) LIKE $2 OR LOWER(a.n_obra) LIKE $2)
+             OR ${normCol('a.order_ref')} LIKE $2 OR ${normCol('a.n_obra')} LIKE $2)
     `;
     const aVals = [plateNorm, textLike];
     if (coordIds) { aq += ` AND a.portal_id = ANY($3)`; aVals.push(coordIds); }
@@ -70,7 +73,7 @@ exports.handler = async (event) => {
       LEFT JOIN appointments a ON a.id = gr.appointment_id
       LEFT JOIN portals po ON po.id = gr.portal_id
       WHERE (UPPER(REGEXP_REPLACE(COALESCE(a.plate,''), '[^A-Z0-9]', '', 'g')) LIKE $1
-             OR LOWER(gr.eurocode) LIKE $2 OR LOWER(gr.order_ref) LIKE $2)
+             OR ${normCol('gr.eurocode')} LIKE $2 OR ${normCol('gr.order_ref')} LIKE $2)
     `;
     const rVals = [plateNorm, textLike];
     if (coordIds) { rq += ` AND gr.portal_id = ANY($3)`; rVals.push(coordIds); }
@@ -84,7 +87,7 @@ exports.handler = async (event) => {
         SELECT id, matricula, car, data_servico, status, n_obra, created_at
         FROM mycar_services
         WHERE UPPER(REGEXP_REPLACE(matricula, '[^A-Z0-9]', '', 'g')) LIKE $1
-           OR LOWER(n_obra) LIKE $2
+           OR ${normCol('n_obra')} LIKE $2
         ORDER BY created_at DESC LIMIT 50
       `, [plateNorm, textLike]);
       mycar = rows;


### PR DESCRIPTION
## Resumo

O campo de pesquisa do separador **Pesquisa Global** do painel admin (`#gsQuery`) passa a assumir a mesma configuração das matrículas:

- **Maiúsculas automáticas** enquanto se escreve
- **Hífens automáticos XX-XX-XX** quando o conteúdo parece uma matrícula (até 6 alfanuméricos com letras e dígitos) — ex.: `12ab34` → `12-AB-34`
- Pesquisas que **não** são matrículas mantêm-se intactas (só maiúsculas): números de encomenda (`51621`), eurocodes (`5548AGSV`), referências com pontuação (`Rec.5548`)
- **Backend**: a pesquisa de encomenda/eurocode/nº de obra passa a ignorar pontuação em ambos os lados — `51-621` encontra `Enc.Axial 51621`

## Test plan

- [ ] Admin → Pesquisa → escrever `12ab34` → formata para `12-AB-34` e encontra a matrícula
- [ ] Escrever `51621` → fica como está (sem hífens) e encontra a encomenda
- [ ] Escrever `rec.5548` → fica `REC.5548` e encontra a receção
- [ ] Escrever eurocode com 7+ caracteres → não é truncado nem hifenizado

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_