### PR TITLE
Fix: gsQuery sempre remove caracteres não-alfanuméricos

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2489,26 +2489,22 @@ document.querySelectorAll('.nav-tab').forEach(tab => {
   });
 });
 
-// Pesquisa Global: mesma config das matrículas (maiúsculas + hífens XX-XX-XX),
-// mas sem partir pesquisas de encomenda (só dígitos), eurocode (>6 alfanum.)
-// ou referências com pontuação (Rec.5548).
+// Pesquisa Global: mesma config das matrículas
+// — sempre maiúsculas, sempre sem pontuação (o backend normaliza ambos os lados)
+// — se parece matrícula (≤6 alfanums com letras+dígitos) insere hífens XX-XX-XX
 (function () {
   const el = document.getElementById('gsQuery');
   if (!el) return;
   el.addEventListener('input', () => {
-    const raw = el.value;
-    const upper = raw.toUpperCase();
-    const clean = upper.replace(/[^A-Z0-9]/g, '');
-    const plateLike = /^[A-Z0-9\s-]*$/.test(upper)
-      && clean.length <= 6
-      && /[A-Z]/.test(clean) && /\d/.test(clean);
+    const clean = el.value.toUpperCase().replace(/[^A-Z0-9]/g, '');
+    const plateLike = clean.length <= 6 && /[A-Z]/.test(clean) && /[0-9]/.test(clean);
     if (plateLike) {
       let v = clean;
       if (v.length > 2) v = v.slice(0, 2) + '-' + v.slice(2);
       if (v.length > 5) v = v.slice(0, 5) + '-' + v.slice(5);
       el.value = v;
     } else {
-      el.value = upper;
+      el.value = clean;
     }
   });
 })();

--- a/admin.html
+++ b/admin.html
@@ -626,7 +626,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-12c"></script>
+  <script src="admin-script.js?v=2026-06-12d"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Fix

O branch `else` definia `el.value = upper` que preservava pontuação (vírgulas, pontos, espaços). Agora todos os caracteres não-alfanuméricos são sempre removidos — igual ao comportamento dos campos de matrícula. O backend normaliza ambos os lados pelo que `Rec.5548` → `REC5548` ainda encontra os registos corretos.

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_