### PR TITLE
Pesquisa Global: formato matrícula estrito (XX-XX-XX)

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2489,23 +2489,20 @@ document.querySelectorAll('.nav-tab').forEach(tab => {
   });
 });
 
-// Pesquisa Global: mesma config das matrículas
-// — sempre maiúsculas, sempre sem pontuação (o backend normaliza ambos os lados)
-// — se parece matrícula (≤6 alfanums com letras+dígitos) insere hífens XX-XX-XX
+// Pesquisa Global: formato matrícula (igual aos campos de matrícula)
+// — maiúsculas, sem pontuação, hífens automáticos XX-XX-XX, máx. 8 caracteres
 (function () {
   const el = document.getElementById('gsQuery');
   if (!el) return;
   el.addEventListener('input', () => {
-    const clean = el.value.toUpperCase().replace(/[^A-Z0-9]/g, '');
-    const plateLike = clean.length <= 6 && /[A-Z]/.test(clean) && /[0-9]/.test(clean);
-    if (plateLike) {
-      let v = clean;
-      if (v.length > 2) v = v.slice(0, 2) + '-' + v.slice(2);
-      if (v.length > 5) v = v.slice(0, 5) + '-' + v.slice(5);
-      el.value = v;
-    } else {
-      el.value = clean;
-    }
+    let v = el.value.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+    if (v.length > 2) v = v.slice(0, 2) + '-' + v.slice(2);
+    if (v.length > 5) v = v.slice(0, 5) + '-' + v.slice(5, 7);
+    el.value = v;
+  });
+  el.addEventListener('keydown', (e) => {
+    const allowed = ['Backspace', 'Delete', 'Tab', 'ArrowLeft', 'ArrowRight', 'Home', 'End', 'Enter'];
+    if (!allowed.includes(e.key) && !/^[A-Za-z0-9]$/.test(e.key)) e.preventDefault();
   });
 })();
 

--- a/admin.html
+++ b/admin.html
@@ -435,7 +435,7 @@
       <h2 style="margin-bottom:6px;">🔎 Pesquisa Global</h2>
       <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Procura por matrícula, encomenda, eurocode ou nº de obra em agendamentos, receções de vidro e mural MyCar.</p>
       <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px;">
-        <input type="text" id="gsQuery" placeholder="Ex: 12-AB-34, 51621, Rec.5548..." style="flex:1;min-width:240px;max-width:420px;padding:10px 14px;border:1px solid #d1d5db;border-radius:8px;font-size:15px;" onkeydown="if(event.key==='Enter')runGlobalSearch()">
+        <input type="text" id="gsQuery" placeholder="XX-XX-XX" maxlength="8" autocomplete="off" style="flex:1;min-width:240px;max-width:420px;padding:10px 14px;border:1px solid #d1d5db;border-radius:8px;font-size:15px;text-transform:uppercase;letter-spacing:2px;font-weight:700;" onkeydown="if(event.key==='Enter')runGlobalSearch()">
         <button onclick="runGlobalSearch()" style="background:#2563eb;color:#fff;border:none;padding:10px 24px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">🔎 Pesquisar</button>
       </div>
       <div id="gsResults"><p style="color:#94a3b8;text-align:center;padding:30px;">Introduza pelo menos 3 caracteres e pesquise.</p></div>
@@ -626,7 +626,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-12d"></script>
+  <script src="admin-script.js?v=2026-06-12e"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;


### PR DESCRIPTION
## Resumo

O campo da Pesquisa Global passa a ter **exatamente** o mesmo comportamento dos campos de matrícula:

- Hífens automáticos **sempre**: escrever `12ab34` → `12-AB-34`
- Máximo 8 caracteres (XX-XX-XX)
- Teclas não alfanuméricas bloqueadas no keydown (Enter continua a pesquisar)
- Placeholder `XX-XX-XX`, maxlength=8, estilo uppercase com letter-spacing

A pesquisa por encomenda/nº de obra continua a funcionar porque o backend remove a pontuação de ambos os lados (`51-62-1` encontra `Enc.Axial 51621`).

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_