### PR TITLE
Hide empty-state Venda compl. button on cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-12b"></script>
-  <script src="script-tail.js?v=2026-06-15a"></script>
+  <script src="script-tail.js?v=2026-06-15d"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -92,7 +92,7 @@ const telBtn = phone ? `
     ? (a.comp_sales_faturado
         ? `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:#059669;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:800;color:#fff;cursor:pointer;">✅ Venda faturada</button>`
         : `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:#d97706;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:800;color:#fff;cursor:pointer;">💰 Venda pendente</button>`)
-    : `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:rgba(0,0,0,0.25);border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:700;color:#fff;cursor:pointer;">💰 Venda compl.</button>`;
+    : '';
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');
   const phcFooter = isAutoImported ? `


### PR DESCRIPTION
Cards no longer show the '💰 Venda compl.' button when there is no complementary sale recorded (`comp_sales_desc` is null/empty). The button only appears when a comp sale exists — as '💰 Venda pendente' (amber) or '✅ Venda faturada' (green). Comp sales can still be added via the appointment edit form.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_