### PR TITLE
Auto-select locality on single match when typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,8 +804,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-12b"></script>
-  <script src="script-tail.js?v=2026-06-15d"></script>
+  <script src="script.js?v=2026-06-15e"></script>
+  <script src="script-tail.js?v=2026-06-15a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -92,7 +92,7 @@ const telBtn = phone ? `
     ? (a.comp_sales_faturado
         ? `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:#059669;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:800;color:#fff;cursor:pointer;">✅ Venda faturada</button>`
         : `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:#d97706;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:800;color:#fff;cursor:pointer;">💰 Venda pendente</button>`)
-    : '';
+    : `<button onclick="event.stopPropagation();openCompSalesModal('${a.id}')" style="margin:4px 8px 0;display:inline-flex;align-items:center;gap:4px;background:rgba(0,0,0,0.25);border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:700;color:#fff;cursor:pointer;">💰 Venda compl.</button>`;
   // Footer PHC: só mostrar se auto_imported E status ainda é NE
   const isAutoImported = a.auto_imported && a.date && (!a.status || a.status === 'NE');
   const phcFooter = isAutoImported ? `

--- a/script.js
+++ b/script.js
@@ -1327,8 +1327,24 @@ function buildLocalityOptions() {
 
   // Ligar evento de pesquisa
   if (search) {
+    let _autoSelectTimer = null;
     search.addEventListener('input', (e) => {
+      clearTimeout(_autoSelectTimer);
       renderLocalityOptions(e.target.value);
+      // Se só houver um resultado, selecionar automaticamente após pausa
+      if (e.target.value.trim().length >= 3) {
+        _autoSelectTimer = setTimeout(() => {
+          const opts = document.querySelectorAll('#localityOptions .loc-opt');
+          if (opts.length === 1) window.selectLocality?.(opts[0].getAttribute('data-value'));
+        }, 400);
+      }
+    });
+    search.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const opts = document.querySelectorAll('#localityOptions .loc-opt');
+        if (opts.length >= 1) window.selectLocality?.(opts[0].getAttribute('data-value'));
+      }
     });
   }
 }


### PR DESCRIPTION
When typing in the locality search field, if there is only one matching concelho after a 400ms pause (≥3 characters typed), it is automatically selected. Pressing Enter also immediately selects the first/only match. This means typing 'famalicao' will auto-fill 'Vila Nova de Famalicão' without requiring a manual click. Also restores the '💰 Venda compl.' button that was mistakenly removed in PR #300.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_