### PR TITLE
Fix sync-portal: missing column migrations causing 76 errors

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1223,6 +1223,7 @@ async function startSync() {
   document.getElementById('btnSyncImport').disabled = true;
 
   let totalCreated = 0, totalUpdated = 0, totalDeleted = 0, totalSkipped = 0, totalErrors = 0;
+  const allErrorSamples = [];
   let done = 0;
   const total = portalIds.length;
 
@@ -1245,10 +1246,12 @@ async function startSync() {
         totalDeleted += result.data.deleted || 0;
         totalSkipped += result.data.skipped || 0;
         totalErrors  += result.data.errors  || 0;
+        if (result.data.error_samples?.length) allErrorSamples.push(...result.data.error_samples);
       }
     } catch (err) {
       console.error('Erro sync portal', portalId, err);
       totalErrors++;
+      allErrorSamples.push('Erro de rede: ' + err.message);
     }
     done++;
   }
@@ -1256,6 +1259,13 @@ async function startSync() {
   document.getElementById('importProgressBar').style.width = '100%';
   document.getElementById('importProgressText').textContent = 'Sincronização concluída!';
   document.getElementById('btnSyncImport').disabled = false;
+
+  const errorSamplesHtml = (totalErrors > 0 && allErrorSamples.length > 0)
+    ? `<div style="margin-top:12px;padding:12px;background:#fef2f2;border-radius:8px;border:1px solid #fecaca;">
+        <div style="font-size:13px;font-weight:700;color:#dc2626;margin-bottom:6px;">⚠️ Primeiros erros registados:</div>
+        ${allErrorSamples.slice(0,5).map(e => `<div style="font-size:12px;color:#7f1d1d;font-family:monospace;margin-bottom:2px;">${e}</div>`).join('')}
+       </div>`
+    : '';
 
   document.getElementById('importResultsContent').innerHTML = `
     <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-top:12px;">
@@ -1276,6 +1286,7 @@ async function startSync() {
         <div style="font-size:13px;color:#6b7280;">Erros</div>
       </div>
     </div>
+    ${errorSamplesHtml}
   `;
   document.getElementById('importResults').style.display = 'block';
   showToast(`Sync concluído: ${totalCreated} criados, ${totalUpdated} agendados, ${totalDeleted} apagados`, 'success');

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -52,9 +52,11 @@ exports.handler = async (event) => {
   }
 
   try {
-    // Ensure n_obra column exists (migration guard)
+    // Migration guards — safe to run repeatedly
     try {
       await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+      await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS order_ref TEXT`);
+      await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS reception_ref TEXT`);
       await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
       await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
     } catch(e) { console.warn('Migration warning:', e.message); }
@@ -83,7 +85,7 @@ exports.handler = async (event) => {
     );
     const deleted = delResult.rowCount;
 
-    const results = { created: 0, updated: 0, skipped: 0, errors: 0, deleted };
+    const results = { created: 0, updated: 0, skipped: 0, errors: 0, deleted, error_samples: [] };
     const todayISO = new Date().toISOString().slice(0, 10);
     const now = new Date().toISOString();
 
@@ -178,6 +180,7 @@ exports.handler = async (event) => {
       } catch (err) {
         console.error('Erro svc', svc.plate, err.message);
         results.errors++;
+        if (results.error_samples.length < 5) results.error_samples.push(`${svc.plate}: ${err.message}`);
       }
     }
 


### PR DESCRIPTION
The sync was failing on ~76 rows because the `order_ref` and `reception_ref` columns were being used in INSERT/UPDATE queries but the migration guard only added `n_obra`. This fix adds `ADD COLUMN IF NOT EXISTS` guards for both columns. Also collects the first 5 error messages per sync and displays them in the import results UI so failures are diagnosable.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_