### PR TITLE
Fix sync-portal param type error and function timeouts

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1244,7 +1244,13 @@ async function startSync() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ portal_id: parseInt(portalId), services })
       });
-      const result = await response.json();
+      const rawText = await response.text();
+      let result;
+      try {
+        result = JSON.parse(rawText);
+      } catch (parseErr) {
+        throw new Error(`resposta inválida do servidor (HTTP ${response.status}): ${rawText.slice(0, 120)}`);
+      }
       if (result.success) {
         totalCreated += result.data.created || 0;
         totalUpdated += result.data.updated || 0;

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -89,34 +89,41 @@ exports.handler = async (event) => {
     const todayISO = new Date().toISOString().slice(0, 10);
     const now = new Date().toISOString();
 
-    for (const svc of services) {
+    // Lookup em lote dos já agendados (com data) deste portal, de uma só vez,
+    // em vez de 1 SELECT por serviço (evita timeout da function em portais grandes).
+    const { rows: existingRows } = await pool.query(
+      `SELECT id, date, UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) AS plate_norm
+       FROM appointments
+       WHERE portal_id = $1 AND date IS NOT NULL
+         AND UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) = ANY($2::text[])`,
+      [portal_id, Array.from(excelNorms)]
+    );
+    const existingByPlate = new Map(existingRows.map(r => [r.plate_norm, r]));
+
+    // Dados existentes nunca são apagados: campos simples só se preenchem
+    // quando vazios; notas/extra acrescentam o que o Excel traz de novo.
+    // Os parâmetros levam cast ::text explícito porque, quando vêm a null,
+    // o Postgres não consegue inferir o tipo só a partir do CASE/POSITION
+    // (erro "could not determine data type of parameter").
+    const mergeText = (col, idx) => `${col}=CASE
+         WHEN ${idx}::text IS NULL OR ${idx}::text='' THEN ${col}
+         WHEN ${col} IS NULL OR ${col}='' THEN ${idx}::text
+         WHEN POSITION(${idx}::text IN ${col}) > 0 THEN ${col}
+         ELSE ${col} || ' | ' || ${idx}::text END`;
+
+    async function processService(svc) {
       const plateNorm = norm(svc.plate);
-      if (!plateNorm) { results.errors++; continue; }
+      if (!plateNorm) { results.errors++; return; }
 
       try {
-        const { rows } = await pool.query(
-          `SELECT id, date FROM appointments
-           WHERE portal_id = $1
-             AND UPPER(REGEXP_REPLACE(plate, '[^A-Z0-9]', '', 'g')) = $2
-             AND date IS NOT NULL
-           LIMIT 1`,
-          [portal_id, plateNorm]
-        );
+        const existing = existingByPlate.get(plateNorm);
 
-        if (rows.length > 0) {
+        if (existing) {
           // Já agendado — atualizar dados e data se necessário
-          const existing = rows[0];
           const existingDate = existing.date ? String(existing.date).slice(0, 10) : null;
           const excelDate = svc.date ? String(svc.date).slice(0, 10) : null;
           const shouldUpdateDate = excelDate && excelDate >= todayISO && (!existingDate || existingDate < todayISO);
 
-          // Dados existentes nunca são apagados: campos simples só se preenchem
-          // quando vazios; notas/extra acrescentam o que o Excel traz de novo.
-          const mergeText = (col, idx) => `${col}=CASE
-               WHEN ${idx} IS NULL OR ${idx}='' THEN ${col}
-               WHEN ${col} IS NULL OR ${col}='' THEN ${idx}
-               WHEN POSITION(${idx} IN ${col}) > 0 THEN ${col}
-               ELSE ${col} || ' | ' || ${idx} END`;
           if (shouldUpdateDate) {
             await pool.query(
               `UPDATE appointments SET date=$1, period=$2,
@@ -182,6 +189,14 @@ exports.handler = async (event) => {
         results.errors++;
         if (results.error_samples.length < 5) results.error_samples.push(`${svc.plate}: ${err.message}`);
       }
+    }
+
+    // Processar com concorrência limitada (em vez de 1 a 1) para caber dentro
+    // do tempo limite da function mesmo em portais com muitos serviços.
+    const CONCURRENCY = 8;
+    for (let i = 0; i < services.length; i += CONCURRENCY) {
+      const chunk = services.slice(i, i + CONCURRENCY);
+      await Promise.all(chunk.map(processService));
     }
 
     console.log(`🔄 Sync portal ${portal_id}: ${results.created} criados, ${results.updated} atualizados, ${results.skipped} ignorados, ${deleted} apagados`);


### PR DESCRIPTION
## Summary
- Fixes `could not determine data type of parameter $2` seen in "Sincronizar com Excel" results: `mergeText()` in `sync-portal.js` now casts its parameters to `::text`, since Postgres couldn't infer the type when notes/extra come in as `null`.
- Fixes `Erro de rede: Unexpected token '<'` (HTML instead of JSON) seen for several portals during sync: replaced the per-service `SELECT` with a single batched lookup, and process services with bounded concurrency (8 at a time) instead of strictly one at a time, so large portals finish well within the Netlify function timeout.
- Client now shows the HTTP status + response snippet if `sync-portal` ever returns non-JSON again, instead of a generic parse error.

## Test plan
- [x] `node --check` on both modified files
- [ ] Run "Sincronizar com Excel" again for the Vila Verde / Ficha Servico 49 portal and confirm 0 erros


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_