### PR TITLE
Set dataservico date on existing Recalibra appointments if missing

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1457,6 +1457,8 @@ async function startSyncOrders() {
         if (recRef)    updates.status = 'ST';
         else if (orderRef && (!existing.status || existing.status === 'NE')) updates.status = 'VE';
         if (carVal) updates.car = carVal;
+        // Preencher data de serviço se ainda não tem (não sobrescreve data manual já definida)
+        if (serviceDate && !existing.date) updates.date = serviceDate;
         if (!Object.keys(updates).length) { skipped++; continue; }
         console.log(`[SyncOrders] PUT ${existing.id} (${plate}):`, updates);
         try {


### PR DESCRIPTION
## Summary
When re-running "Importar Encomendas" on entries that already exist in the Recalibra portal (created before the dataservico fix), now fills in the `date` from the Excel `dataservico` column if the appointment has no date yet. Does not overwrite a date already manually set.

## Test plan
- [ ] BS-76-XL, AN-81-NJ, BJ-04-DC (created without date in the previous run) should move from "Serviços por Agendar" to the correct calendar day after re-running "Importar Encomendas"
- [ ] Appointments with a manually-set date should not have their date overwritten


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_