### PR TITLE
Skip locality warning for Recalibra portals

### DIFF
--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2163,7 +2163,8 @@ function buildDesktopCard(a){
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
   const isPreAgendado = a.confirmed === false;
-  const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  const needsLoc = !loja && !isRecalibra && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
   const locWarning = needsLoc ? `
       <div class="needs-loc-msg">
         <div>⚠️ Falta localidade</div>

--- a/script.js
+++ b/script.js
@@ -2561,7 +2561,8 @@ function buildDesktopCard(a){
     </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;
-  const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  const needsLoc = !loja && !isRecalibra && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
   const locWarning = needsLoc ? `
       <div class="needs-loc-msg">
         <div>⚠️ Falta localidade</div>


### PR DESCRIPTION
## Summary
- Recalibra is a fixed-location workshop — the car goes to them, not the other way around
- The blinking "Falta localidade / Confirma agendamento?" warning only applies to SM portals where the technician travels to the customer
- Added `!isRecalibra` guard to the `needsLoc` condition in both `script.js` and `netlify/functions/script.js`

## Test plan
- [ ] Open Recalibra Minho agenda — cards with a date should show as normal confirmed appointments (no blinking, no yellow, no locality warning)
- [ ] SM portals unchanged — locality warning still appears for SM appointments without locality


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_