### PR TITLE
Add Serviço/Calibragem toggle to Recalibra appointment modal

### DIFF
--- a/glass-removed-patch.js
+++ b/glass-removed-patch.js
@@ -139,6 +139,7 @@
       const id = row.dataset.id;
       const appt = appts.find(a => String(a.id) === String(id));
       if (!appt) return;
+      if (appt.service === 'CAL') return;
       const isActive = !!appt.glass_removed;
       const btnRow = document.createElement('div');
       btnRow.style.cssText = 'margin:4px 0 0;';
@@ -160,6 +161,7 @@
       if (!id) return;
       const appt = appts.find(a => String(a.id) === String(id));
       if (!appt) return;
+      if (appt.service === 'CAL') return;
       const isActive = !!appt.glass_removed;
       const btnRow = document.createElement('div');
       btnRow.style.cssText = 'margin:6px 8px 0;';

--- a/index.html
+++ b/index.html
@@ -444,6 +444,20 @@
         </div>
         <form id="appointmentForm" class="appointment-form">
 
+          <!-- Toggle Serviço / Calibragem (só portais Recalibra) -->
+          <div id="recalibraServiceToggle" style="display:none;margin-bottom:14px;">
+            <div style="display:flex;background:#f1f5f9;border-radius:10px;padding:3px;gap:3px;">
+              <button type="button" id="btnTipoServico" onclick="window.setRecalibraTipo('servico')"
+                style="flex:1;padding:8px;border:none;border-radius:8px;font-size:14px;font-weight:700;cursor:pointer;background:#fff;color:#1e293b;box-shadow:0 1px 4px rgba(0,0,0,0.12);transition:all .15s;">
+                🔧 Serviço
+              </button>
+              <button type="button" id="btnTipoCalib" onclick="window.setRecalibraTipo('calibragem')"
+                style="flex:1;padding:8px;border:none;border-radius:8px;font-size:14px;font-weight:700;cursor:pointer;background:transparent;color:#64748b;transition:all .15s;">
+                🎯 Calibragem
+              </button>
+            </div>
+          </div>
+
           <!-- Dica de sugestão de data -->
           <div id="localityHint" style="display:flex;align-items:center;gap:8px;background:#f0fdf4;border:1.5px solid #86efac;border-radius:10px;padding:9px 14px;margin-bottom:12px;font-size:12px;color:#166534;">
             <span style="font-size:16px;">💡</span>
@@ -497,7 +511,7 @@
           <div id="crDateSuggestion" style="display:none;"></div>
 
           <!-- LINHA 3: Tipo de Serviço + Status do Vidro -->
-          <div class="form-row">
+          <div class="form-row" id="serviceStatusRow">
             <div class="form-group">
               <label for="appointmentService">Tipo de Serviço *</label>
               <select id="appointmentService" required>
@@ -509,6 +523,7 @@
                 <option value="POL">POL - Polimento</option>
                 <option value="RV">RV - Retirar Vidro</option>
                 <option value="OUT">OUT - Outros</option>
+                <option value="CAL" style="display:none">CAL - Calibragem</option>
               </select>
               <!-- Campo de tempo personalizado para "Outros" -->
               <div id="customServiceTimeGroup" style="display:none;margin-top:8px;">

--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2163,7 +2163,8 @@ function buildDesktopCard(a){
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
   const isPreAgendado = a.confirmed === false;
-  const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  const needsLoc = !loja && !isRecalibra && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
   const locWarning = needsLoc ? `
       <div class="needs-loc-msg">
         <div>⚠️ Falta localidade</div>

--- a/script-tail.js
+++ b/script-tail.js
@@ -1112,7 +1112,7 @@ async function vendasComplMarkFaturado(id) {
 function _injectLocalityFirstOverlay() {
   var existing = document.getElementById('localityFirstOverlay');
   if (existing) existing.remove();
-  if (isLoja() || editingId) return;
+  if (isLoja() || editingId || window.portalConfig?.portalType === 'recalibra') return;
   var localityVal = document.getElementById('appointmentLocality')?.value;
   if (localityVal) return;
   var form = document.getElementById('appointmentForm');
@@ -1466,6 +1466,7 @@ cancelEdit?.();
       selectedDot.style.backgroundColor = '';
     }
     applyLojaModalMode();
+    applyRecalibraModalMode(null);
     toggleCompSales(false);
     _syncCompSalesFaturadoVisibility();
     document.getElementById('appointmentModal').classList.add('show');
@@ -1493,6 +1494,7 @@ cancelEdit?.();
       selectedDot.style.backgroundColor = '';
     }
     applyLojaModalMode();
+    applyRecalibraModalMode(null);
     document.getElementById('appointmentModal').classList.add('show');
     if (!isLoja()) {
       setTimeout(() => _injectLocalityFirstOverlay(), 50);

--- a/script.js
+++ b/script.js
@@ -950,6 +950,37 @@ function applyLojaModalMode() {
   if (localityInput) localityInput.required = !loja;
 }
 
+function setRecalibraTipo(tipo) {
+  const isCalib = tipo === 'calibragem';
+  const btnSvc = document.getElementById('btnTipoServico');
+  const btnCal = document.getElementById('btnTipoCalib');
+  if (btnSvc) { btnSvc.style.background = isCalib ? 'transparent' : '#fff'; btnSvc.style.color = isCalib ? '#64748b' : '#1e293b'; btnSvc.style.boxShadow = isCalib ? '' : '0 1px 4px rgba(0,0,0,0.12)'; }
+  if (btnCal) { btnCal.style.background = isCalib ? '#fff' : 'transparent'; btnCal.style.color = isCalib ? '#1e293b' : '#64748b'; btnCal.style.boxShadow = isCalib ? '0 1px 4px rgba(0,0,0,0.12)' : ''; }
+  const svcRow = document.getElementById('serviceStatusRow');
+  if (svcRow) svcRow.style.display = isCalib ? 'none' : '';
+  const localityGroup = document.getElementById('localityFormGroup');
+  if (localityGroup) localityGroup.classList.toggle('loja-hidden', isCalib);
+  const localityHint = document.getElementById('localityHint');
+  if (localityHint) localityHint.classList.toggle('loja-hidden', isCalib);
+  const svc = document.getElementById('appointmentService');
+  if (svc) { if (isCalib) { svc.value = 'CAL'; svc.required = false; } else { if (svc.value === 'CAL') svc.value = ''; svc.required = true; } }
+  const statusEl = document.getElementById('appointmentStatus');
+  if (statusEl) statusEl.required = !isCalib;
+  const localityInput = document.getElementById('appointmentLocality');
+  if (localityInput) localityInput.required = !isCalib && !isLoja();
+}
+window.setRecalibraTipo = setRecalibraTipo;
+
+function applyRecalibraModalMode(serviceValue) {
+  const toggle = document.getElementById('recalibraServiceToggle');
+  if (!toggle) return;
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  toggle.style.display = isRecalibra ? 'block' : 'none';
+  if (isRecalibra) setRecalibraTipo(serviceValue === 'CAL' ? 'calibragem' : 'servico');
+}
+window.applyRecalibraModalMode = applyRecalibraModalMode;
+
+
 // Cores dos cards para Loja (baseadas no status do vidro)
 const glassCardColors = {
   NE: '#EF4444', // Vermelho - Não encomendado
@@ -2413,6 +2444,7 @@ function editAppointment(id) {
   if (statusEl) statusEl.value = appointment.status || 'NE';
 
   applyLojaModalMode();
+  applyRecalibraModalMode(appointment.service);
   document.getElementById('appointmentModal').classList.add('show');
 }
 

--- a/script.js
+++ b/script.js
@@ -2561,7 +2561,8 @@ function buildDesktopCard(a){
     </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;
-  const needsLoc = !loja && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  const needsLoc = !loja && !isRecalibra && a.date && !a.locality && canSeeUnconfirmed && !isPreAgendado ? ' needs-locality' : '';
   const locWarning = needsLoc ? `
       <div class="needs-loc-msg">
         <div>⚠️ Falta localidade</div>


### PR DESCRIPTION
## Summary
- Adds a **Serviço / Calibragem** pill toggle at the top of the appointment modal, visible only on Recalibra portals
- **Serviço** (default): modal is identical to before
- **Calibragem**: hides Tipo de Serviço, Status do Vidro, and Localidade; saves `service = 'CAL'`
- The **Retirar Vidro** button is not injected on `CAL` cards
- The locality-first overlay is skipped for all Recalibra portals
- Works for both creating and editing appointments (editing a `CAL` appointment pre-selects Calibragem)

## Test plan
- [ ] Open Recalibra portal → "+ Novo Serviço" → toggle appears at top
- [ ] Serviço mode: all fields shown as normal
- [ ] Calibragem mode: tipo de serviço, status do vidro, localidade hidden
- [ ] Save calibragem → card shows without "Retirar Vidro" button
- [ ] Edit a CAL appointment → toggle pre-selects Calibragem
- [ ] SM/Loja portals: toggle not shown


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_