### PR TITLE
fix(recalibra): use loja-hidden class to hide serviceStatusRow for calibragem

### DIFF
--- a/script.js
+++ b/script.js
@@ -962,7 +962,7 @@ function setRecalibraTipo(tipo) {
   if (btnSvc) { btnSvc.style.background = isCalib ? 'transparent' : '#fff'; btnSvc.style.color = isCalib ? '#64748b' : '#1e293b'; btnSvc.style.boxShadow = isCalib ? '' : '0 1px 4px rgba(0,0,0,0.12)'; }
   if (btnCal) { btnCal.style.background = isCalib ? '#fff' : 'transparent'; btnCal.style.color = isCalib ? '#1e293b' : '#64748b'; btnCal.style.boxShadow = isCalib ? '0 1px 4px rgba(0,0,0,0.12)' : ''; }
   const svcRow = document.getElementById('serviceStatusRow');
-  if (svcRow) svcRow.style.display = isCalib ? 'none' : '';
+  if (svcRow) svcRow.classList.toggle('loja-hidden', isCalib);
   const localityGroup = document.getElementById('localityFormGroup');
   if (localityGroup) localityGroup.classList.toggle('loja-hidden', isCalib);
   const localityHint = document.getElementById('localityHint');


### PR DESCRIPTION
## Summary

`setRecalibraTipo` was using `svcRow.style.display = 'none'` to hide the Tipo de Serviço + Status do Vidro row when Calibragem is selected, but `.form-row` has `display: grid !important` in CSS which overrides inline styles. Changed to `classList.toggle('loja-hidden', isCalib)` which uses `!important` to force `display: none`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_