### PR TITLE
fix(recalibra): show appointments on mobile (no locality filter)

### DIFF
--- a/script-tail.js
+++ b/script-tail.js
@@ -295,7 +295,8 @@ async function renderMobileDay(){
 
   // Mobile SM: mostrar serviços com localidade OU pré-agendamentos importados (sem localidade mas com data)
   // Esconder apenas os que não têm nem data nem localidade (pendentes normais sem atribuição)
-  if (!isLoja()) {
+  // Recalibra: mostrar todos (localização fixa, sem campo localidade)
+  if (!isLoja() && window.portalConfig?.portalType !== 'recalibra') {
     items = items.filter(a => !!a.locality || (!!a.date && a.confirmed === false));
   }
 

--- a/script.js
+++ b/script.js
@@ -962,7 +962,7 @@ function setRecalibraTipo(tipo) {
   if (btnSvc) { btnSvc.style.background = isCalib ? 'transparent' : '#fff'; btnSvc.style.color = isCalib ? '#64748b' : '#1e293b'; btnSvc.style.boxShadow = isCalib ? '' : '0 1px 4px rgba(0,0,0,0.12)'; }
   if (btnCal) { btnCal.style.background = isCalib ? '#fff' : 'transparent'; btnCal.style.color = isCalib ? '#1e293b' : '#64748b'; btnCal.style.boxShadow = isCalib ? '0 1px 4px rgba(0,0,0,0.12)' : ''; }
   const svcRow = document.getElementById('serviceStatusRow');
-  if (svcRow) svcRow.style.display = isCalib ? 'none' : '';
+  if (svcRow) svcRow.classList.toggle('loja-hidden', isCalib);
   const localityGroup = document.getElementById('localityFormGroup');
   if (localityGroup) localityGroup.classList.toggle('loja-hidden', isCalib);
   const localityHint = document.getElementById('localityHint');


### PR DESCRIPTION
## Summary

Mobile `renderMobileDay()` was filtering appointments to only show those with `locality` set (or pre-agendamentos without locality). Recalibra is a fixed-location workshop — appointments have no `locality` field and `confirmed: true`, so both filter conditions failed and the mobile list showed empty.

Fix: skip the locality filter entirely for Recalibra portals.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_