### PR TITLE
fix: add CAL to service check constraint in appointments API

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -80,7 +80,7 @@ exports.handler = async (event) => {
   // Migração: actualizar constraint de service para incluir RV e OUT
   try {
     await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_service_check`);
-    await pool.query(`ALTER TABLE appointments ADD CONSTRAINT appointments_service_check CHECK (service IS NULL OR service IN ('PB', 'LT', 'OC', 'REP', 'POL', 'RV', 'OUT'))`);
+    await pool.query(`ALTER TABLE appointments ADD CONSTRAINT appointments_service_check CHECK (service IS NULL OR service IN ('PB', 'LT', 'OC', 'REP', 'POL', 'RV', 'OUT', 'CAL'))`);
   } catch(migErr) { console.warn('Migration service_check warning:', migErr.message); }
 
   try {

--- a/script-tail.js
+++ b/script-tail.js
@@ -295,7 +295,8 @@ async function renderMobileDay(){
 
   // Mobile SM: mostrar serviços com localidade OU pré-agendamentos importados (sem localidade mas com data)
   // Esconder apenas os que não têm nem data nem localidade (pendentes normais sem atribuição)
-  if (!isLoja()) {
+  // Recalibra: mostrar todos (localização fixa, sem campo localidade)
+  if (!isLoja() && window.portalConfig?.portalType !== 'recalibra') {
     items = items.filter(a => !!a.locality || (!!a.date && a.confirmed === false));
   }
 

--- a/script.js
+++ b/script.js
@@ -962,7 +962,7 @@ function setRecalibraTipo(tipo) {
   if (btnSvc) { btnSvc.style.background = isCalib ? 'transparent' : '#fff'; btnSvc.style.color = isCalib ? '#64748b' : '#1e293b'; btnSvc.style.boxShadow = isCalib ? '' : '0 1px 4px rgba(0,0,0,0.12)'; }
   if (btnCal) { btnCal.style.background = isCalib ? '#fff' : 'transparent'; btnCal.style.color = isCalib ? '#1e293b' : '#64748b'; btnCal.style.boxShadow = isCalib ? '0 1px 4px rgba(0,0,0,0.12)' : ''; }
   const svcRow = document.getElementById('serviceStatusRow');
-  if (svcRow) svcRow.style.display = isCalib ? 'none' : '';
+  if (svcRow) svcRow.classList.toggle('loja-hidden', isCalib);
   const localityGroup = document.getElementById('localityFormGroup');
   if (localityGroup) localityGroup.classList.toggle('loja-hidden', isCalib);
   const localityHint = document.getElementById('localityHint');


### PR DESCRIPTION
## Summary

The `appointments_service_check` DB constraint only allowed `'PB', 'LT', 'OC', 'REP', 'POL', 'RV', 'OUT'`. The value `'CAL'` (Calibragem) was missing, causing any save attempt on a Recalibra/Calibragem appointment to fail with a DB constraint violation — which surfaced as "Agendamento não encontrado" (the UPDATE returned 0 rows).

Added `'CAL'` to the allowed values list.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_