### PR TITLE
Recalibra: campo Loja no modal e badge vermelho/amarelo nos cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
               <input type="date" id="appointmentDate" autocomplete="off"/>
             </div>
             <div class="form-group" id="localityFormGroup">
-              <label for="appointmentLocality">Localidade *</label>
+              <label id="localityLabel" for="appointmentLocality">Localidade *</label>
               <input type="hidden" id="appointmentLocality" required>
               <div class="locality-autocomplete" id="localityAutocomplete">
                 <div class="locality-selected" id="localitySelected" onclick="window.toggleLocalityDropdown()">
@@ -504,6 +504,9 @@
                   <div id="localityOptions"></div>
                 </div>
               </div>
+              <input type="text" id="lojaInput" placeholder="Ex: Braga, Guimarães..." autocomplete="off"
+                style="display:none;width:100%;padding:10px 12px;border:1.5px solid #e5e7eb;border-radius:8px;font-size:14px;box-sizing:border-box;"
+                oninput="document.getElementById('appointmentLocality').value=this.value">
             </div>
           </div>
 

--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2225,6 +2225,7 @@ function buildDesktopCard(a){
          data-locality="${a.locality||''}" data-loccolor="${base}"
          style="--c1:${g.c1}; --c2:${g.c2}; --tc:${textColor}; ${bar}">
       <div class="dc-title"><span class="dc-title-text">${plate}</span></div>
+      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#fbbf24;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-top:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
       <div class="dc-meta">
         <span class="dc-badge">${service}</span>
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}

--- a/script-tail.js
+++ b/script-tail.js
@@ -7,6 +7,7 @@ function extractPhoneFromText(txt){
 
 // ---------- Render MOBILE (lista do dia) ----------
 function buildMobileCard(a){
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
   // Ícones oficiais (fallback para emoji se falhar)
   const mapsBtn = a.address ? `
     <a href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(a.address)}"
@@ -74,10 +75,13 @@ const telBtn = phone ? `
     const extraNames = extra.map(function(s) { return s && s.service ? s.service : ''; }).filter(Boolean);
     return [...primary, ...extraNames];
   })();
+  const lojaBadge = isRecalibra && a.locality
+    ? `<div style="display:inline-block;background:#dc2626;color:#fbbf24;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin:4px 0;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>`
+    : '';
   const chips = [
     a.period ? `<span class="m-chip">${a.period}</span>` : '',
     ..._allSvcs.map(function(s) { return `<span class="m-chip">${s}</span>`; }),
-    !isLoja() && a.locality ? `<span class="m-chip">${a.locality}</span>` : '',
+    !isLoja() && !isRecalibra && a.locality ? `<span class="m-chip">${a.locality}</span>` : '',
     a.calibration ? `<span class="m-chip m-chip-calib">⊕ CALIB</span>` : '',
     a.first_of_day ? `<span class="m-chip" style="background:#f59e0b;color:#fff;font-weight:700;">⭐ 1.º</span>` : '',
     a.second_of_day ? `<span class="m-chip" style="background:#f97316;color:#fff;font-weight:700;">⭐ 2.º</span>` : ''
@@ -185,10 +189,11 @@ const telBtn = phone ? `
         <div class="m-title"><span class="m-title-text">${plate}</span></div>
         ${car ? `<div class="m-car">${car}</div>` : ''}
         ${chips ? `<div class="m-chips" data-ms-patched="1">${chips}</div>` : ''}
+        ${lojaBadge}
         ${a.commercial_user_id ? `<div style="display:inline-block;background:#7c3aed !important;color:#fff !important;font-size:11px;font-weight:800;padding:3px 10px;border-radius:12px;margin-bottom:4px;animation:blink 1.5s infinite;">🤝 COMERCIAL</div>` : ''}
         ${notes}
         ${damageRow}
-        ${compSalesBadge}
+        ${isRecalibra ? '' : compSalesBadge}
         ${preAgendadoM ? `<span class="pre-agendado-badge">⏳ Aguarda confirmação</span>` : ''}
         ${preAgendadoM
           ? `<div class="m-pending-confirm">⏳ Aguarda confirmação do coordenador</div>`

--- a/script.js
+++ b/script.js
@@ -928,29 +928,41 @@ function isLoja() { return window.portalConfig?.portalType === 'loja'; }
 // — Loja / Recalibra: oculta campos de morada/localidade/km (localização fixa)
 // — SM  : mostra tudo
 function applyLojaModalMode() {
-  const loja = isLoja() || window.portalConfig?.portalType === 'recalibra';
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  const loja = isLoja() || isRecalibra;
 
   // Hint "seleciona a localidade para sugestão de data"
-  // (tem display:flex inline no HTML — usar classe que force none)
   const hint = document.getElementById('localityHint');
   if (hint) hint.classList.toggle('loja-hidden', loja);
 
-  // Grupo de localidade (LINHA 2, segundo form-group)
-  // (form-group tem display:flex !important no CSS — usar classe)
+  // Grupo de localidade: sempre visível para Recalibra (campo "Loja"), escondido para Loja, normal para SM
   const localityGroup = document.getElementById('localityFormGroup');
-  if (localityGroup) localityGroup.classList.toggle('loja-hidden', loja);
+  if (localityGroup) localityGroup.classList.toggle('loja-hidden', isLoja() && !isRecalibra);
+
+  // Para Recalibra: mostrar input simples "Loja", esconder autocomplete; repor para SM/Loja
+  const localityAutocomplete = document.getElementById('localityAutocomplete');
+  const lojaInput = document.getElementById('lojaInput');
+  const localityLabel = document.getElementById('localityLabel');
+  if (isRecalibra) {
+    if (localityAutocomplete) localityAutocomplete.style.display = 'none';
+    if (lojaInput) lojaInput.style.display = 'block';
+    if (localityLabel) localityLabel.textContent = 'Loja';
+    if (localityGroup) localityGroup.classList.remove('loja-hidden');
+  } else {
+    if (localityAutocomplete) localityAutocomplete.style.display = '';
+    if (lojaInput) lojaInput.style.display = 'none';
+    if (localityLabel) localityLabel.textContent = 'Localidade *';
+  }
 
   // LINHA 7 — Morada + Distância (km)
-  // (form-row tem display:grid !important no CSS — usar classe)
   const addressRow = document.getElementById('addressKmRow');
   if (addressRow) addressRow.classList.toggle('loja-hidden', loja);
 
-  // Remove/repõe required na localidade (campo hidden, evita erro de validação)
+  // Remove/repõe required na localidade
   const localityInput = document.getElementById('appointmentLocality');
   if (localityInput) localityInput.required = !loja;
 
   // Recalibra não tem vendas complementares — esconder secção no modal
-  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
   const compSales = document.getElementById('compSalesSection');
   if (compSales) compSales.style.display = isRecalibra ? 'none' : '';
 }
@@ -963,8 +975,9 @@ function setRecalibraTipo(tipo) {
   if (btnCal) { btnCal.style.background = isCalib ? '#fff' : 'transparent'; btnCal.style.color = isCalib ? '#1e293b' : '#64748b'; btnCal.style.boxShadow = isCalib ? '0 1px 4px rgba(0,0,0,0.12)' : ''; }
   const svcRow = document.getElementById('serviceStatusRow');
   if (svcRow) svcRow.classList.toggle('loja-hidden', isCalib);
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
   const localityGroup = document.getElementById('localityFormGroup');
-  if (localityGroup) localityGroup.classList.toggle('loja-hidden', isCalib);
+  if (localityGroup && !isRecalibra) localityGroup.classList.toggle('loja-hidden', isCalib);
   const localityHint = document.getElementById('localityHint');
   if (localityHint) localityHint.classList.toggle('loja-hidden', isCalib);
   const svc = document.getElementById('appointmentService');
@@ -2342,6 +2355,8 @@ function editAppointment(id) {
   if (secondCb) secondCb.checked = !!(appointment.second_of_day);
   setTimeout(function() { if (typeof window.updateSecondOfDayVisibility === 'function') window.updateSecondOfDayVisibility(); }, 50);
   document.getElementById('appointmentLocality').value = appointment.locality || '';
+  const _lojaInput = document.getElementById('lojaInput');
+  if (_lojaInput) _lojaInput.value = appointment.locality || '';
   if (document.getElementById('appointmentPeriod')) {
     document.getElementById('appointmentPeriod').value = appointment.period || 'Manhã';
   }
@@ -2684,6 +2699,7 @@ function buildDesktopCard(a){
          data-locality="${a.locality||''}" data-loccolor="${base}"
          style="--c1:${g.c1}; --c2:${g.c2}; --tc:${textColor}; ${bar} ${glassRemovedBorderStyle}">
       <div class="dc-title"><span class="dc-title-text">${plate}</span></div>
+      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#fbbf24;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-top:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
       <div class="dc-meta" data-ms-patched="1">
         ${getAllServices(a).map(s => `<span class="dc-badge">${s.service||''}</span>`).join('')}
         ${a.calibration ? '<span class="dc-calib-badge">⊕ CALIB</span>' : ''}


### PR DESCRIPTION
## Summary

- **Modal**: novo campo "Loja" (texto livre) no grupo de localidade para portais Recalibra — esconde o autocomplete de localidade, mostra input de texto, label muda para "Loja"; valor sincroniza com o campo hidden `appointmentLocality` (gravado na coluna `locality`)
- **Desktop card**: badge vermelho (`#dc2626`) com texto amarelo (`#fbbf24`) em maiúsculas mostrando o nome da loja
- **Mobile card**: mesmo badge vermelho/amarelo; localidade deixa de aparecer como chip simples para Recalibra; Venda Complementar escondida

## Test plan
- [ ] Criar/editar agendamento Recalibra → campo "Loja" visível no modal, gravar → sem erros
- [ ] Card desktop mostra badge vermelho/amarelo com nome da loja em maiúsculas
- [ ] Card mobile mostra o mesmo badge
- [ ] Portais não-Recalibra não são afetados (loja, sm, pesados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_