### PR TITLE
Fix: badge Loja com letras brancas (override CSS !important)

### DIFF
--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2242,7 +2242,7 @@ function buildDesktopCard(a){
         <label><input type="checkbox" data-status="VE" ${a.status==='VE'?'checked':''}/> V/E</label>
         <label><input type="checkbox" data-status="ST" ${a.status==='ST'?'checked':''}/> ST</label>
       </div>` : ''}
-      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-bottom:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
+      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#ffffff !important;-webkit-text-fill-color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-bottom:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
       ${execBadge}
       <div class="card-actions">
         <button class="icon edit" onclick="editAppointment('${a.id}')" title="Editar" aria-label="Editar">✏️</button>

--- a/script-tail.js
+++ b/script-tail.js
@@ -76,7 +76,7 @@ const telBtn = phone ? `
     return [...primary, ...extraNames];
   })();
   const lojaBadge = isRecalibra && a.locality
-    ? `<div style="display:inline-block;background:#dc2626;color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin:4px 0;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>`
+    ? `<div style="display:inline-block;background:#dc2626;color:#ffffff !important;-webkit-text-fill-color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin:4px 0;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>`
     : '';
   const chips = [
     a.period ? `<span class="m-chip">${a.period}</span>` : '',

--- a/script.js
+++ b/script.js
@@ -2720,7 +2720,7 @@ function buildDesktopCard(a){
         <label><input type="checkbox" data-status="VE" ${a.status==='VE'?'checked':''}/> V/E</label>
         <label><input type="checkbox" data-status="ST" ${a.status==='ST'?'checked':''}/> ST</label>
       </div>` : ''}
-      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-bottom:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
+      ${isRecalibra && a.locality ? `<div style="display:inline-block;background:#dc2626;color:#ffffff !important;-webkit-text-fill-color:#ffffff;font-weight:900;font-size:12px;letter-spacing:1.5px;padding:3px 10px;border-radius:6px;margin-bottom:4px;text-transform:uppercase;">${(a.locality).toUpperCase()}</div>` : ''}
       ${execBadge}
       <div class="card-actions">
         ${a.photo_url ? `<a href="${a.photo_url}" target="_blank" rel="noopener" class="icon" title="Ver foto" style="text-decoration:none;">📷</a>` : ''}


### PR DESCRIPTION
## Fix

`style.css` tem `.desk-card * { color: var(--tc) !important }` e `.m-card * { color: var(--tc) !important }` que sobrepunham o `color:#ffffff` inline do badge.

Adicionado `color:#ffffff !important` e `-webkit-text-fill-color:#ffffff` ao badge para forçar texto branco em desktop e mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_