### PR TITLE
Fix: calendário Recalibra em branco para técnicos

### DIFF
--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2295,6 +2295,7 @@ function renderSchedule(){
     // SM: resumo do dia + serviços
     const userRole = window.authClient?.getUser()?.role;
     const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
+    const _isRecalibraPortal = window.portalConfig?.portalType === 'recalibra';
 
     const renderCell = (dayDate) => {
       const iso = localISO(dayDate);
@@ -2302,8 +2303,8 @@ function renderSchedule(){
         appointments.filter(a => a.date && a.date === iso)
           .sort((a,b) => (a.sortIndex||0) - (b.sortIndex||0))
       );
-      // Técnicos: esconder serviços SM sem localidade
-      if (!canSeeUnconfirmed) {
+      // Técnicos: esconder serviços SM sem localidade (não aplica a Recalibra)
+      if (!canSeeUnconfirmed && !_isRecalibraPortal) {
         items = items.filter(a => !!a.locality);
       }
       const blocks = items.map(buildDesktopCard).join('');

--- a/script.js
+++ b/script.js
@@ -2775,6 +2775,7 @@ function renderSchedule(){
     // SM: resumo do dia + serviços
     const userRole = window.authClient?.getUser()?.role;
     const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
+    const _isRecalibraPortal = window.portalConfig?.portalType === 'recalibra';
 
     const renderCell = (dayDate) => {
       const iso = localISO(dayDate);
@@ -2788,8 +2789,8 @@ function renderSchedule(){
             return (a.sortIndex||0) - (b.sortIndex||0);
           })
       );
-      // Técnicos: esconder serviços SM sem localidade
-      if (!canSeeUnconfirmed) {
+      // Técnicos: esconder serviços SM sem localidade (não aplica a Recalibra)
+      if (!canSeeUnconfirmed && !_isRecalibraPortal) {
         items = items.filter(a => !!a.locality);
       }
       const blocks = items.map(buildDesktopCard).join('');


### PR DESCRIPTION
## Fix

O `renderSchedule` filtrava todos os agendamentos sem `locality` para utilizadores não-admin. Como os agendamentos Recalibra tipicamente não têm loja definida, o calendário aparecia vazio para técnicos.

Adicionado `&& !_isRecalibraPortal` à condição do filtro em `script.js` e `netlify/functions/script.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_