### PR TITLE
Fix: Recalibra esconde N/E/V/E/ST e Retirar Vidro em agendamentos com service legado

### DIFF
--- a/glass-removed-patch.js
+++ b/glass-removed-patch.js
@@ -139,7 +139,7 @@
       const id = row.dataset.id;
       const appt = appts.find(a => String(a.id) === String(id));
       if (!appt) return;
-      if (appt.service === 'CAL') return;
+      if (appt.service === 'CAL' || window.portalConfig?.portalType === 'recalibra') return;
       const isActive = !!appt.glass_removed;
       const btnRow = document.createElement('div');
       btnRow.style.cssText = 'margin:4px 0 0;';
@@ -161,7 +161,7 @@
       if (!id) return;
       const appt = appts.find(a => String(a.id) === String(id));
       if (!appt) return;
-      if (appt.service === 'CAL') return;
+      if (appt.service === 'CAL' || window.portalConfig?.portalType === 'recalibra') return;
       const isActive = !!appt.glass_removed;
       const btnRow = document.createElement('div');
       btnRow.style.cssText = 'margin:6px 8px 0;';

--- a/netlify/functions/script.js
+++ b/netlify/functions/script.js
@@ -2237,7 +2237,7 @@ function buildDesktopCard(a){
       ${preAgendadoBadge}
       ${confirmBtn}
       ${locWarning}
-      ${a.service !== 'CAL' ? `<div class="appt-status dc-status">
+      ${(a.service !== 'CAL' && !isRecalibra) ? `<div class="appt-status dc-status">
         <label><input type="checkbox" data-status="NE" ${a.status==='NE'?'checked':''}/> N/E</label>
         <label><input type="checkbox" data-status="VE" ${a.status==='VE'?'checked':''}/> V/E</label>
         <label><input type="checkbox" data-status="ST" ${a.status==='ST'?'checked':''}/> ST</label>
@@ -2248,7 +2248,7 @@ function buildDesktopCard(a){
         <button class="icon edit" onclick="editAppointment('${a.id}')" title="Editar" aria-label="Editar">✏️</button>
         <button class="icon delete" onclick="deleteAppointment('${a.id}')" title="Eliminar" aria-label="Eliminar">🗑️</button>
       </div>
-    ${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
+    ${diasAbertoBadge}${(loja || isRecalibra) ? '' : buildKmRow(a)}${phcFooter}</div>`;
 }
 
 function renderSchedule(){

--- a/script.js
+++ b/script.js
@@ -2715,7 +2715,7 @@ function buildDesktopCard(a){
       ${preAgendadoBadge}
       ${confirmBtn}
       ${locWarning}
-      ${a.service !== 'CAL' ? `<div class="appt-status dc-status">
+      ${(a.service !== 'CAL' && !isRecalibra) ? `<div class="appt-status dc-status">
         <label><input type="checkbox" data-status="NE" ${a.status==='NE'?'checked':''}/> N/E</label>
         <label><input type="checkbox" data-status="VE" ${a.status==='VE'?'checked':''}/> V/E</label>
         <label><input type="checkbox" data-status="ST" ${a.status==='ST'?'checked':''}/> ST</label>
@@ -2728,7 +2728,7 @@ function buildDesktopCard(a){
         <button class="icon delete" onclick="deleteAppointment('${a.id}')" title="Eliminar" aria-label="Eliminar">🗑️</button>
         ${encRecFooter}
       </div>
-    ${glassRemovedBadge}${diasAbertoBadge}${loja ? '' : buildKmRow(a)}${phcFooter}</div>`;
+    ${glassRemovedBadge}${diasAbertoBadge}${(loja || isRecalibra) ? '' : buildKmRow(a)}${phcFooter}</div>`;
 }
 
 function renderSchedule(){


### PR DESCRIPTION
## Fix

Agendamentos Recalibra criados antes de PR #313 têm `service=PB/LT/REP` em vez de `CAL`. O check anterior `a.service !== 'CAL'` não escondia os elementos SM nestes casos.

Alterados para usar `(a.service !== 'CAL' && !isRecalibra)`:
- N/E/V/E/ST checkboxes — `script.js` e `netlify/functions/script.js`
- KM row — idem
- Botão "Retirar Vidro" — `glass-removed-patch.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_