### PR TITLE
Receção vidros: esconder matrículas já rececionadas ao picar mesmo eurocode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1937,10 +1937,9 @@
 
     const safeRawForCard = (rawText||'').substring(0,200).replace(/[\n\r\t]/g,' ').replace(/'/g,"\\'").replace(/"/g,'\\"');
 
-    // Store appts globally for filter re-render
+    // Store appts globally for filter re-render (excluding already-received)
     const storeNames = [...new Set(appts.map(a => a.portal_name || window.portalConfig?.name || '—'))];
     const multiStore = storeNames.length > 1;
-    window._grAllAppts = appts;
     window._grRawForCard = safeRawForCard;
     window._grOrderRef = orderRef;
     window._grEurocode = eurocode;
@@ -1956,9 +1955,7 @@
           ? '<span style="background:#dcfce7;color:#166534;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">✅ Realizado</span>'
           : '<span style="background:#fef3c7;color:#92400e;font-size:10px;font-weight:700;padding:2px 7px;border-radius:10px;margin-left:6px;">⏳ Por realizar</span>';
         const recStatus = recepMap[a.id];
-        const recBadge = recStatus === 'received'
-          ? '<div style="margin-top:6px;"><span style="background:#1d4ed8;color:#fff;font-size:11px;font-weight:700;padding:3px 9px;border-radius:10px;">📦 Já rececionado</span></div>'
-          : recStatus === 'confirmed'
+        const recBadge = recStatus === 'confirmed'
           ? '<div style="margin-top:6px;"><span style="background:#f59e0b;color:#fff;font-size:11px;font-weight:700;padding:3px 9px;border-radius:10px;">⏳ Aguarda confirmação</span></div>'
           : '';
         const safeId = String(a.id);
@@ -2000,10 +1997,21 @@
       </div>
     ` : '';
 
+    // Exclude already-received — not selectable options
+    const alreadyReceived = appts.filter(a => recepMap[a.id] === 'received');
+    const selectableAppts = appts.filter(a => recepMap[a.id] !== 'received');
+    window._grAllAppts = selectableAppts;
+    const alreadyReceivedNote = alreadyReceived.length
+      ? `<div style="margin-bottom:10px;padding:8px 12px;background:#dbeafe;border-radius:8px;font-size:12px;color:#1d4ed8;font-weight:600;">
+           📦 ${alreadyReceived.map(a => (a.plate||'').toUpperCase()).join(', ')} — já rececionado${alreadyReceived.length > 1 ? 's' : ''} para este eurocode
+         </div>`
+      : '';
+
     body.innerHTML = infoHtml + `
       <p style="font-size:13px;font-weight:700;color:#374151;margin-bottom:10px;">Seleciona o processo para este vidro:</p>
+      ${alreadyReceivedNote}
       ${storeFilterHtml}
-      <div id="grCardsList">${buildCardsHtml(appts)}</div>
+      <div id="grCardsList">${buildCardsHtml(selectableAppts)}</div>
       <button onclick="window.glassReception._step1()" style="background:#e2e8f0;border:none;border-radius:8px;padding:10px 20px;cursor:pointer;font-weight:600;margin-top:4px;width:100%;">← Voltar</button>
     `;
   }

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -291,6 +291,22 @@ exports.handler = async (event) => {
         }
       }
 
+      // Prevent duplicate reception of the same eurocode (unless it's a return)
+      if (d.eurocode && !d.is_return && d.appointment_id) {
+        const dupCheck = await client.query(
+          `SELECT gr.id, a.plate FROM glass_receptions gr
+           LEFT JOIN appointments a ON a.id = gr.appointment_id
+           WHERE LOWER(REPLACE(REPLACE(gr.eurocode,'i','1'),'o','0')) = LOWER(REPLACE(REPLACE($1,'i','1'),'o','0'))
+             AND gr.status != 'return'
+             AND gr.appointment_id IS NOT NULL`,
+          [d.eurocode]
+        );
+        if (dupCheck.rows.length > 0) {
+          const plates = dupCheck.rows.map(r => r.plate || '?').join(', ');
+          return { statusCode: 409, headers, body: JSON.stringify({ error: `Eurocode já rececionado para: ${plates}` }) };
+        }
+      }
+
       const { rows } = await client.query(`
         INSERT INTO glass_receptions
           (order_ref, eurocode, raw_label_text, appointment_id,


### PR DESCRIPTION
## Comportamento

Quando um eurocode já foi rececionado e associado a uma matrícula, se esse eurocode for picado novamente:
- A matrícula já rececionada **não aparece como opção** de associação
- Mostra uma nota azul informativa: "📦 XX-YY-ZZ — já rececionado para este eurocode"
- Backend rejeita com 409 se tentar associar o mesmo eurocode duas vezes (última linha de defesa)

## Detalhes técnicos
- **Frontend (`index.html`)**: filtra `recStatus === 'received'` dos cards antes de renderizar; remove o badge "Já rececionado" dos cards (já não aparecem); `window._grAllAppts` recebe apenas os selecionáveis (store filter também fica correto)
- **Backend (`glass-reception.js`)**: duplicate check no POST com normalização i↔1/o↔0 igual à da pesquisa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_