### PR TITLE
Cards: mostrar data de receção do vidro (Rec DD/MM/YY)

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -71,6 +71,10 @@ exports.handler = async (event) => {
   } catch(migErr) { console.warn('Migration reception_ref warning:', migErr.message); }
 
   try {
+    await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS reception_date DATE`);
+  } catch(migErr) { console.warn('Migration reception_date warning:', migErr.message); }
+
+  try {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_desc TEXT`);
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_nif VARCHAR(20)`);
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_name VARCHAR(255)`);
@@ -159,7 +163,7 @@ exports.handler = async (event) => {
                  a.calibration, a.first_of_day, a.second_of_day, a.not_done_reason, a.commercial_user_id,
                  a.return_km, a.return_time, a.client_name, a.damage_details, a.glass_removed, a.glass_removed_date,
                  a.custom_service_time, a.foreign_plate, a.extra_services, a.n_obra,
-                 a.order_ref, a.glass_eurocode, a.reception_ref,
+                 a.order_ref, a.glass_eurocode, a.reception_ref, a.reception_date,
                  a.comp_sales_desc, a.comp_sales_nif, a.comp_sales_name, a.comp_sales_faturado,
                  a.created_at, a.updated_at, a.not_done_at, a.portal_id,
                  p.name AS portal_name

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -330,7 +330,7 @@ exports.handler = async (event) => {
       // When glass is matched to an appointment: set status ST (received) and propagate refs
       if (d.appointment_id && !d.is_return) {
         await client.query(
-          `UPDATE appointments SET status = 'ST', updated_at = NOW() WHERE id = $1`,
+          `UPDATE appointments SET status = 'ST', reception_date = CURRENT_DATE, updated_at = NOW() WHERE id = $1`,
           [d.appointment_id]
         );
         if (d.order_ref) {

--- a/script-tail.js
+++ b/script-tail.js
@@ -58,6 +58,7 @@ const telBtn = phone ? `
       </div>
       ${a.order_ref ? `<div style="white-space:nowrap;font-size:9px;font-weight:800;color:#fff !important;-webkit-text-fill-color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.5);">📦 ${a.order_ref}</div>` : ''}
       ${a.reception_ref ? `<div style="white-space:nowrap;font-size:9px;font-weight:800;color:#fff !important;-webkit-text-fill-color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.5);">✅ ${a.reception_ref}</div>` : ''}
+      ${a.reception_date ? `<div style="white-space:nowrap;font-size:9px;font-weight:800;color:#fff !important;-webkit-text-fill-color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.5);">Rec ${new Date(a.reception_date+'T12:00:00').toLocaleDateString('pt-PT',{day:'2-digit',month:'2-digit',year:'2-digit'})}</div>` : ''}
     </div>`;
 
   // Hierarquia visual: matrícula em destaque, carro secundário

--- a/script.js
+++ b/script.js
@@ -2610,10 +2610,12 @@ function buildDesktopCard(a){
   const sub = loja
     ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
     : [isRecalibra ? null : a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
-  const encRecFooter = (a.order_ref || a.reception_ref) ? `
+  const _recDateFmt = a.reception_date ? new Date(String(a.reception_date).slice(0,10)+'T12:00:00').toLocaleDateString('pt-PT',{day:'2-digit',month:'2-digit',year:'2-digit'}) : null;
+  const encRecFooter = (a.order_ref || a.reception_ref || a.reception_date) ? `
     <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:2px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);">
       ${a.order_ref ? `<span>📦 ${a.order_ref}</span>` : ''}
       ${a.reception_ref ? `<span>✅ ${a.reception_ref}</span>` : ''}
+      ${_recDateFmt ? `<span>Rec ${_recDateFmt}</span>` : ''}
     </div>` : '';
   // SM com data mas sem localidade → piscar (só coord/admin) — mas não para pré-agendamentos (têm o seu próprio sistema)
   const isPreAgendado = a.confirmed === false;


### PR DESCRIPTION
## Comportamento

Quando um vidro é rececionado, passa a mostrar a data de receção no card:
- **Mobile**: `Rec 17/06/26` abaixo do `✅ Rec.79` na coluna do semáforo
- **Desktop**: `Rec 17/06/26` no footer junto ao `📦 Enc.Axial` e `✅ Rec.79`

## Técnico
- Nova coluna `reception_date DATE` em `appointments` (migration-safe `ADD COLUMN IF NOT EXISTS`)
- Populada com `CURRENT_DATE` no POST de `glass-reception` quando `appointment_id` está presente
- Formatação `DD/MM/YY` via `toLocaleDateString('pt-PT', {year:'2-digit'})`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_