### PR TITLE
Backfill reception_date em agendamentos ST sem data de receção

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -75,6 +75,18 @@ exports.handler = async (event) => {
   } catch(migErr) { console.warn('Migration reception_date warning:', migErr.message); }
 
   try {
+    await pool.query(`
+      UPDATE appointments a
+      SET reception_date = gr.created_at::date
+      FROM glass_receptions gr
+      WHERE gr.appointment_id = a.id
+        AND a.reception_date IS NULL
+        AND gr.is_return = false
+        AND gr.status != 'return'
+    `);
+  } catch(migErr) { console.warn('Migration reception_date backfill warning:', migErr.message); }
+
+  try {
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_desc TEXT`);
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_nif VARCHAR(20)`);
     await pool.query(`ALTER TABLE appointments ADD COLUMN IF NOT EXISTS comp_sales_name VARCHAR(255)`);


### PR DESCRIPTION
Receções feitas antes do PR #326 têm `reception_date=NULL`. Migration que corre em cada invocação (idempotente) preenche `reception_date` a partir de `glass_receptions.created_at::date` para todos os agendamentos com `reception_date IS NULL` que tenham um registo de receção associado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_