### PR TITLE
Sync stock PHC: write consumed status to DB when appointment Realizado

### DIFF
--- a/index.html
+++ b/index.html
@@ -2713,98 +2713,81 @@
   async function _checkPhcStock() {
     const content = document.getElementById('grHResults');
     if (!content) return;
-    content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">🔄 A verificar stock com PHC…</p>`;
-
-    const portalId = document.getElementById('grHPortal')?.value || '';
-    const qp = new URLSearchParams({ history: 'true' });
-    if (portalId) qp.set('portal_id', portalId);
-    // No date filter — fetch ALL receptions for accurate stock
+    content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">🔄 A dar baixa de vidros com serviço Realizado…</p>`;
 
     try {
-      const res = await fetch(API + '/glass-reception?' + qp.toString(), { headers: authHeaders() });
-      const json = await res.json();
-      if (!json.success) throw new Error(json.error);
-      const rows = json.data;
+      // Step 1: write to DB — mark consumed glasses (appointment executed=true)
+      const syncRes = await fetch(API + '/glass-reception', {
+        method: 'PUT',
+        headers: authHeaders(),
+        body: JSON.stringify({ action: 'sync_stock' })
+      });
+      const syncJson = await syncRes.json();
+      if (!syncJson.success) throw new Error(syncJson.error);
+      const nowConsumed = syncJson.data; // list of records just deducted
+
+      // Step 2: fetch full history (no date filter) to show current stock
+      const portalId = document.getElementById('grHPortal')?.value || '';
+      const qp = new URLSearchParams({ history: 'true' });
+      if (portalId) qp.set('portal_id', portalId);
+      const histRes = await fetch(API + '/glass-reception?' + qp.toString(), { headers: authHeaders() });
+      const histJson = await histRes.json();
+      if (!histJson.success) throw new Error(histJson.error);
+      const rows = histJson.data;
 
       const _normEc = ec => (ec || '').toLowerCase().replace(/i/g,'1').replace(/o/g,'0').trim();
 
-      // Separate receptions into in-stock vs consumed by Realizado
-      const inStock = [], consumed = [];
-      rows.forEach(r => {
-        if (r.is_return) return;
-        if (r.apt_executed) consumed.push(r);
-        else inStock.push(r);
-      });
-
-      // Build per-eurocode totals for in-stock
+      // In stock = non-return + not consumed
+      const inStock = rows.filter(r => !r.is_return && r.status !== 'consumed');
       const stockTotals = {};
       inStock.forEach(r => {
         const k = _normEc(r.eurocode);
         if (!k) return;
         if (!stockTotals[k]) stockTotals[k] = { eurocode: r.eurocode, order_ref: r.order_ref, count: 0, plates: [] };
         stockTotals[k].count++;
-        if (r.apt_plate) stockTotals[k].plates.push((r.apt_plate).toUpperCase());
+        if (r.apt_plate) stockTotals[k].plates.push(r.apt_plate.toUpperCase());
       });
-
       const stockList = Object.values(stockTotals).sort((a,b) => b.count - a.count);
 
       content.innerHTML = `
+        ${nowConsumed.length ? `
+        <div style="background:#fef3c7;border:1.5px solid #fcd34d;border-radius:10px;padding:12px 16px;margin-bottom:12px;">
+          <div style="font-weight:800;color:#92400e;margin-bottom:6px;">🔄 ${nowConsumed.length} vidro${nowConsumed.length!==1?'s':''} baixado${nowConsumed.length!==1?'s':''} agora do stock:</div>
+          <div style="font-size:12px;color:#78350f;">${nowConsumed.map(r=>`<span style="font-family:monospace;margin-right:10px;">${(r.apt_plate||'?').toUpperCase()} — ${r.eurocode||'?'}</span>`).join('')}</div>
+        </div>` : `
+        <div style="background:#f0fdf4;border:1.5px solid #86efac;border-radius:10px;padding:10px 16px;margin-bottom:12px;font-weight:700;color:#166534;font-size:13px;">
+          ✅ Nenhuma baixa nova — stock já está sincronizado.
+        </div>`}
         <div style="margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;">
-          <div style="background:#dcfce7;border:1.5px solid #86efac;border-radius:10px;padding:12px 18px;flex:1;min-width:120px;">
+          <div style="background:#dcfce7;border:1.5px solid #86efac;border-radius:10px;padding:12px 18px;flex:1;min-width:100px;">
             <div style="font-size:22px;font-weight:900;color:#16a34a;">${inStock.length}</div>
             <div style="font-size:11px;font-weight:700;color:#166534;text-transform:uppercase;letter-spacing:0.5px;">Em Stock</div>
           </div>
-          <div style="background:#fee2e2;border:1.5px solid #fca5a5;border-radius:10px;padding:12px 18px;flex:1;min-width:120px;">
-            <div style="font-size:22px;font-weight:900;color:#dc2626;">${consumed.length}</div>
-            <div style="font-size:11px;font-weight:700;color:#991b1b;text-transform:uppercase;letter-spacing:0.5px;">Baixados (Realizado)</div>
+          <div style="background:#fee2e2;border:1.5px solid #fca5a5;border-radius:10px;padding:12px 18px;flex:1;min-width:100px;">
+            <div style="font-size:22px;font-weight:900;color:#dc2626;">${rows.filter(r=>!r.is_return&&r.status==='consumed').length}</div>
+            <div style="font-size:11px;font-weight:700;color:#991b1b;text-transform:uppercase;letter-spacing:0.5px;">Baixados</div>
           </div>
         </div>
         ${stockList.length ? `
         <div style="font-size:11px;font-weight:800;color:#0f172a;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;">Vidros em stock</div>
         <div style="overflow-x:auto;">
           <table style="width:100%;border-collapse:collapse;font-size:12px;">
-            <thead>
-              <tr style="background:#0f172a;color:#fff;">
-                <th style="padding:7px 10px;text-align:left;">Eurocode</th>
-                <th style="padding:7px 10px;text-align:left;">Encomenda</th>
-                <th style="padding:7px 10px;text-align:center;">Qtd</th>
-                <th style="padding:7px 10px;text-align:left;">Matrículas</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${stockList.map((s, i) => `
+            <thead><tr style="background:#0f172a;color:#fff;">
+              <th style="padding:7px 10px;text-align:left;">Eurocode</th>
+              <th style="padding:7px 10px;text-align:left;">Encomenda</th>
+              <th style="padding:7px 10px;text-align:center;">Qtd</th>
+              <th style="padding:7px 10px;text-align:left;">Matrículas</th>
+            </tr></thead>
+            <tbody>${stockList.map((s,i)=>`
               <tr style="background:${i%2===0?'#fff':'#f8fafc'};">
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${s.eurocode || '—'}</td>
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;">${s.order_ref || '—'}</td>
+                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${s.eurocode||'—'}</td>
+                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;">${s.order_ref||'—'}</td>
                 <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;text-align:center;"><span style="background:#dcfce7;color:#16a34a;font-weight:800;padding:2px 8px;border-radius:6px;">✅ ${s.count}</span></td>
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;font-size:11px;">${s.plates.join(', ') || '—'}</td>
+                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;font-size:11px;">${s.plates.join(', ')||'—'}</td>
               </tr>`).join('')}
             </tbody>
           </table>
         </div>` : `<p style="text-align:center;color:#94a3b8;padding:12px;">Sem vidros em stock.</p>`}
-        ${consumed.length ? `
-        <div style="font-size:11px;font-weight:800;color:#0f172a;text-transform:uppercase;letter-spacing:0.5px;margin:14px 0 6px;">Baixados por Realizado</div>
-        <div style="overflow-x:auto;">
-          <table style="width:100%;border-collapse:collapse;font-size:12px;">
-            <thead>
-              <tr style="background:#64748b;color:#fff;">
-                <th style="padding:7px 10px;text-align:left;">Data Rec.</th>
-                <th style="padding:7px 10px;text-align:left;">Matrícula</th>
-                <th style="padding:7px 10px;text-align:left;">Eurocode</th>
-                <th style="padding:7px 10px;text-align:left;">Encomenda</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${consumed.map((r, i) => `
-              <tr style="background:${i%2===0?'#fff':'#f8fafc'};">
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${fmtDate(r.created_at)}</td>
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;font-weight:700;">${(r.apt_plate||'—').toUpperCase()}</td>
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${r.eurocode||'—'}</td>
-                <td style="padding:6px 10px;border-bottom:1px solid #e2e8f0;">${r.order_ref||'—'}</td>
-              </tr>`).join('')}
-            </tbody>
-          </table>
-        </div>` : ''}
         <div style="margin-top:12px;text-align:right;">
           <button onclick="window.glassReception._loadHistory()" style="background:#e2e8f0;color:#374151;font-weight:700;font-size:12px;padding:8px 16px;border-radius:8px;border:none;cursor:pointer;">← Voltar ao histórico</button>
         </div>
@@ -2820,6 +2803,7 @@
     if (s === 'devolvido') return '<span style="color:#7c3aed;font-weight:700;">📦 Devolvido</span>';
     if (s === 'reported')  return '<span style="color:#2563eb;font-weight:700;">📧 Reportado</span>';
     if (s === 'return')    return '<span style="color:#dc2626;font-weight:700;">↩️ Devolução</span>';
+    if (s === 'consumed')  return '<span style="color:#64748b;font-weight:700;">✔ Usado</span>';
     return '<span style="color:#94a3b8;">Pendente</span>';
   }
 
@@ -2833,11 +2817,12 @@
       return;
     }
 
-    // Build per-eurocode stock map: received (not return) rows where appointment not yet executed
+    // Build per-eurocode stock map: received (not return, not consumed) rows
     const _normEc = ec => (ec || '').toLowerCase().replace(/i/g,'1').replace(/o/g,'0').trim();
     const stockMap = {};
     rows.forEach(r => {
       if (r.is_return) return;
+      if (r.status === 'consumed') return;
       const k = _normEc(r.eurocode);
       if (!k) return;
       if (!stockMap[k]) stockMap[k] = 0;

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -354,6 +354,33 @@ exports.handler = async (event) => {
     // ── PUT ────────────────────────────────────────────────────────────────────
     if (event.httpMethod === 'PUT') {
       const d = JSON.parse(event.body || '{}');
+
+      // Bulk sync: mark glasses consumed when linked appointment is Realizado
+      if (d.action === 'sync_stock') {
+        let allowedIds;
+        if (user.role === 'admin') {
+          const { rows: allP } = await client.query('SELECT id FROM portals');
+          allowedIds = allP.map(r => r.id);
+        } else {
+          allowedIds = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+        }
+        if (!allowedIds.length) return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: [] }) };
+
+        const { rows: consumed } = await client.query(`
+          UPDATE glass_receptions gr
+          SET status = 'consumed', updated_at = NOW()
+          FROM appointments a
+          WHERE gr.appointment_id = a.id
+            AND a.executed = true
+            AND gr.is_return = false
+            AND gr.status NOT IN ('return', 'consumed')
+            AND gr.portal_id = ANY($1)
+          RETURNING gr.id, gr.eurocode, gr.order_ref, a.plate AS apt_plate, a.car AS apt_car
+        `, [allowedIds]);
+
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: consumed }) };
+      }
+
       const id = d.id || (event.path || '').split('/').filter(Boolean).pop();
 
       const updates = ['updated_at = NOW()'];


### PR DESCRIPTION
## Summary
- `PUT /glass-reception { action: 'sync_stock' }` — new backend action that finds all glass receptions linked to appointments with `executed=true` and sets their status to `'consumed'`
- **🔄 Verificar Stock PHC** button now actually writes to the DB, not just reads
- After sync: shows a yellow banner listing which plates/eurocodes were just deducted
- If already synced: shows green "stock já está sincronizado"
- History stock column excludes `status='consumed'` rows
- `_statusLabel` shows `✔ Usado` for consumed records in the table

## Test plan
- [ ] Mark one or more appointments as Realizado
- [ ] Open glass reception history → click **🔄 Verificar Stock PHC**
- [ ] Should see yellow banner listing deducted plates
- [ ] Stock column in history should show 0 for those eurocodes
- [ ] Run again → "stock já está sincronizado" (idempotent)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_