### PR TITLE
Fix: show appointment eurocode/order_ref as fallback in reception history

### DIFF
--- a/index.html
+++ b/index.html
@@ -2741,7 +2741,7 @@
       const inStock = rows.filter(r => !r.is_return && r.status !== 'consumed');
       const stockTotals = {};
       inStock.forEach(r => {
-        const k = _normEc(r.eurocode);
+        const k = _normEc(r.eurocode || r.apt_eurocode);
         if (!k) return;
         if (!stockTotals[k]) stockTotals[k] = { eurocode: r.eurocode, order_ref: r.order_ref, count: 0, plates: [] };
         stockTotals[k].count++;
@@ -2844,7 +2844,7 @@
     rows.forEach(r => {
       if (r.is_return) return;
       if (r.status === 'consumed') return;
-      const k = _normEc(r.eurocode);
+      const k = _normEc(r.eurocode || r.apt_eurocode);
       if (!k) return;
       if (!stockMap[k]) stockMap[k] = 0;
       if (!r.apt_executed) stockMap[k]++;
@@ -2881,7 +2881,7 @@
               const tipoHtml = r.is_return
                 ? `<span style="background:#fef2f2;color:#dc2626;font-size:11px;font-weight:700;padding:2px 6px;border-radius:6px;white-space:nowrap;">${reasonMap[r.return_reason] || '↩️ Devolução'}</span>`
                 : `<span style="background:#f0fdf4;color:#16a34a;font-size:11px;font-weight:700;padding:2px 6px;border-radius:6px;white-space:nowrap;">📦 Receção</span>`;
-              const stockVal = r.is_return ? null : (stockMap[_normEc(r.eurocode)] || 0);
+              const stockVal = r.is_return ? null : (stockMap[_normEc(r.eurocode || r.apt_eurocode)] || 0);
               const stockCell = r.is_return ? `<span style="color:#94a3b8;">—</span>`
                 : stockVal > 0
                   ? `<span style="background:#dcfce7;color:#16a34a;font-weight:800;font-size:12px;padding:2px 8px;border-radius:6px;white-space:nowrap;">✅ ${stockVal}</span>`
@@ -2893,8 +2893,8 @@
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;font-weight:700;">${(r.apt_plate || '—').toUpperCase()}</td>
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${r.apt_car || '—'}</td>
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${r.portal_label || '—'}</td>
-                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${r.eurocode || '—'}</td>
-                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${r.order_ref || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;font-family:monospace;">${r.eurocode || r.apt_eurocode || '—'}</td>
+                <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${r.order_ref || r.apt_order_ref || '—'}</td>
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;text-align:center;">${stockCell}</td>
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;white-space:nowrap;">${r.technician_name || '—'}</td>
                 <td style="padding:7px 10px;border-bottom:1px solid #e2e8f0;">${_statusLabel(r.status)}</td>
@@ -2923,7 +2923,7 @@
       r.is_return ? (reasonMap[r.return_reason] || 'Devolução') : 'Receção',
       (r.apt_plate || '').toUpperCase(),
       r.apt_car || '', r.portal_label || '',
-      r.eurocode || '', r.order_ref || '',
+      r.eurocode || r.apt_eurocode || '', r.order_ref || r.apt_order_ref || '',
       r.is_return ? '—' : String(stockMapExp[_normEcExp(r.eurocode)] || 0),
       r.technician_name || '', statusTxt(r.status)
     ]);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -166,6 +166,8 @@ exports.handler = async (event) => {
                  a.date          AS apt_date,
                  a.reception_ref AS apt_reception_ref,
                  a.executed      AS apt_executed,
+                 a.glass_eurocode AS apt_eurocode,
+                 a.order_ref     AS apt_order_ref,
                  po.name         AS portal_label
           FROM glass_receptions gr
           LEFT JOIN appointments a  ON a.id = gr.appointment_id


### PR DESCRIPTION
## Summary
When a reception is confirmed by plate/match without scanning the barcode, `glass_receptions.eurocode` is NULL — but the appointment already has `glass_eurocode` set manually. The history table was showing `—` for those rows.

- Added `a.glass_eurocode AS apt_eurocode` and `a.order_ref AS apt_order_ref` to the history query
- Table, Excel export, and stock normalization all fall back to `apt_eurocode`/`apt_order_ref` when the reception's own field is NULL

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_