### PR TITLE
Fix: eurocode in extra JSON not showing in reception history

### DIFF
--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -166,8 +166,10 @@ exports.handler = async (event) => {
                  a.date          AS apt_date,
                  a.reception_ref AS apt_reception_ref,
                  a.executed      AS apt_executed,
-                 a.glass_eurocode AS apt_eurocode,
-                 a.order_ref     AS apt_order_ref,
+                 COALESCE(a.glass_eurocode,
+                   CASE WHEN a.extra ~ '^\{' THEN (a.extra::jsonb->>'eurocode') ELSE NULL END
+                 ) AS apt_eurocode,
+                 COALESCE(a.order_ref) AS apt_order_ref,
                  po.name         AS portal_label
           FROM glass_receptions gr
           LEFT JOIN appointments a  ON a.id = gr.appointment_id

--- a/script-tail.js
+++ b/script-tail.js
@@ -1293,6 +1293,7 @@ function bootApp() {
         return JSON.stringify({ eurocode: eurocode, photo_url: photo_url, history: newHistory });
       })(),
       status: (document.getElementById('appointmentStatus')?.value || 'NE'),
+      glass_eurocode: (get('appointmentExtra') || null),
       vehicleType: (document.getElementById('appointmentVehicleType')?.value || localStorage.getItem('eg_last_vehicleType') || 'L'),
       calibration: document.getElementById('appointmentCalibration')?.checked || false,
       first_of_day: document.getElementById('appointmentFirstOfDay')?.checked || false,


### PR DESCRIPTION
## Root cause
The `appointmentExtra` field in the edit form saves the eurocode to `appointments.extra` as JSON (`{ "eurocode": "...", "photo_url": "...", "history": "..." }`). The `appointments.glass_eurocode` column is only populated when a glass reception is confirmed — NOT when editing the form. So for AH-04-GZ, `glass_eurocode` was NULL even though the form showed a value.

## Fix
1. **Form save** (`script-tail.js`): now also sends `glass_eurocode` alongside `extra`, so future saves populate both columns
2. **History query** (`glass-reception.js`): uses `COALESCE(a.glass_eurocode, a.extra::jsonb->>'eurocode')` to fall back to the JSON `extra` field for existing records where `glass_eurocode` is NULL

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_