### PR TITLE
Add Check-up Viatura button to mobile card view (Braga)

### DIFF
--- a/index.html
+++ b/index.html
@@ -831,7 +831,7 @@
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
-  <script src="/vehicle-checkup-patch.js?v=1"></script>
+  <script src="/vehicle-checkup-patch.js?v=2"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -264,7 +264,14 @@
       const wrap = document.createElement('div');
       wrap.style.cssText = 'margin:6px 8px 0;';
       wrap.appendChild(btn);
-      row.insertAdjacentElement('afterend', wrap);
+      // Insert after any already-injected button rows (e.g. Retirar Vidro) so check-up stays last
+      let insertAfter = row;
+      let next = row.nextElementSibling;
+      while (next && next.querySelector && next.querySelector('.m-status-btn')) {
+        insertAfter = next;
+        next = next.nextElementSibling;
+      }
+      insertAfter.insertAdjacentElement('afterend', wrap);
     });
   }
 

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -225,17 +225,18 @@
     }
   };
 
-  // ── Inject "Check-up" button after dc-exec-row ────────────────────────────
+  // ── Inject "Check-up" button after dc-exec-row (desktop) and m-status-row (mobile) ───
   function injectCheckupButtons() {
     if (!isBraga()) return;
     const appts = window.appointments || [];
+
+    // Desktop
     document.querySelectorAll('.dc-exec-row').forEach(row => {
       if (row.dataset.vcInjected) return;
       row.dataset.vcInjected = '1';
       const id = row.dataset.id;
       const appt = appts.find(a => String(a.id) === String(id));
       if (!appt) return;
-      const plate = (appt.plate || '').replace(/'/g, "\\'");
       const btn = document.createElement('button');
       btn.className = 'dc-exec-btn';
       btn.style.cssText = 'width:100%;margin-top:4px;';
@@ -243,6 +244,25 @@
       btn.onclick = function (e) { e.stopPropagation(); window._openVehicleCheckup(id, appt.plate || ''); };
       const wrap = document.createElement('div');
       wrap.style.cssText = 'margin:4px 0 0;';
+      wrap.appendChild(btn);
+      row.insertAdjacentElement('afterend', wrap);
+    });
+
+    // Mobile
+    document.querySelectorAll('.m-status-row').forEach(row => {
+      if (row.dataset.vcInjected) return;
+      row.dataset.vcInjected = '1';
+      const id = row.querySelector('[data-exec]')?.dataset?.id;
+      if (!id) return;
+      const appt = appts.find(a => String(a.id) === String(id));
+      if (!appt) return;
+      const btn = document.createElement('button');
+      btn.className = 'm-status-btn';
+      btn.style.cssText = 'width:100%;justify-content:center;';
+      btn.innerHTML = '<span class="m-status-dot" style="background:#2563eb;"></span>Check-up Viatura';
+      btn.onclick = function (e) { e.stopPropagation(); window._openVehicleCheckup(id, appt.plate || ''); };
+      const wrap = document.createElement('div');
+      wrap.style.cssText = 'margin:6px 8px 0;';
       wrap.appendChild(btn);
       row.insertAdjacentElement('afterend', wrap);
     });


### PR DESCRIPTION
## Summary

Adds the **Check-up Viatura** button to the mobile card view (`m-status-row`) so technicians can use the feature directly from their phones — which is where they'll be taking the photos anyway.

The button appears below the Retirar Vidro button on mobile, styled as a standard `m-status-btn`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_