### PR TITLE
Remove Check-up button from desktop (mobile only)

### DIFF
--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -230,25 +230,7 @@
     if (!isBraga()) return;
     const appts = window.appointments || [];
 
-    // Desktop
-    document.querySelectorAll('.dc-exec-row').forEach(row => {
-      if (row.dataset.vcInjected) return;
-      row.dataset.vcInjected = '1';
-      const id = row.dataset.id;
-      const appt = appts.find(a => String(a.id) === String(id));
-      if (!appt) return;
-      const btn = document.createElement('button');
-      btn.className = 'dc-exec-btn';
-      btn.style.cssText = 'width:100%;margin-top:4px;';
-      btn.innerHTML = '🔍 Check-up';
-      btn.onclick = function (e) { e.stopPropagation(); window._openVehicleCheckup(id, appt.plate || ''); };
-      const wrap = document.createElement('div');
-      wrap.style.cssText = 'margin:4px 0 0;';
-      wrap.appendChild(btn);
-      row.insertAdjacentElement('afterend', wrap);
-    });
-
-    // Mobile
+    // Mobile only
     document.querySelectorAll('.m-status-row').forEach(row => {
       if (row.dataset.vcInjected) return;
       row.dataset.vcInjected = '1';


### PR DESCRIPTION
Remove the Check-up button from desktop cards — it only makes sense on mobile where the technician can take photos with the camera.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_