### PR TITLE
Add Campanhas feature — timed popup in all portals

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -32,6 +32,7 @@
       <button class="nav-tab admin-only-tab" data-tab="settings">⚙️ Configurações</button>
       <button class="nav-tab" data-tab="reports">📊 Relatórios</button>
       <button class="nav-tab admin-only-tab" data-tab="audit">🔍 Auditoria</button>
+      <button class="nav-tab admin-only-tab" data-tab="campaigns">📣 Campanhas</button>
       <button class="nav-tab" data-tab="checkins">⏱️ Check-in</button>
       <button class="nav-tab" data-tab="search">🔎 Pesquisa</button>
       <button class="nav-tab" data-tab="alerts">🚨 Alertas <span id="alertsBadge" style="display:none;background:#dc2626;color:#fff;font-size:11px;font-weight:800;padding:1px 7px;border-radius:10px;margin-left:4px;vertical-align:middle;"></span></button>
@@ -402,6 +403,50 @@
       </div>
       <p style="color:#64748b;font-size:13px;margin-bottom:16px;">Vidros em stock sem serviço agendado e encomendas sem receção há demasiado tempo.</p>
       <div id="alertsContent"><p style="color:#94a3b8;text-align:center;padding:30px;">A carregar...</p></div>
+    </div>
+
+    <!-- Tab: Campanhas -->
+    <div id="campaignsTab" class="tab-content">
+      <div class="content-header" style="margin-bottom:20px;">
+        <h2 style="margin:0;">📣 Campanhas</h2>
+        <button onclick="campAdmin.openForm()" class="btn-primary">+ Nova Campanha</button>
+      </div>
+
+      <!-- Form -->
+      <div id="campForm" style="display:none;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:20px;margin-bottom:24px;">
+        <h3 style="margin:0 0 16px;font-size:16px;">Campanha</h3>
+        <input type="hidden" id="campId">
+        <div style="display:grid;grid-template-columns:1fr 1fr 2fr;gap:12px;margin-bottom:12px;align-items:end;">
+          <div>
+            <label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Início *</label>
+            <input type="date" id="campStart" style="width:100%;padding:8px 10px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;box-sizing:border-box;">
+          </div>
+          <div>
+            <label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Fim *</label>
+            <input type="date" id="campEnd" style="width:100%;padding:8px 10px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;box-sizing:border-box;">
+          </div>
+          <div>
+            <label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Título (opcional)</label>
+            <input type="text" id="campTitle" maxlength="100" placeholder="Ex: Campanha de Verão" style="width:100%;padding:8px 10px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;box-sizing:border-box;">
+          </div>
+        </div>
+        <div style="margin-bottom:12px;">
+          <label style="display:block;font-size:13px;font-weight:600;margin-bottom:6px;">Imagem do pop-up *</label>
+          <input type="file" id="campImageFile" accept="image/*" onchange="campAdmin.onImagePick(this)" style="font-size:13px;">
+          <div id="campImagePreview" style="margin-top:10px;"></div>
+        </div>
+        <div style="display:flex;gap:10px;align-items:center;">
+          <label style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;">
+            <input type="checkbox" id="campActive" checked> Ativa
+          </label>
+          <button onclick="campAdmin.save()" style="background:#2563eb;color:#fff;border:none;padding:9px 20px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">Guardar</button>
+          <button onclick="campAdmin.closeForm()" style="background:#fff;border:1px solid #d1d5db;padding:9px 16px;border-radius:8px;font-size:14px;cursor:pointer;">Cancelar</button>
+          <span id="campSaveMsg" style="font-size:13px;color:#16a34a;"></span>
+        </div>
+      </div>
+
+      <!-- List -->
+      <div id="campList"><p style="color:#94a3b8;text-align:center;padding:30px;">A carregar...</p></div>
     </div>
 
 </div><!-- fim admin-container -->
@@ -776,6 +821,187 @@
       document.querySelectorAll('.nav-tab').forEach(tab => {
         tab.addEventListener('click', () => {
           if (tab.dataset.tab === 'checkins') window.ciLoad();
+        });
+      });
+    });
+  })();
+  </script>
+
+  <script>
+  (function () {
+    var _imageData = null;
+    var _AUTH = window.authClient;
+
+    function _fmtDate(d) {
+      if (!d) return '—';
+      return d.slice(0, 10).split('-').reverse().join('/');
+    }
+
+    function _load() {
+      var el = document.getElementById('campList');
+      if (!el) return;
+      el.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:30px;">A carregar...</p>';
+      _AUTH.authenticatedFetch('/.netlify/functions/campaign?all=1')
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+          if (!d.success) throw new Error(d.error || 'Erro');
+          var camps = d.campaigns || [];
+          if (!camps.length) {
+            el.innerHTML = '<p style="color:#94a3b8;text-align:center;padding:30px;">Sem campanhas criadas.</p>';
+            return;
+          }
+          el.innerHTML = '<table class="data-table"><thead><tr><th>Título</th><th>Início</th><th>Fim</th><th>Estado</th><th>Ações</th></tr></thead><tbody>' +
+            camps.map(function (c) {
+              var today = new Date().toISOString().slice(0, 10);
+              var isActive = c.active && c.start_date <= today && c.end_date >= today;
+              var badge = isActive
+                ? '<span style="background:#dcfce7;color:#16a34a;font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;">Em curso</span>'
+                : (c.active
+                  ? '<span style="background:#fef9c3;color:#854d0e;font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;">Agendada</span>'
+                  : '<span style="background:#f1f5f9;color:#94a3b8;font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;">Inativa</span>');
+              return '<tr><td>' + (c.title || '—') + '</td><td>' + _fmtDate(c.start_date) + '</td><td>' + _fmtDate(c.end_date) + '</td><td>' + badge + '</td>' +
+                '<td style="white-space:nowrap;"><button onclick="campAdmin.edit(' + c.id + ')" style="background:#1e40af;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;margin-right:4px;">Editar</button>' +
+                '<button onclick="campAdmin.del(' + c.id + ')" style="background:#dc2626;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;">Eliminar</button></td></tr>';
+            }).join('') +
+          '</tbody></table>';
+        })
+        .catch(function (e) {
+          el.innerHTML = '<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ' + e.message + '</p>';
+        });
+    }
+
+    window.campAdmin = {
+      openForm: function () {
+        document.getElementById('campId').value = '';
+        document.getElementById('campTitle').value = '';
+        document.getElementById('campStart').value = '';
+        document.getElementById('campEnd').value = '';
+        document.getElementById('campActive').checked = true;
+        document.getElementById('campImagePreview').innerHTML = '';
+        document.getElementById('campImageFile').value = '';
+        document.getElementById('campSaveMsg').textContent = '';
+        _imageData = null;
+        document.getElementById('campForm').style.display = 'block';
+      },
+
+      closeForm: function () {
+        document.getElementById('campForm').style.display = 'none';
+        _imageData = null;
+      },
+
+      onImagePick: function (input) {
+        var file = input.files[0];
+        if (!file) return;
+        var preview = document.getElementById('campImagePreview');
+        preview.innerHTML = '<span style="font-size:13px;color:#94a3b8;">A processar imagem...</span>';
+        var reader = new FileReader();
+        reader.onload = function (e) {
+          var src = e.target.result;
+          // Resize to max 1600px wide before storing
+          var img = new Image();
+          img.onload = function () {
+            var canvas = document.createElement('canvas');
+            var maxW = 1600, maxH = 1600;
+            var w = img.width, h = img.height;
+            if (w > maxW || h > maxH) {
+              var ratio = Math.min(maxW / w, maxH / h);
+              w = Math.round(w * ratio);
+              h = Math.round(h * ratio);
+            }
+            canvas.width = w;
+            canvas.height = h;
+            canvas.getContext('2d').drawImage(img, 0, 0, w, h);
+            _imageData = canvas.toDataURL('image/jpeg', 0.88);
+            preview.innerHTML = '<img src="' + _imageData + '" style="max-width:320px;max-height:200px;border-radius:8px;border:1px solid #e2e8f0;margin-top:4px;">';
+          };
+          img.src = src;
+        };
+        reader.readAsDataURL(file);
+      },
+
+      save: function () {
+        var id = document.getElementById('campId').value;
+        var body = {
+          title: document.getElementById('campTitle').value.trim(),
+          start_date: document.getElementById('campStart').value,
+          end_date: document.getElementById('campEnd').value,
+          active: document.getElementById('campActive').checked
+        };
+        if (!body.start_date || !body.end_date) {
+          alert('Preenche as datas de início e fim.');
+          return;
+        }
+        if (!id && !_imageData) {
+          alert('Escolhe uma imagem para o pop-up.');
+          return;
+        }
+        if (_imageData) body.image_data = _imageData;
+
+        var url = id ? '/.netlify/functions/campaign?id=' + id : '/.netlify/functions/campaign';
+        var method = id ? 'PUT' : 'POST';
+        var msg = document.getElementById('campSaveMsg');
+        msg.textContent = 'A guardar...';
+        msg.style.color = '#94a3b8';
+
+        _AUTH.authenticatedFetch(url, {
+          method: method,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (!d.success) throw new Error(d.error || 'Erro');
+            msg.textContent = 'Guardado!';
+            msg.style.color = '#16a34a';
+            setTimeout(function () { campAdmin.closeForm(); _load(); }, 800);
+          })
+          .catch(function (e) {
+            msg.textContent = 'Erro: ' + e.message;
+            msg.style.color = '#dc2626';
+          });
+      },
+
+      edit: function (id) {
+        _AUTH.authenticatedFetch('/.netlify/functions/campaign?id=' + id)
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (!d.success || !d.campaign) throw new Error('Não encontrado');
+            var c = d.campaign;
+            document.getElementById('campId').value = c.id;
+            document.getElementById('campTitle').value = c.title || '';
+            document.getElementById('campStart').value = (c.start_date || '').slice(0, 10);
+            document.getElementById('campEnd').value = (c.end_date || '').slice(0, 10);
+            document.getElementById('campActive').checked = !!c.active;
+            document.getElementById('campSaveMsg').textContent = '';
+            document.getElementById('campImageFile').value = '';
+            _imageData = null;
+            var preview = document.getElementById('campImagePreview');
+            if (c.image_data) {
+              preview.innerHTML = '<img src="' + c.image_data + '" style="max-width:320px;max-height:200px;border-radius:8px;border:1px solid #e2e8f0;margin-top:4px;"><p style="font-size:12px;color:#64748b;margin:4px 0 0;">Carrega um novo ficheiro para substituir a imagem atual.</p>';
+            } else {
+              preview.innerHTML = '';
+            }
+            document.getElementById('campForm').style.display = 'block';
+          })
+          .catch(function (e) { alert('Erro: ' + e.message); });
+      },
+
+      del: function (id) {
+        if (!confirm('Eliminar esta campanha?')) return;
+        _AUTH.authenticatedFetch('/.netlify/functions/campaign?id=' + id, { method: 'DELETE' })
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (!d.success) throw new Error(d.error || 'Erro');
+            _load();
+          })
+          .catch(function (e) { alert('Erro: ' + e.message); });
+      }
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('.nav-tab').forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          if (tab.dataset.tab === 'campaigns') _load();
         });
       });
     });

--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -1,0 +1,91 @@
+(function () {
+  'use strict';
+
+  var SLOTS = [
+    { h: 9,  m: 45, key: 'morning' },
+    { h: 14, m: 45, key: 'afternoon' }
+  ];
+
+  var _campaign = null;
+
+  function _todayKey() {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  function _wasShown(slotKey) {
+    try {
+      var stored = JSON.parse(localStorage.getItem('campaign_shown') || '{}');
+      return (stored[_todayKey()] || {})[slotKey] === true;
+    } catch (e) { return false; }
+  }
+
+  function _markShown(slotKey) {
+    try {
+      var stored = JSON.parse(localStorage.getItem('campaign_shown') || '{}');
+      var today = _todayKey();
+      stored[today] = stored[today] || {};
+      stored[today][slotKey] = true;
+      Object.keys(stored).forEach(function (d) { if (d < today) delete stored[d]; });
+      localStorage.setItem('campaign_shown', JSON.stringify(stored));
+    } catch (e) {}
+  }
+
+  function _showModal() {
+    if (!_campaign || !_campaign.image_data) return;
+    var modal = document.getElementById('campaignPopupModal');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.id = 'campaignPopupModal';
+      modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
+      modal.innerHTML =
+        '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
+          '<button id="campPopClose" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
+          '<img id="campPopImg" src="" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;">' +
+        '</div>';
+      document.body.appendChild(modal);
+      modal.querySelector('#campPopClose').addEventListener('click', function () { modal.style.display = 'none'; });
+      modal.addEventListener('click', function (e) { if (e.target === modal) modal.style.display = 'none'; });
+    }
+    modal.querySelector('#campPopImg').src = _campaign.image_data;
+    modal.style.display = 'flex';
+  }
+
+  function _scheduleSlot(slot) {
+    var now = new Date();
+    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, slot.m, 0, 0);
+    var ms = fire - now;
+
+    if (ms <= 0) {
+      // Already past — show if within last 30 min and not yet shown
+      if (ms > -30 * 60 * 1000 && !_wasShown(slot.key)) {
+        _markShown(slot.key);
+        _showModal();
+      }
+      return;
+    }
+
+    setTimeout(function () {
+      if (!_wasShown(slot.key)) {
+        _markShown(slot.key);
+        _showModal();
+      }
+    }, ms);
+  }
+
+  function _init() {
+    fetch('/.netlify/functions/campaign')
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        if (!d.success || !d.campaign) return;
+        _campaign = d.campaign;
+        SLOTS.forEach(_scheduleSlot);
+      })
+      .catch(function () {});
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _init);
+  } else {
+    _init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -794,6 +794,7 @@
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=2"></script>
+  <script src="/campaign-popup.js?v=2026-06-19a"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>

--- a/netlify/functions/campaign.js
+++ b/netlify/functions/campaign.js
@@ -1,0 +1,128 @@
+// netlify/functions/campaign.js
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+async function ensureTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS campaigns (
+      id SERIAL PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT '',
+      start_date DATE NOT NULL,
+      end_date DATE NOT NULL,
+      image_data TEXT,
+      active BOOLEAN DEFAULT true,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
+function verifyAdmin(event) {
+  const h = event.headers.authorization || event.headers.Authorization || '';
+  if (!h.startsWith('Bearer ')) throw new Error('Não autenticado');
+  const user = jwt.verify(h.substring(7), JWT_SECRET);
+  if (user.role !== 'admin') throw new Error('Acesso negado');
+  return user;
+}
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Content-Type': 'application/json'
+  };
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+
+  const client = await pool.connect();
+  try {
+    await ensureTable(client);
+    const qs = event.queryStringParameters || {};
+
+    if (event.httpMethod === 'GET') {
+      // Admin: list all (without image_data for efficiency)
+      if (qs.all === '1') {
+        verifyAdmin(event);
+        const { rows } = await client.query(
+          'SELECT id, title, start_date, end_date, active, created_at FROM campaigns ORDER BY created_at DESC'
+        );
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, campaigns: rows }) };
+      }
+
+      // Admin: fetch one campaign with image
+      if (qs.id) {
+        verifyAdmin(event);
+        const { rows } = await client.query('SELECT * FROM campaigns WHERE id = $1', [qs.id]);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, campaign: rows[0] || null }) };
+      }
+
+      // Public: active campaign for today (no auth required)
+      const today = new Date().toISOString().slice(0, 10);
+      const { rows } = await client.query(
+        `SELECT id, title, start_date, end_date, image_data
+         FROM campaigns
+         WHERE active = true AND start_date <= $1 AND end_date >= $1
+         ORDER BY created_at DESC LIMIT 1`,
+        [today]
+      );
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, campaign: rows[0] || null }) };
+    }
+
+    if (event.httpMethod === 'POST') {
+      verifyAdmin(event);
+      const d = JSON.parse(event.body || '{}');
+      if (!d.start_date || !d.end_date) {
+        return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'start_date e end_date são obrigatórios' }) };
+      }
+      const { rows } = await client.query(
+        `INSERT INTO campaigns (title, start_date, end_date, image_data, active)
+         VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false]
+      );
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, id: rows[0].id }) };
+    }
+
+    if (event.httpMethod === 'PUT') {
+      verifyAdmin(event);
+      const id = qs.id;
+      if (!id) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'id obrigatório' }) };
+      const d = JSON.parse(event.body || '{}');
+      const hasImage = d.image_data !== undefined;
+      if (hasImage) {
+        await client.query(
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5 WHERE id=$6`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, id]
+        );
+      } else {
+        await client.query(
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4 WHERE id=$5`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, id]
+        );
+      }
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+    }
+
+    if (event.httpMethod === 'DELETE') {
+      verifyAdmin(event);
+      const id = qs.id;
+      if (!id) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'id obrigatório' }) };
+      await client.query('DELETE FROM campaigns WHERE id = $1', [id]);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Method not allowed' }) };
+  } catch (err) {
+    console.error('campaign:', err);
+    const code = err.message.includes('autenticado') || err.message.includes('negado') ? 403 : 500;
+    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  } finally {
+    client.release();
+  }
+};


### PR DESCRIPTION
## Summary
- New `campaigns` DB table (auto-created on first request)
- **Admin panel** → tab "📣 Campanhas": create/edit/delete campaigns with start date, end date, title, and image upload
- **All portals**: `campaign-popup.js` fetches the active campaign and shows a full-screen image popup at **09:45** and **14:45** daily
- Each slot shown only once per day per browser (localStorage tracking)
- Image is resized on upload (max 1600px) and stored as base64

## Test plan
- [ ] Admin can create a campaign with an image and date range
- [ ] Admin can edit/delete campaigns
- [ ] Popup appears at 09:45 / 14:45 when a campaign is active
- [ ] Popup does not re-appear if already shown for that slot today
- [ ] No popup shown when no active campaign exists

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_