### PR TITLE
Fix check-up save failing for admin users

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,7 @@
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
-  <script src="/vehicle-checkup-patch.js?v=2"></script>
+  <script src="/vehicle-checkup-patch.js?v=3"></script>
   <script src="/campaign-popup.js?v=2026-06-19b"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -200,10 +200,11 @@
 
     try {
       const tok = localStorage.getItem('eg_auth_token');
-      const res = await fetch('/.netlify/functions/appointments', {
+      const portalId = window.portalConfig?.id || appt?.portal_id || null;
+      const res = await fetch('/.netlify/functions/appointments/' + _apptId, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', ...(tok ? { Authorization: 'Bearer ' + tok } : {}) },
-        body: JSON.stringify({ id: _apptId, notes: newNotes, damage_details: newDamageDetails })
+        body: JSON.stringify({ notes: newNotes, damage_details: newDamageDetails, _portalId: portalId })
       });
       const json = await res.json();
       if (!json.success) throw new Error(json.error || 'Erro ao guardar');


### PR DESCRIPTION
## Summary
- PUT URL was `/.netlify/functions/appointments` — the API reads the appointment ID from `path.split('/').pop()`, so it was extracting `"appointments"` instead of the real ID. Fixed to `/.netlify/functions/appointments/:id`.
- Admin JWT has no `portalId`, so `appointments.js` returned 403 "Utilizador sem portal atribuído" before reaching the admin bypass in the PUT handler. Fixed by passing `_portalId` (from `window.portalConfig.id` or the appointment's own `portal_id`) in the request body.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_