### PR TITLE
Show campaign popup immediately today (2026-06-19) once per user

### DIFF
--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -81,6 +81,11 @@
         if (!d.success || !d.campaign) return;
         _campaign = d.campaign;
         SLOTS.forEach(_scheduleSlot);
+        // Disparo imediato pontual (2026-06-19)
+        if (_todayKey() === '2026-06-19' && !_wasShown('special_immediate')) {
+          _markShown('special_immediate');
+          setTimeout(_showModal, 800);
+        }
       })
       .catch(function () {});
   }

--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=3"></script>
-  <script src="/campaign-popup.js?v=2026-06-19b"></script>
+  <script src="/campaign-popup.js?v=2026-06-19c"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>


### PR DESCRIPTION
One-time immediate popup for 2026-06-19: on page load, if the campaign is active and the key `special_immediate` hasn't been shown today, the modal appears after 800ms. Does not affect the permanent 09:45/14:45 schedule.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_