### PR TITLE
feat: redesign comparison view — rich visuals + team stats

### DIFF
--- a/reports-widget.js
+++ b/reports-widget.js
@@ -489,6 +489,7 @@ function _rwRenderComparison(dataA, dataB) {
   const nameA = dataA.portal.name || 'Portal A';
   const nameB = dataB.portal.name || 'Portal B';
   const fmtDate = d => new Date(d + 'T12:00:00').toLocaleDateString('pt-PT', { day: '2-digit', month: 'long', year: 'numeric' });
+  const fmtH = h => (h == null || isNaN(h) || h === 0) ? '—' : `${Math.floor(h)}h${String(Math.round((h - Math.floor(h)) * 60)).padStart(2, '0')}`;
 
   function calcKpis(data) {
     const { totals } = data;
@@ -499,31 +500,88 @@ function _rwRenderComparison(dataA, dataB) {
     const km     = parseInt(totals.total_km) || 0;
     const pend   = parseInt(totals.total_pendentes) || 0;
     const tMin   = parseInt(totals.total_travel_min) || 0;
-    const travel = tMin > 0 ? `${Math.floor(tMin / 60)}h${String(tMin % 60).padStart(2, '0')}` : '—';
     const custo  = ((km * 7.5 / 100) * 1.95).toFixed(2);
-    return { total, realiz, nReal, taxa, km, pend, travel, custo };
+    return { total, realiz, nReal, taxa, km, pend, tMin, custo };
+  }
+
+  function calcTeam(teamStats) {
+    if (!teamStats || !teamStats.length) return null;
+    const daysWithBoth = teamStats.filter(r => r.checkin_at && r.checkout_at);
+    const totalNetHrs  = daysWithBoth.reduce((s, r) => s + Math.max(0, parseFloat(r.hours_raw || 0) - 1), 0);
+    const avgNetHrs    = daysWithBoth.length ? totalNetHrs / daysWithBoth.length : 0;
+    const totalSvcs    = teamStats.reduce((s, r) => s + parseInt(r.services_done || 0), 0);
+    const avgSvcs      = teamStats.length ? totalSvcs / teamStats.length : 0;
+    const totalKm      = teamStats.reduce((s, r) => s + parseFloat(r.km_day || 0), 0);
+    const sph          = totalNetHrs > 0 ? totalSvcs / totalNetHrs : 0;
+    return { days: teamStats.length, totalNetHrs, avgNetHrs, totalSvcs, avgSvcs, totalKm, sph };
   }
 
   const kA = calcKpis(dataA);
   const kB = calcKpis(dataB);
+  const tA = calcTeam(dataA.teamStats);
+  const tB = calcTeam(dataB.teamStats);
 
-  const kpiRows = [
-    { label: 'Agendados',       vA: kA.total,  vB: kB.total,  fmt: v => v,        num: true,  better: true  },
-    { label: 'Realizados',      vA: kA.realiz, vB: kB.realiz, fmt: v => v,        num: true,  better: true  },
-    { label: 'Não realizados',  vA: kA.nReal,  vB: kB.nReal,  fmt: v => v,        num: true,  better: false },
-    { label: 'Taxa realização', vA: kA.taxa,   vB: kB.taxa,   fmt: v => v + '%',  num: true,  better: true  },
-    { label: 'Total km',        vA: kA.km,     vB: kB.km,     fmt: v => v + ' km',num: true,  better: null  },
-    { label: 'Pendentes',       vA: kA.pend,   vB: kB.pend,   fmt: v => v,        num: true,  better: false },
-    { label: 'Custo gasóleo',   vA: parseFloat(kA.custo), vB: parseFloat(kB.custo), fmt: v => v + '€', num: true, better: false },
+  const metrics = [
+    { icon: '📋', label: 'Agendados',       vA: kA.total,              vB: kB.total,              fmt: v => v,                                           better: true  },
+    { icon: '✅', label: 'Realizados',      vA: kA.realiz,             vB: kB.realiz,             fmt: v => v,                                           better: true  },
+    { icon: '❌', label: 'Não realizados',  vA: kA.nReal,              vB: kB.nReal,              fmt: v => v,                                           better: false },
+    { icon: '🎯', label: 'Taxa realização', vA: kA.taxa,               vB: kB.taxa,               fmt: v => v + '%',                                     better: true  },
+    { icon: '🚗', label: 'Total km',        vA: kA.km,                 vB: kB.km,                 fmt: v => v + ' km',                                   better: null  },
+    { icon: '⏳', label: 'Pendentes',       vA: kA.pend,               vB: kB.pend,               fmt: v => v,                                           better: false },
+    { icon: '⏱️', label: 'Tempo estrada',   vA: kA.tMin,               vB: kB.tMin,               fmt: v => { const m=parseInt(v); return m>0?fmtH(m/60):'—'; }, better: null },
+    { icon: '⛽', label: 'Custo gasóleo',   vA: parseFloat(kA.custo),  vB: parseFloat(kB.custo),  fmt: v => v + '€',                                     better: false },
   ];
+
+  const teamMetrics = [
+    { icon: '📅', label: 'Dias registados',  vA: tA?.days || 0,        vB: tB?.days || 0,        fmt: v => v,                    better: true  },
+    { icon: '⏱️', label: 'Horas líq. total', vA: tA?.totalNetHrs || 0, vB: tB?.totalNetHrs || 0, fmt: v => fmtH(v),              better: true  },
+    { icon: '🕐', label: 'Média horas/dia',  vA: tA?.avgNetHrs || 0,   vB: tB?.avgNetHrs || 0,   fmt: v => fmtH(v),              better: true  },
+    { icon: '📦', label: 'Serviços total',   vA: tA?.totalSvcs || 0,   vB: tB?.totalSvcs || 0,   fmt: v => v,                    better: true  },
+    { icon: '📈', label: 'Média serv./dia',  vA: tA?.avgSvcs || 0,     vB: tB?.avgSvcs || 0,     fmt: v => v.toFixed(1),         better: true  },
+    { icon: '⚡', label: 'Serv./hora',       vA: tA?.sph || 0,         vB: tB?.sph || 0,         fmt: v => v.toFixed(2),         better: true  },
+    { icon: '🗺️', label: 'Km percorridos',   vA: tA?.totalKm || 0,    vB: tB?.totalKm || 0,     fmt: v => Math.round(v)+' km',  better: null  },
+  ];
+
+  let winsA = 0, winsB = 0;
+  metrics.forEach(m => {
+    if (m.better === null || m.vA === m.vB) return;
+    (m.better ? m.vA > m.vB : m.vA < m.vB) ? winsA++ : winsB++;
+  });
+
+  const badge = '<span style="font-size:10px;font-weight:800;color:#16a34a;background:#dcfce7;padding:2px 8px;border-radius:10px;white-space:nowrap;letter-spacing:.02em;">↑ Melhor</span>';
+
+  function metricRow(m, nameA_, nameB_, hasA = true, hasB = true) {
+    const aWins = m.better !== null && m.vA !== m.vB && (m.better ? m.vA > m.vB : m.vA < m.vB);
+    const bWins = m.better !== null && m.vA !== m.vB && (m.better ? m.vB > m.vA : m.vB < m.vA);
+    const sum = m.vA + m.vB;
+    const pctA = sum > 0 ? Math.round((m.vA / sum) * 100) : 50;
+    return `
+      <div style="display:grid;grid-template-columns:1fr 150px 1fr;align-items:center;padding:13px 16px;border-bottom:1px solid #f1f5f9;">
+        <div style="display:flex;align-items:center;gap:8px;">
+          <span style="font-size:26px;font-weight:900;color:#2563eb;">${hasA ? m.fmt(m.vA) : '—'}</span>
+          ${aWins && hasA ? badge : ''}
+        </div>
+        <div style="text-align:center;padding:0 6px;">
+          <div style="font-size:10px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:.07em;margin-bottom:5px;">${m.icon} ${m.label}</div>
+          <div style="display:flex;height:4px;border-radius:2px;overflow:hidden;background:#f1f5f9;">
+            <div style="width:${pctA}%;background:#3b82f6;"></div>
+            <div style="width:${100 - pctA}%;background:#8b5cf6;"></div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;justify-content:flex-end;gap:8px;">
+          ${bWins && hasB ? badge : ''}
+          <span style="font-size:26px;font-weight:900;color:#7c3aed;">${hasB ? m.fmt(m.vB) : '—'}</span>
+        </div>
+      </div>`;
+  }
 
   const svcMap = { PB: 'Para-brisas', LT: 'Lateral', OC: 'Óculo', REP: 'Reparação', POL: 'Polimento', MO: 'Montante' };
 
   function localityTable(rows) {
-    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px 0;">Sem dados</p>';
+    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px;">Sem dados</p>';
     return `<table style="width:100%;border-collapse:collapse;font-size:13px;">
       <thead><tr style="background:#f8fafc;border-bottom:1px solid #e2e8f0;">
-        <th style="text-align:left;padding:7px 10px;font-weight:700;color:#374151;">Localidade</th>
+        <th style="text-align:left;padding:7px 10px;font-weight:700;">Localidade</th>
         <th style="text-align:center;padding:7px;font-weight:700;">Total</th>
         <th style="text-align:center;padding:7px;font-weight:700;color:#16a34a;">Real.</th>
         <th style="text-align:center;padding:7px;font-weight:700;">Taxa</th>
@@ -536,117 +594,134 @@ function _rwRenderComparison(dataA, dataB) {
           <td style="padding:7px 10px;font-weight:600;font-size:12px;">${r.locality}</td>
           <td style="text-align:center;padding:7px;font-weight:700;">${t}</td>
           <td style="text-align:center;padding:7px;color:#16a34a;font-weight:700;">${rl}</td>
-          <td style="text-align:center;padding:7px;"><span style="background:${txC}15;color:${txC};font-weight:700;padding:1px 6px;border-radius:10px;font-size:11px;">${tx}%</span></td>
+          <td style="text-align:center;padding:7px;"><span style="background:${txC}18;color:${txC};font-weight:700;padding:1px 7px;border-radius:10px;font-size:11px;">${tx}%</span></td>
         </tr>`;
       }).join('')}</tbody>
     </table>`;
   }
 
   function serviceTable(rows) {
-    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px 0;">Sem dados</p>';
-    const total = rows.reduce((s, r) => s + parseInt(r.total), 0);
+    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px;">Sem dados</p>';
+    const tot = rows.reduce((s, r) => s + parseInt(r.total), 0);
     return `<table style="width:100%;border-collapse:collapse;font-size:13px;">
       <thead><tr style="background:#f8fafc;border-bottom:1px solid #e2e8f0;">
-        <th style="text-align:left;padding:7px 10px;font-weight:700;color:#374151;">Serviço</th>
+        <th style="text-align:left;padding:7px 10px;font-weight:700;">Serviço</th>
         <th style="text-align:center;padding:7px;font-weight:700;">Total</th>
-        <th style="text-align:center;padding:7px;font-weight:700;">%</th>
+        <th style="text-align:left;padding:7px 10px;font-weight:700;">Dist.</th>
       </tr></thead>
       <tbody>${rows.map((r, i) => {
         const t = parseInt(r.total);
-        const pct = total > 0 ? Math.round((t / total) * 100) : 0;
+        const pct = tot > 0 ? Math.round((t / tot) * 100) : 0;
         return `<tr style="border-bottom:1px solid #f1f5f9;${i % 2 === 0 ? 'background:#fafafa' : ''}">
           <td style="padding:7px 10px;font-weight:600;font-size:12px;">${svcMap[r.service] || r.service}</td>
-          <td style="text-align:center;padding:7px;font-weight:700;">${t}</td>
-          <td style="text-align:center;padding:7px;"><span style="background:#eff6ff;color:#2563eb;font-weight:700;padding:1px 6px;border-radius:10px;font-size:11px;">${pct}%</span></td>
+          <td style="text-align:center;padding:7px;font-weight:800;">${t}</td>
+          <td style="padding:7px 10px;">
+            <div style="display:flex;align-items:center;gap:6px;">
+              <div style="flex:1;height:6px;border-radius:3px;background:#e2e8f0;overflow:hidden;">
+                <div style="width:${pct}%;height:100%;background:#3b82f6;border-radius:3px;"></div>
+              </div>
+              <span style="font-size:11px;font-weight:700;color:#2563eb;min-width:28px;">${pct}%</span>
+            </div>
+          </td>
         </tr>`;
       }).join('')}</tbody>
     </table>`;
   }
 
   function motivoTable(rows) {
-    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px 0;">Sem dados</p>';
+    if (!rows || !rows.length) return '<p style="color:#94a3b8;font-size:13px;padding:10px;">Sem dados</p>';
+    const tot = rows.reduce((s, r) => s + parseInt(r.total), 0);
     return `<table style="width:100%;border-collapse:collapse;font-size:13px;">
       <thead><tr style="background:#fef2f2;border-bottom:1px solid #fecdd3;">
         <th style="text-align:left;padding:7px 10px;font-weight:700;color:#dc2626;">Motivo</th>
         <th style="text-align:center;padding:7px;font-weight:700;">N.º</th>
+        <th style="padding:7px 10px;font-weight:700;">%</th>
       </tr></thead>
-      <tbody>${rows.map((r, i) => `<tr style="border-bottom:1px solid #f1f5f9;${i % 2 === 0 ? 'background:#fafafa' : ''}">
-        <td style="padding:7px 10px;color:#374151;font-size:12px;">${r.motivo}</td>
-        <td style="text-align:center;padding:7px;"><span style="background:#fef2f2;color:#dc2626;font-weight:700;padding:1px 8px;border-radius:10px;font-size:11px;">${r.total}×</span></td>
-      </tr>`).join('')}</tbody>
+      <tbody>${rows.map((r, i) => {
+        const t = parseInt(r.total), pct = tot > 0 ? Math.round((t / tot) * 100) : 0;
+        return `<tr style="border-bottom:1px solid #f1f5f9;${i % 2 === 0 ? 'background:#fafafa' : ''}">
+          <td style="padding:7px 10px;color:#374151;font-size:12px;">${r.motivo}</td>
+          <td style="text-align:center;padding:7px;"><span style="background:#fef2f2;color:#dc2626;font-weight:800;padding:1px 8px;border-radius:10px;font-size:11px;">${t}×</span></td>
+          <td style="padding:7px 10px;">
+            <div style="display:flex;align-items:center;gap:5px;">
+              <div style="flex:1;height:5px;border-radius:3px;background:#fecdd3;overflow:hidden;">
+                <div style="width:${pct}%;height:100%;background:#ef4444;border-radius:3px;"></div>
+              </div>
+              <span style="font-size:10px;color:#dc2626;font-weight:700;min-width:26px;">${pct}%</span>
+            </div>
+          </td>
+        </tr>`;
+      }).join('')}</tbody>
     </table>`;
   }
 
-  const kpiHtml = kpiRows.map(row => {
-    let bgA = '', bgB = '';
-    if (row.better !== null && row.vA !== row.vB) {
-      const aWins = row.better ? row.vA > row.vB : row.vA < row.vB;
-      bgA = aWins ? 'background:#dcfce7;' : 'background:#fff1f2;';
-      bgB = aWins ? 'background:#fff1f2;' : 'background:#dcfce7;';
-    }
-    return `<tr style="border-bottom:1px solid #f1f5f9;">
-      <td style="padding:12px 16px;font-size:22px;font-weight:800;color:#2563eb;${bgA}">${row.fmt(row.vA)}</td>
-      <td style="padding:12px 8px;text-align:center;font-size:11px;font-weight:700;color:#6b7280;text-transform:uppercase;letter-spacing:.05em;background:#f8fafc;white-space:nowrap;">${row.label}</td>
-      <td style="padding:12px 16px;font-size:22px;font-weight:800;color:#7c3aed;text-align:right;${bgB}">${row.fmt(row.vB)}</td>
-    </tr>`;
-  }).join('');
+  const sectionCard = (borderColor, bgColor, title, content) =>
+    `<div style="background:#fff;border:1px solid ${borderColor};border-radius:12px;overflow:hidden;">
+      <div style="padding:11px 16px;background:${bgColor};font-weight:700;font-size:13px;color:${borderColor === '#bfdbfe' ? '#2563eb' : borderColor === '#ddd6fe' ? '#7c3aed' : '#6b7280'};border-bottom:1px solid ${borderColor};">${title}</div>
+      <div style="padding:0 6px 8px;">${content}</div>
+    </div>`;
 
   const periodStr = `${fmtDate(dataA.period.from)} → ${fmtDate(dataA.period.to)}`;
+  const hasTeam = tA || tB;
 
   document.getElementById('reportCompareContent').innerHTML = `
-    <div style="margin-bottom:24px;padding:22px 28px;background:linear-gradient(135deg,#1e3a5f 0%,#4c1d95 100%);border-radius:14px;color:#fff;display:flex;justify-content:space-between;align-items:center;">
+    <div style="margin-bottom:18px;padding:20px 26px;background:linear-gradient(130deg,#1e3a5f 0%,#312e81 60%,#4c1d95 100%);border-radius:14px;color:#fff;display:flex;justify-content:space-between;align-items:center;">
       <div>
-        <div style="font-size:11px;opacity:0.7;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:6px;">ExpressGlass — Comparação de Portais</div>
-        <div style="font-size:20px;font-weight:800;"><span style="color:#93c5fd;">${nameA}</span> <span style="opacity:0.6;">vs</span> <span style="color:#c4b5fd;">${nameB}</span></div>
-        <div style="font-size:13px;opacity:0.7;margin-top:4px;">${periodStr}</div>
+        <div style="font-size:10px;font-weight:700;opacity:0.6;text-transform:uppercase;letter-spacing:2px;margin-bottom:8px;">ExpressGlass — Comparação de Portais</div>
+        <div style="font-size:22px;font-weight:800;line-height:1.2;"><span style="color:#93c5fd;">${nameA}</span><span style="opacity:0.4;margin:0 10px;font-size:18px;">vs</span><span style="color:#c4b5fd;">${nameB}</span></div>
+        <div style="font-size:12px;opacity:0.6;margin-top:6px;">${periodStr}</div>
       </div>
-      <div style="font-size:52px;opacity:0.35;">⚖️</div>
+      <div style="font-size:44px;opacity:0.25;">⚖️</div>
     </div>
 
-    <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:20px;margin-bottom:20px;">
-      <div style="font-weight:700;font-size:14px;color:#1e293b;margin-bottom:14px;">📊 Indicadores Chave — rubrica a rubrica</div>
-      <table style="width:100%;border-collapse:collapse;">
-        <thead><tr style="border-bottom:2px solid #e2e8f0;">
-          <th style="padding:10px 16px;text-align:left;font-weight:800;color:#2563eb;font-size:15px;">${nameA}</th>
-          <th style="padding:10px 8px;text-align:center;font-weight:700;color:#6b7280;font-size:11px;text-transform:uppercase;letter-spacing:.05em;background:#f8fafc;">Métrica</th>
-          <th style="padding:10px 16px;text-align:right;font-weight:800;color:#7c3aed;font-size:15px;">${nameB}</th>
-        </tr></thead>
-        <tbody>${kpiHtml}</tbody>
-      </table>
-      <p style="margin-top:10px;font-size:11px;color:#94a3b8;text-align:center;">🟢 fundo verde = melhor resultado · 🔴 fundo vermelho = resultado inferior</p>
-    </div>
-
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px;">
-      <div style="background:#fff;border:1px solid #bfdbfe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#2563eb;margin-bottom:10px;">📍 ${nameA} — Por Localidade</div>
-        ${localityTable(dataA.byLocality)}
+    <div style="display:grid;grid-template-columns:1fr auto 1fr;gap:10px;margin-bottom:18px;align-items:stretch;">
+      <div style="background:linear-gradient(135deg,#2563eb,#1d4ed8);border-radius:12px;padding:16px 20px;color:#fff;display:flex;align-items:center;gap:14px;box-shadow:0 4px 14px rgba(37,99,235,.25);">
+        <div style="font-size:44px;font-weight:900;line-height:1;">${winsA}</div>
+        <div><div style="font-size:10px;opacity:0.75;text-transform:uppercase;letter-spacing:.08em;">métricas ganhas</div><div style="font-size:14px;font-weight:700;margin-top:3px;">${nameA}</div></div>
       </div>
-      <div style="background:#fff;border:1px solid #ddd6fe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#7c3aed;margin-bottom:10px;">📍 ${nameB} — Por Localidade</div>
-        ${localityTable(dataB.byLocality)}
+      <div style="display:flex;align-items:center;justify-content:center;padding:0 4px;">
+        <span style="font-size:18px;font-weight:800;color:#cbd5e1;">vs</span>
+      </div>
+      <div style="background:linear-gradient(135deg,#7c3aed,#6d28d9);border-radius:12px;padding:16px 20px;color:#fff;display:flex;align-items:center;justify-content:flex-end;gap:14px;box-shadow:0 4px 14px rgba(124,58,237,.25);">
+        <div style="text-align:right;"><div style="font-size:10px;opacity:0.75;text-transform:uppercase;letter-spacing:.08em;">métricas ganhas</div><div style="font-size:14px;font-weight:700;margin-top:3px;">${nameB}</div></div>
+        <div style="font-size:44px;font-weight:900;line-height:1;">${winsB}</div>
       </div>
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px;">
-      <div style="background:#fff;border:1px solid #bfdbfe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#2563eb;margin-bottom:10px;">🔧 ${nameA} — Tipo de Serviço</div>
-        ${serviceTable(dataA.byService)}
+    <div style="background:#fff;border:1px solid #e2e8f0;border-radius:14px;overflow:hidden;margin-bottom:18px;box-shadow:0 1px 4px rgba(0,0,0,.06);">
+      <div style="display:grid;grid-template-columns:1fr 150px 1fr;background:linear-gradient(90deg,#eff6ff 0%,#f8fafc 50%,#f5f3ff 100%);border-bottom:2px solid #e2e8f0;">
+        <div style="padding:13px 16px;font-size:13px;font-weight:800;color:#2563eb;">${nameA}</div>
+        <div style="padding:13px 6px;font-size:10px;font-weight:700;color:#94a3b8;text-align:center;text-transform:uppercase;letter-spacing:.07em;">Métrica</div>
+        <div style="padding:13px 16px;font-size:13px;font-weight:800;color:#7c3aed;text-align:right;">${nameB}</div>
       </div>
-      <div style="background:#fff;border:1px solid #ddd6fe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#7c3aed;margin-bottom:10px;">🔧 ${nameB} — Tipo de Serviço</div>
-        ${serviceTable(dataB.byService)}
-      </div>
+      ${metrics.map(m => metricRow(m)).join('')}
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px;">
-      <div style="background:#fff;border:1px solid #bfdbfe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#2563eb;margin-bottom:10px;">❌ ${nameA} — Motivos Não Realização</div>
-        ${motivoTable(dataA.byMotivo)}
+    ${hasTeam ? `
+    <div style="background:#fff;border:1px solid #e2e8f0;border-radius:14px;overflow:hidden;margin-bottom:18px;box-shadow:0 1px 4px rgba(0,0,0,.06);">
+      <div style="padding:13px 16px;background:linear-gradient(90deg,#f5f3ff,#faf5ff);border-bottom:2px solid #e2e8f0;display:flex;align-items:center;justify-content:space-between;">
+        <span style="font-size:13px;font-weight:800;color:#7c3aed;">⏱️ Equipa — Tempos e Rentabilidade</span>
+        <div style="display:flex;gap:16px;font-size:11px;font-weight:700;">
+          <span style="color:#2563eb;">${nameA}</span>
+          <span style="color:#7c3aed;">${nameB}</span>
+        </div>
       </div>
-      <div style="background:#fff;border:1px solid #ddd6fe;border-radius:12px;padding:16px;">
-        <div style="font-weight:700;font-size:13px;color:#7c3aed;margin-bottom:10px;">❌ ${nameB} — Motivos Não Realização</div>
-        ${motivoTable(dataB.byMotivo)}
-      </div>
+      ${teamMetrics.map(m => metricRow(m, nameA, nameB, !!tA, !!tB)).join('')}
+    </div>` : ''}
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px;">
+      ${sectionCard('#bfdbfe','#eff6ff',`📍 ${nameA} — Por Localidade`, localityTable(dataA.byLocality))}
+      ${sectionCard('#ddd6fe','#f5f3ff',`📍 ${nameB} — Por Localidade`, localityTable(dataB.byLocality))}
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px;">
+      ${sectionCard('#bfdbfe','#eff6ff',`🔧 ${nameA} — Tipo de Serviço`, serviceTable(dataA.byService))}
+      ${sectionCard('#ddd6fe','#f5f3ff',`🔧 ${nameB} — Tipo de Serviço`, serviceTable(dataB.byService))}
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:20px;">
+      ${sectionCard('#bfdbfe','#eff6ff',`❌ ${nameA} — Motivos Não Realização`, motivoTable(dataA.byMotivo))}
+      ${sectionCard('#ddd6fe','#f5f3ff',`❌ ${nameB} — Motivos Não Realização`, motivoTable(dataB.byMotivo))}
     </div>
   `;
 


### PR DESCRIPTION
## Summary

- **Score cards** at the top: two coloured cards (blue/purple) showing how many metrics each portal won
- **Metric rows** with a proportional split bar (blue|purple) and a "↑ Melhor" badge on the winning side — no more plain red/green backgrounds
- **Progress bars** inside service-type and motivo tables for at-a-glance distribution
- **New ⏱️ Equipa section** in the same row format: days registered, total net hours, avg hours/day, total services, avg services/day, services/hour, km — uses the `teamStats` already returned by the reports API
- Consistent blue (#2563eb) = Portal A, purple (#7c3aed) = Portal B colour coding throughout
- Team section only renders when at least one portal has check-in data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_