### PR TITLE
fix: comparison view — clean 3-column layout with large numbers

### DIFF
--- a/reports-widget.js
+++ b/reports-widget.js
@@ -549,54 +549,43 @@ function _rwRenderComparison(dataA, dataB) {
     (m.better ? m.vA > m.vB : m.vA < m.vB) ? winsA++ : winsB++;
   });
 
-  const winBadge = `<span style="font-size:9px;font-weight:800;color:#16a34a;background:#dcfce7;padding:1px 7px;border-radius:8px;letter-spacing:.02em;flex-shrink:0;">↑</span>`;
+  const melhorBadge = `<span style="display:inline-block;font-size:10px;font-weight:800;color:#16a34a;background:#dcfce7;padding:2px 8px;border-radius:8px;margin-top:5px;">↑ Melhor</span>`;
 
-  // 4-column table: [Metric] [Distribution bar] [Value A] [Value B]
+  // 3-column table: [Metric] [Value A] [Value B] — no distribution bar
   function compTable(rows, sectionTitle, hasA = true, hasB = true) {
     const rowsHtml = rows.map((r, i) => {
       const aWins = r.better !== null && r.vA !== r.vB && (r.better ? r.vA > r.vB : r.vA < r.vB);
       const bWins = r.better !== null && r.vA !== r.vB && (r.better ? r.vB > r.vA : r.vB < r.vA);
-      const sum = r.vA + r.vB;
-      const pctA = sum > 0 ? Math.round((r.vA / sum) * 100) : 50;
+      const cellStyleA = aWins
+        ? 'border-left:3px solid #16a34a;background:linear-gradient(to right,#f0fdf420,transparent);'
+        : bWins ? 'border-left:3px solid transparent;' : '';
+      const cellStyleB = bWins
+        ? 'border-left:3px solid #16a34a;background:linear-gradient(to right,#f0fdf420,transparent);'
+        : aWins ? 'border-left:3px solid transparent;' : '';
       return `
-        <div style="display:grid;grid-template-columns:190px 1fr 130px 130px;align-items:center;border-bottom:1px solid #f1f5f9;${i%2===1?'background:#fafbfc;':''}">
-          <div style="padding:11px 14px;display:flex;align-items:center;gap:7px;border-right:1px solid #f1f5f9;">
-            <span style="font-size:13px;">${r.icon}</span>
-            <span style="font-size:11px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:.05em;">${r.label}</span>
+        <div style="display:grid;grid-template-columns:200px 1fr 1fr;align-items:stretch;border-bottom:1px solid #f1f5f9;${i%2===1?'background:#fafbfc;':''}">
+          <div style="padding:14px 16px;display:flex;align-items:center;gap:8px;border-right:1px solid #f1f5f9;">
+            <span style="font-size:15px;">${r.icon}</span>
+            <span style="font-size:12px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:.05em;">${r.label}</span>
           </div>
-          <div style="padding:11px 14px;border-right:1px solid #f1f5f9;">
-            <div style="display:flex;height:6px;border-radius:3px;overflow:hidden;background:#f1f5f9;">
-              <div style="width:${pctA}%;background:#3b82f6;"></div>
-              <div style="width:${100-pctA}%;background:#8b5cf6;"></div>
-            </div>
-            <div style="display:flex;justify-content:space-between;margin-top:3px;">
-              <span style="font-size:9px;color:#94a3b8;font-weight:600;">${pctA}%</span>
-              <span style="font-size:9px;color:#94a3b8;font-weight:600;">${100-pctA}%</span>
-            </div>
+          <div style="padding:12px 20px;border-right:1px solid #f1f5f9;${cellStyleA}">
+            <div style="font-size:28px;font-weight:900;color:${BLUE};line-height:1.1;${bWins&&!aWins?'opacity:.45;':''}">${hasA ? r.fmt(r.vA) : '—'}</div>
+            ${aWins && hasA ? melhorBadge : ''}
           </div>
-          <div style="padding:11px 14px;text-align:right;background:#eff6ff22;border-right:1px solid #f1f5f9;">
-            <div style="display:inline-flex;align-items:center;justify-content:flex-end;gap:5px;">
-              ${aWins && hasA ? winBadge : ''}
-              <span style="font-size:19px;font-weight:900;color:${BLUE};">${hasA ? r.fmt(r.vA) : '—'}</span>
-            </div>
-          </div>
-          <div style="padding:11px 14px;text-align:right;background:#f5f3ff22;">
-            <div style="display:inline-flex;align-items:center;justify-content:flex-end;gap:5px;">
-              ${bWins && hasB ? winBadge : ''}
-              <span style="font-size:19px;font-weight:900;color:${PURPLE};">${hasB ? r.fmt(r.vB) : '—'}</span>
-            </div>
+          <div style="padding:12px 20px;${cellStyleB}">
+            <div style="font-size:28px;font-weight:900;color:${PURPLE};line-height:1.1;${aWins&&!bWins?'opacity:.45;':''}">${hasB ? r.fmt(r.vB) : '—'}</div>
+            ${bWins && hasB ? melhorBadge : ''}
           </div>
         </div>`;
     }).join('');
 
     return `
-      <div style="background:#fff;border-radius:14px;overflow:hidden;margin-bottom:14px;box-shadow:0 2px 10px rgba(0,0,0,.07);">
-        ${sectionTitle ? `<div style="padding:13px 16px;border-bottom:1px solid #f1f5f9;font-size:11px;font-weight:800;color:#1e293b;text-transform:uppercase;letter-spacing:.07em;">${sectionTitle}</div>` : ''}
-        <div style="display:grid;grid-template-columns:190px 1fr 130px 130px;background:#f8fafc;border-bottom:2px solid #e2e8f0;">
-          <div style="padding:8px 14px;font-size:10px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:.07em;border-right:1px solid #e2e8f0;">Métrica</div>
-          <div style="padding:8px 14px;font-size:10px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:.07em;text-align:center;border-right:1px solid #e2e8f0;">Distribuição</div>
-          <div style="padding:8px 14px;font-size:11px;font-weight:800;color:${BLUE};text-align:right;background:#eff6ff;border-right:1px solid #bfdbfe;">${nameA}</div>
-          <div style="padding:8px 14px;font-size:11px;font-weight:800;color:${PURPLE};text-align:right;background:#f5f3ff;">${nameB}</div>
+      <div style="background:#fff;border-radius:14px;overflow:hidden;margin-bottom:14px;box-shadow:0 2px 12px rgba(0,0,0,.08);">
+        ${sectionTitle ? `<div style="padding:13px 18px;border-bottom:2px solid #f1f5f9;font-size:11px;font-weight:800;color:#1e293b;text-transform:uppercase;letter-spacing:.08em;">${sectionTitle}</div>` : ''}
+        <div style="display:grid;grid-template-columns:200px 1fr 1fr;background:#f8fafc;border-bottom:2px solid #e2e8f0;">
+          <div style="padding:9px 16px;font-size:10px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:.07em;border-right:1px solid #e2e8f0;">Métrica</div>
+          <div style="padding:9px 20px;font-size:12px;font-weight:800;color:${BLUE};background:#eff6ff;border-right:1px solid #bfdbfe;">${nameA}</div>
+          <div style="padding:9px 20px;font-size:12px;font-weight:800;color:${PURPLE};background:#f5f3ff;">${nameB}</div>
         </div>
         ${rowsHtml}
       </div>`;


### PR DESCRIPTION
## Summary

- Removes the 4-column layout where the distribution bar (`1fr`) was dominating the screen and squeezing the value columns to 130px (causing truncation like "23h0")
- New layout: **3 columns** — `[200px Metric | 1fr Portal A | 1fr Portal B]` — no bar column
- Values are now **28px bold numbers** with full column width, always fully visible
- Winner indicator: green left border (3px) + `↑ Melhor` badge below the number
- Loser: number dims to 45% opacity for clear visual contrast
- Header row keeps colored backgrounds (blue for A, purple for B)

## Test plan

- [ ] Generate a comparison report for two portals
- [ ] Verify values display in full (e.g. "23h04" not truncated)
- [ ] Verify winner/loser visual indicators (green border + badge vs dimmed)
- [ ] Verify team metrics section renders correctly
- [ ] Verify side-by-side locality/service/motivo cards still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_