### PR TITLE
fix: filtro PHC — só excluir ANULADO e SEM EFEITO

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1163,7 +1163,7 @@ async function startSync() {
   const encColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_encomendas');
   const recColSync = importHeaders.findIndex(h => h.toLowerCase() === 'numeros_rececao_mercadorias');
   const statusColSync = importHeaders.findIndex(h => h.toLowerCase() === 'status');
-  const inactivePhcStatuses = new Set(['RECUSADO', 'ANULADO', 'SEM EFEITO']);
+  const inactivePhcStatuses = new Set(['ANULADO', 'SEM EFEITO']);
 
   const codeToPortal = {};
   portals.forEach(p => { if (p.nmdos_code) codeToPortal[p.nmdos_code] = { id: p.id, type: p.portal_type || 'sm' }; });


### PR DESCRIPTION
## Correção

Filtro PHC corrigido conforme regra definida pelo utilizador:

- **Não importar**: `ANULADO`, `SEM EFEITO`
- **Importar tudo o resto**: RECUSADO, Consulta/Orçamento, Serviço Realizado, ORÇAMENTO, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_