### PR TITLE
feat: horas de exibição configuráveis por campanha

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -441,6 +441,10 @@
           <input type="file" id="campImageFile" accept="image/*" onchange="campAdmin.onImagePick(this)" style="font-size:13px;">
           <div id="campImagePreview" style="margin-top:10px;"></div>
         </div>
+        <div style="margin-bottom:14px;">
+          <label style="display:block;font-size:13px;font-weight:600;margin-bottom:8px;">Horas de exibição <span style="font-weight:400;color:#94a3b8;font-size:12px;">(seleciona uma ou mais; sem seleção usa 9h, 14h e 17h)</span></label>
+          <div id="campHoursGrid" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
+        </div>
         <div style="display:flex;gap:10px;align-items:center;">
           <label style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;">
             <input type="checkbox" id="campActive" checked> Ativa
@@ -836,7 +840,21 @@
   <script>
   (function () {
     var _imageData = null;
+    var _selectedHours = [];
     var _AUTH = window.authClient;
+
+    var CAMP_HOURS = [7,8,9,10,11,12,13,14,15,16,17,18,19,20];
+
+    function _renderHourChips() {
+      var el = document.getElementById('campHoursGrid');
+      if (!el) return;
+      el.innerHTML = CAMP_HOURS.map(function(h) {
+        var sel = _selectedHours.indexOf(h) >= 0;
+        return '<button type="button" onclick="campAdmin._toggleHour(' + h + ')" style="padding:5px 13px;border-radius:20px;border:1.5px solid ' +
+          (sel ? '#2563eb' : '#d1d5db') + ';background:' + (sel ? '#eff6ff' : '#fff') + ';cursor:pointer;font-size:13px;font-weight:' +
+          (sel ? '700' : '500') + ';color:' + (sel ? '#2563eb' : '#374151') + ';">' + h + 'h</button>';
+      }).join('');
+    }
 
     function _fmtDate(d) {
       if (!d) return '—';
@@ -887,7 +905,16 @@
         document.getElementById('campImageFile').value = '';
         document.getElementById('campSaveMsg').textContent = '';
         _imageData = null;
+        _selectedHours = [];
+        _renderHourChips();
         document.getElementById('campForm').style.display = 'block';
+      },
+
+      _toggleHour: function (h) {
+        var idx = _selectedHours.indexOf(h);
+        if (idx >= 0) _selectedHours.splice(idx, 1);
+        else _selectedHours.push(h);
+        _renderHourChips();
       },
 
       closeForm: function () {
@@ -931,7 +958,8 @@
           title: document.getElementById('campTitle').value.trim(),
           start_date: document.getElementById('campStart').value,
           end_date: document.getElementById('campEnd').value,
-          active: document.getElementById('campActive').checked
+          active: document.getElementById('campActive').checked,
+          display_hours: _selectedHours.length ? _selectedHours.slice().sort(function(a,b){return a-b;}).join(',') : null
         };
         if (!body.start_date || !body.end_date) {
           alert('Preenche as datas de início e fim.');
@@ -981,6 +1009,10 @@
             document.getElementById('campSaveMsg').textContent = '';
             document.getElementById('campImageFile').value = '';
             _imageData = null;
+            _selectedHours = c.display_hours
+              ? String(c.display_hours).split(',').map(function(h){return parseInt(h,10);}).filter(function(h){return !isNaN(h);})
+              : [];
+            _renderHourChips();
             var preview = document.getElementById('campImagePreview');
             if (c.image_data) {
               preview.innerHTML = '<img src="' + c.image_data + '" style="max-width:320px;max-height:200px;border-radius:8px;border:1px solid #e2e8f0;margin-top:4px;"><p style="font-size:12px;color:#64748b;margin:4px 0 0;">Carrega um novo ficheiro para substituir a imagem atual.</p>';

--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -1,12 +1,6 @@
 (function () {
   'use strict';
 
-  var SLOTS = [
-    { h: 9,  m: 45, key: 'morning' },
-    { h: 14, m: 45, key: 'afternoon' },
-    { h: 16, m: 0,  key: 'special_1600', onlyDate: '2026-06-19' }
-  ];
-
   var _campaign = null;
 
   function _todayKey() {
@@ -52,9 +46,8 @@
   }
 
   function _scheduleSlot(slot) {
-    if (slot.onlyDate && _todayKey() !== slot.onlyDate) return;
     var now = new Date();
-    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, slot.m, 0, 0);
+    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, 0, 0, 0);
     var ms = fire - now;
 
     if (ms <= 0) {
@@ -74,18 +67,28 @@
     }, ms);
   }
 
+  function _buildSlots() {
+    var hours = null;
+    if (_campaign && _campaign.display_hours) {
+      var parsed = String(_campaign.display_hours).split(',')
+        .map(function (h) { return parseInt(h.trim(), 10); })
+        .filter(function (h) { return !isNaN(h) && h >= 0 && h <= 23; });
+      if (parsed.length > 0) hours = parsed;
+    }
+    // Default slots when no hours defined in campaign
+    if (!hours) hours = [9, 14, 17];
+    return hours.map(function (h) {
+      return { h: h, key: 'h' + h };
+    });
+  }
+
   function _init() {
     fetch('/.netlify/functions/campaign')
       .then(function (r) { return r.json(); })
       .then(function (d) {
         if (!d.success || !d.campaign) return;
         _campaign = d.campaign;
-        SLOTS.forEach(_scheduleSlot);
-        // Disparo imediato pontual (2026-06-19)
-        if (_todayKey() === '2026-06-19' && !_wasShown('special_immediate')) {
-          _markShown('special_immediate');
-          setTimeout(_showModal, 800);
-        }
+        _buildSlots().forEach(_scheduleSlot);
       })
       .catch(function () {});
   }

--- a/netlify/functions/campaign.js
+++ b/netlify/functions/campaign.js
@@ -21,6 +21,7 @@ async function ensureTable(client) {
       created_at TIMESTAMPTZ DEFAULT NOW()
     )
   `);
+  await client.query(`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS display_hours TEXT`);
 }
 
 function verifyAdmin(event) {
@@ -66,7 +67,7 @@ exports.handler = async (event) => {
       // Public: active campaign for today (no auth required)
       const today = new Date().toISOString().slice(0, 10);
       const { rows } = await client.query(
-        `SELECT id, title, start_date, end_date, image_data
+        `SELECT id, title, start_date, end_date, image_data, display_hours
          FROM campaigns
          WHERE active = true AND start_date <= $1 AND end_date >= $1
          ORDER BY created_at DESC LIMIT 1`,
@@ -82,9 +83,9 @@ exports.handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'start_date e end_date são obrigatórios' }) };
       }
       const { rows } = await client.query(
-        `INSERT INTO campaigns (title, start_date, end_date, image_data, active)
-         VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false]
+        `INSERT INTO campaigns (title, start_date, end_date, image_data, active, display_hours)
+         VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false, d.display_hours || null]
       );
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, id: rows[0].id }) };
     }
@@ -97,13 +98,13 @@ exports.handler = async (event) => {
       const hasImage = d.image_data !== undefined;
       if (hasImage) {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5 WHERE id=$6`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5, display_hours=$6 WHERE id=$7`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, d.display_hours || null, id]
         );
       } else {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4 WHERE id=$5`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, display_hours=$5 WHERE id=$6`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.display_hours || null, id]
         );
       }
       return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };


### PR DESCRIPTION
## Funcionalidade

Permite definir as horas em que o pop-up da campanha deve aparecer diretamente no formulário de edição.

## Alterações

**`admin.html`** — chips de hora no formulário:
- Chips clicáveis 7h → 20h (multi-selecção)
- Azul = selecionado, cinzento = não selecionado
- Ao editar uma campanha existente, as horas guardadas são pré-selecionadas

**`netlify/functions/campaign.js`** — nova coluna `display_hours`:
- `ALTER TABLE … ADD COLUMN IF NOT EXISTS display_hours TEXT`
- Guardada como CSV de inteiros: `"9,14,17"`
- Incluída nas queries de POST, PUT e GET público

**`campaign-popup.js`** — slots dinâmicos:
- Lê `campaign.display_hours` e agenda o pop-up às horas definidas
- Fallback para 9h, 14h e 17h se nenhuma hora estiver definida
- Remove os slots fixos e a data especial hardcoded `2026-06-19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_