### PR TITLE
feat: chips de meia hora nas campanhas (7h, 7h30...20h)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -843,16 +843,23 @@
     var _selectedHours = [];
     var _AUTH = window.authClient;
 
-    var CAMP_HOURS = [7,8,9,10,11,12,13,14,15,16,17,18,19,20];
+    var CAMP_SLOTS = (function() {
+      var s = [];
+      for (var h = 7; h <= 20; h++) {
+        s.push({ key: (h<10?'0':'')+h+':00', label: h+'h' });
+        if (h < 20) s.push({ key: (h<10?'0':'')+h+':30', label: h+'h30' });
+      }
+      return s;
+    })();
 
     function _renderHourChips() {
       var el = document.getElementById('campHoursGrid');
       if (!el) return;
-      el.innerHTML = CAMP_HOURS.map(function(h) {
-        var sel = _selectedHours.indexOf(h) >= 0;
-        return '<button type="button" onclick="campAdmin._toggleHour(' + h + ')" style="padding:5px 13px;border-radius:20px;border:1.5px solid ' +
+      el.innerHTML = CAMP_SLOTS.map(function(slot) {
+        var sel = _selectedHours.indexOf(slot.key) >= 0;
+        return '<button type="button" onclick="campAdmin._toggleHour(\'' + slot.key + '\')" style="padding:5px 13px;border-radius:20px;border:1.5px solid ' +
           (sel ? '#2563eb' : '#d1d5db') + ';background:' + (sel ? '#eff6ff' : '#fff') + ';cursor:pointer;font-size:13px;font-weight:' +
-          (sel ? '700' : '500') + ';color:' + (sel ? '#2563eb' : '#374151') + ';">' + h + 'h</button>';
+          (sel ? '700' : '500') + ';color:' + (sel ? '#2563eb' : '#374151') + ';">' + slot.label + '</button>';
       }).join('');
     }
 
@@ -959,7 +966,7 @@
           start_date: document.getElementById('campStart').value,
           end_date: document.getElementById('campEnd').value,
           active: document.getElementById('campActive').checked,
-          display_hours: _selectedHours.length ? _selectedHours.slice().sort(function(a,b){return a-b;}).join(',') : null
+          display_hours: _selectedHours.length ? _selectedHours.slice().sort().join(',') : null
         };
         if (!body.start_date || !body.end_date) {
           alert('Preenche as datas de início e fim.');
@@ -1010,7 +1017,12 @@
             document.getElementById('campImageFile').value = '';
             _imageData = null;
             _selectedHours = c.display_hours
-              ? String(c.display_hours).split(',').map(function(h){return parseInt(h,10);}).filter(function(h){return !isNaN(h);})
+              ? String(c.display_hours).split(',').map(function(s) {
+                  s = s.trim();
+                  // Convert legacy integer format "9" → "09:00"
+                  if (/^\d+$/.test(s)) return (s.length===1?'0':'')+s+':00';
+                  return s;
+                }).filter(Boolean)
               : [];
             _renderHourChips();
             var preview = document.getElementById('campImagePreview');

--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -68,18 +68,28 @@
   }
 
   function _buildSlots() {
-    var hours = null;
+    var slots = null;
     if (_campaign && _campaign.display_hours) {
-      var parsed = String(_campaign.display_hours).split(',')
-        .map(function (h) { return parseInt(h.trim(), 10); })
-        .filter(function (h) { return !isNaN(h) && h >= 0 && h <= 23; });
-      if (parsed.length > 0) hours = parsed;
+      var parsed = String(_campaign.display_hours).split(',').map(function (s) {
+        s = s.trim();
+        // Legacy integer format "9" → h:9 m:0
+        if (/^\d+$/.test(s)) {
+          var h = parseInt(s, 10);
+          return isNaN(h) ? null : { h: h, m: 0, key: 'h' + h + 'm0' };
+        }
+        // HH:MM format "09:30"
+        var parts = s.split(':');
+        if (parts.length === 2) {
+          var hh = parseInt(parts[0], 10), mm = parseInt(parts[1], 10);
+          if (!isNaN(hh) && !isNaN(mm)) return { h: hh, m: mm, key: 'h' + hh + 'm' + mm };
+        }
+        return null;
+      }).filter(Boolean);
+      if (parsed.length > 0) slots = parsed;
     }
     // Default slots when no hours defined in campaign
-    if (!hours) hours = [9, 14, 17];
-    return hours.map(function (h) {
-      return { h: h, key: 'h' + h };
-    });
+    if (!slots) slots = [{ h: 9, m: 0, key: 'h9m0' }, { h: 14, m: 0, key: 'h14m0' }, { h: 17, m: 0, key: 'h17m0' }];
+    return slots;
   }
 
   function _init() {


### PR DESCRIPTION
## Alteração

Adiciona meias horas ao picker de horas das campanhas.

O seletor passa de 14 chips (7h–20h inteiros) para 27 chips em intervalos de 30 minutos: **7h, 7h30, 8h, 8h30, … 20h**.

O formato de armazenamento muda de CSV de inteiros (`"9,14,17"`) para CSV de `HH:MM` (`"09:00,09:30,14:00"`). O `campaign-popup.js` mantém retrocompatibilidade com o formato antigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_