### PR TITLE
feat: campanha interativa — popup Sim/Não ao marcar serviço realizado

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -422,6 +422,17 @@
       <div id="campForm" style="display:none;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:20px;margin-bottom:24px;">
         <h3 style="margin:0 0 16px;font-size:16px;">Campanha</h3>
         <input type="hidden" id="campId">
+        <input type="hidden" id="campType" value="horaria">
+        <div style="margin-bottom:14px;">
+          <label style="display:block;font-size:13px;font-weight:600;margin-bottom:8px;">Tipo de campanha</label>
+          <div style="display:inline-flex;border:1.5px solid #d1d5db;border-radius:8px;overflow:hidden;">
+            <button type="button" id="campTypeBtnHoraria" onclick="campAdmin._setType('horaria')"
+              style="padding:7px 18px;border:none;background:#2563eb;color:#fff;font-size:13px;font-weight:700;cursor:pointer;">⏰ Horária</button>
+            <button type="button" id="campTypeBtnInterativa" onclick="campAdmin._setType('interativa')"
+              style="padding:7px 18px;border:none;background:#fff;color:#374151;font-size:13px;font-weight:500;cursor:pointer;">👆 Interativa</button>
+          </div>
+          <p id="campTypeDesc" style="margin:6px 0 0;font-size:12px;color:#64748b;">Aparece automaticamente nas horas definidas.</p>
+        </div>
         <div style="display:grid;grid-template-columns:1fr 1fr 2fr;gap:12px;margin-bottom:12px;align-items:end;">
           <div>
             <label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Início *</label>
@@ -441,7 +452,7 @@
           <input type="file" id="campImageFile" accept="image/*" onchange="campAdmin.onImagePick(this)" style="font-size:13px;">
           <div id="campImagePreview" style="margin-top:10px;"></div>
         </div>
-        <div style="margin-bottom:14px;">
+        <div id="campHoursSection" style="margin-bottom:14px;">
           <label style="display:block;font-size:13px;font-weight:600;margin-bottom:8px;">Horas de exibição <span style="font-weight:400;color:#94a3b8;font-size:12px;">(seleciona uma ou mais; sem seleção usa 9h, 14h e 17h)</span></label>
           <div id="campHoursGrid" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
         </div>
@@ -902,6 +913,17 @@
     }
 
     window.campAdmin = {
+      _setType: function (t) {
+        document.getElementById('campType').value = t;
+        var isH = t === 'horaria';
+        document.getElementById('campTypeBtnHoraria').style.cssText = 'padding:7px 18px;border:none;cursor:pointer;font-size:13px;font-weight:' + (isH?'700':'500') + ';background:' + (isH?'#2563eb':'#fff') + ';color:' + (isH?'#fff':'#374151') + ';';
+        document.getElementById('campTypeBtnInterativa').style.cssText = 'padding:7px 18px;border:none;cursor:pointer;font-size:13px;font-weight:' + (!isH?'700':'500') + ';background:' + (!isH?'#7c3aed':'#fff') + ';color:' + (!isH?'#fff':'#374151') + ';';
+        document.getElementById('campTypeDesc').textContent = isH
+          ? 'Aparece automaticamente nas horas definidas.'
+          : 'Aparece quando um técnico/admin clica em "Serviço Realizado".';
+        document.getElementById('campHoursSection').style.display = isH ? '' : 'none';
+      },
+
       openForm: function () {
         document.getElementById('campId').value = '';
         document.getElementById('campTitle').value = '';
@@ -914,6 +936,7 @@
         _imageData = null;
         _selectedHours = [];
         _renderHourChips();
+        campAdmin._setType('horaria');
         document.getElementById('campForm').style.display = 'block';
       },
 
@@ -961,12 +984,14 @@
 
       save: function () {
         var id = document.getElementById('campId').value;
+        var campType = document.getElementById('campType').value || 'horaria';
         var body = {
           title: document.getElementById('campTitle').value.trim(),
           start_date: document.getElementById('campStart').value,
           end_date: document.getElementById('campEnd').value,
           active: document.getElementById('campActive').checked,
-          display_hours: _selectedHours.length ? _selectedHours.slice().sort().join(',') : null
+          campaign_type: campType,
+          display_hours: campType === 'horaria' && _selectedHours.length ? _selectedHours.slice().sort().join(',') : null
         };
         if (!body.start_date || !body.end_date) {
           alert('Preenche as datas de início e fim.');
@@ -1019,12 +1044,12 @@
             _selectedHours = c.display_hours
               ? String(c.display_hours).split(',').map(function(s) {
                   s = s.trim();
-                  // Convert legacy integer format "9" → "09:00"
                   if (/^\d+$/.test(s)) return (s.length===1?'0':'')+s+':00';
                   return s;
                 }).filter(Boolean)
               : [];
             _renderHourChips();
+            campAdmin._setType(c.campaign_type || 'horaria');
             var preview = document.getElementById('campImagePreview');
             if (c.image_data) {
               preview.innerHTML = '<img src="' + c.image_data + '" style="max-width:320px;max-height:200px;border-radius:8px;border:1px solid #e2e8f0;margin-top:4px;"><p style="font-size:12px;color:#64748b;margin:4px 0 0;">Carrega um novo ficheiro para substituir a imagem atual.</p>';

--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -25,6 +25,7 @@
     } catch (e) {}
   }
 
+  // ── Modal horária (só imagem + fechar) ───────────────────────────────────
   function _showModal() {
     if (!_campaign || !_campaign.image_data) return;
     var modal = document.getElementById('campaignPopupModal');
@@ -32,26 +33,58 @@
       modal = document.createElement('div');
       modal.id = 'campaignPopupModal';
       modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
-      modal.innerHTML =
-        '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
-          '<button id="campPopClose" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
-          '<img id="campPopImg" src="" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;">' +
-        '</div>';
       document.body.appendChild(modal);
-      modal.querySelector('#campPopClose').addEventListener('click', function () { modal.style.display = 'none'; });
       modal.addEventListener('click', function (e) { if (e.target === modal) modal.style.display = 'none'; });
     }
-    modal.querySelector('#campPopImg').src = _campaign.image_data;
+    modal.innerHTML =
+      '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
+        '<button id="campPopClose" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
+        '<img src="' + _campaign.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;">' +
+      '</div>';
+    modal.querySelector('#campPopClose').addEventListener('click', function () { modal.style.display = 'none'; });
     modal.style.display = 'flex';
   }
 
+  // ── Modal interativa (imagem + Sim / Não) ────────────────────────────────
+  function _showInteractiveModal(onSim, onNao) {
+    if (!_campaign || !_campaign.image_data) {
+      // Sem campanha ativa — executar diretamente com emojis normais
+      if (onSim) onSim();
+      return;
+    }
+    var modal = document.getElementById('campaignPopupModal');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.id = 'campaignPopupModal';
+      modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
+      document.body.appendChild(modal);
+    }
+    modal.innerHTML =
+      '<div style="position:relative;max-width:540px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);background:#fff;">' +
+        '<img src="' + _campaign.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:60vh;object-fit:contain;background:#000;">' +
+        '<div style="padding:18px 20px;display:flex;gap:12px;">' +
+          '<button id="campPopSim" style="flex:1;background:#16a34a;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👍 Sim</button>' +
+          '<button id="campPopNao" style="flex:1;background:#dc2626;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👎 Não</button>' +
+        '</div>' +
+      '</div>';
+    modal.querySelector('#campPopSim').addEventListener('click', function () {
+      modal.style.display = 'none';
+      if (onSim) onSim();
+    });
+    modal.querySelector('#campPopNao').addEventListener('click', function () {
+      modal.style.display = 'none';
+      if (onNao) onNao();
+    });
+    modal.style.display = 'flex';
+  }
+
+  // ── Slots horários ───────────────────────────────────────────────────────
   function _scheduleSlot(slot) {
     var now = new Date();
-    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, 0, 0, 0);
+    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, slot.m, 0, 0);
     var ms = fire - now;
 
     if (ms <= 0) {
-      // Already past — show if within last 30 min and not yet shown
       if (ms > -30 * 60 * 1000 && !_wasShown(slot.key)) {
         _markShown(slot.key);
         _showModal();
@@ -72,12 +105,10 @@
     if (_campaign && _campaign.display_hours) {
       var parsed = String(_campaign.display_hours).split(',').map(function (s) {
         s = s.trim();
-        // Legacy integer format "9" → h:9 m:0
         if (/^\d+$/.test(s)) {
           var h = parseInt(s, 10);
           return isNaN(h) ? null : { h: h, m: 0, key: 'h' + h + 'm0' };
         }
-        // HH:MM format "09:30"
         var parts = s.split(':');
         if (parts.length === 2) {
           var hh = parseInt(parts[0], 10), mm = parseInt(parts[1], 10);
@@ -87,18 +118,27 @@
       }).filter(Boolean);
       if (parsed.length > 0) slots = parsed;
     }
-    // Default slots when no hours defined in campaign
     if (!slots) slots = [{ h: 9, m: 0, key: 'h9m0' }, { h: 14, m: 0, key: 'h14m0' }, { h: 17, m: 0, key: 'h17m0' }];
     return slots;
   }
 
+  // ── Init ─────────────────────────────────────────────────────────────────
   function _init() {
     fetch('/.netlify/functions/campaign')
       .then(function (r) { return r.json(); })
       .then(function (d) {
         if (!d.success || !d.campaign) return;
         _campaign = d.campaign;
-        _buildSlots().forEach(_scheduleSlot);
+
+        if (_campaign.campaign_type === 'interativa') {
+          // Expor função para script.js usar quando clicam em "Serviço Realizado"
+          window._showInteractiveCampaign = function (onSim, onNao) {
+            _showInteractiveModal(onSim, onNao);
+          };
+        } else {
+          // Horária: agendar slots normais
+          _buildSlots().forEach(_scheduleSlot);
+        }
       })
       .catch(function () {});
   }

--- a/netlify/functions/campaign.js
+++ b/netlify/functions/campaign.js
@@ -22,6 +22,7 @@ async function ensureTable(client) {
     )
   `);
   await client.query(`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS display_hours TEXT`);
+  await client.query(`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS campaign_type TEXT NOT NULL DEFAULT 'horaria'`);
 }
 
 function verifyAdmin(event) {
@@ -67,7 +68,7 @@ exports.handler = async (event) => {
       // Public: active campaign for today (no auth required)
       const today = new Date().toISOString().slice(0, 10);
       const { rows } = await client.query(
-        `SELECT id, title, start_date, end_date, image_data, display_hours
+        `SELECT id, title, start_date, end_date, image_data, display_hours, campaign_type
          FROM campaigns
          WHERE active = true AND start_date <= $1 AND end_date >= $1
          ORDER BY created_at DESC LIMIT 1`,
@@ -83,9 +84,9 @@ exports.handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'start_date e end_date são obrigatórios' }) };
       }
       const { rows } = await client.query(
-        `INSERT INTO campaigns (title, start_date, end_date, image_data, active, display_hours)
-         VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false, d.display_hours || null]
+        `INSERT INTO campaigns (title, start_date, end_date, image_data, active, display_hours, campaign_type)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false, d.display_hours || null, d.campaign_type || 'horaria']
       );
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, id: rows[0].id }) };
     }
@@ -98,13 +99,13 @@ exports.handler = async (event) => {
       const hasImage = d.image_data !== undefined;
       if (hasImage) {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5, display_hours=$6 WHERE id=$7`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, d.display_hours || null, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5, display_hours=$6, campaign_type=$7 WHERE id=$8`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, d.display_hours || null, d.campaign_type || 'horaria', id]
         );
       } else {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, display_hours=$5 WHERE id=$6`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, d.display_hours || null, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, display_hours=$5, campaign_type=$6 WHERE id=$7`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.display_hours || null, d.campaign_type || 'horaria', id]
         );
       }
       return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };

--- a/script.js
+++ b/script.js
@@ -2047,7 +2047,7 @@ async function enforceSingleSecondOfDay(newId, date) {
   if (others.length > 0) renderAll();
 }
 
-async function _doSaveExecuted(id, executed, reason) {
+async function _doSaveExecuted(id, executed, reason, sadEmojis) {
   const i = appointments.findIndex(a => String(a.id) === String(id));
   if (i < 0) return;
   const prev = { executed: appointments[i].executed, not_done_reason: appointments[i].not_done_reason, glass_removed: appointments[i].glass_removed, glass_removed_date: appointments[i].glass_removed_date };
@@ -2059,7 +2059,8 @@ async function _doSaveExecuted(id, executed, reason) {
     appointments[i].glass_removed_date = null;
   }
   renderAll();
-  if (executed === true) fireRealizadoEmojis(); else if (executed === false) fireNaoRealizadoEmojis();
+  if (executed === true) { sadEmojis ? fireNaoRealizadoEmojis() : fireRealizadoEmojis(); }
+  else if (executed === false) fireNaoRealizadoEmojis();
   try {
     await window.apiClient.updateAppointment(id, { ...appointments[i], executed, not_done_reason: reason || null });
 
@@ -2096,6 +2097,14 @@ async function persistExecuted(id, executed) {
   }
   if (!executed) {
     openNotDoneModal(id);
+    return;
+  }
+  // Campanha interativa: mostrar popup com Sim/Não antes de gravar
+  if (window._showInteractiveCampaign) {
+    window._showInteractiveCampaign(
+      async function () { await _doSaveExecuted(id, true, null, false); },  // Sim → emojis alegres
+      async function () { await _doSaveExecuted(id, true, null, true); }    // Não → emojis tristes
+    );
     return;
   }
   await _doSaveExecuted(id, true, null);


### PR DESCRIPTION
## Funcionalidade

Duas tipologias de campanha configuráveis no painel de admin:

### ⏰ Horária (existente)
Aparece automaticamente nas horas definidas no picker.

### 👆 Interativa (nova)
Aparece quando qualquer utilizador (técnico, admin, coordenador) clica em **"Serviço Realizado"**.

**Comportamento:**
- Pop-up com a imagem da campanha + botões **Sim** e **Não**
- Ambos marcam o serviço como realizado
- **Sim** → emojis alegres (🎉 ✅ 🏆…)
- **Não** → emojis tristes (😢 💔 😞…)

## Alterações

- **`netlify/functions/campaign.js`**: nova coluna `campaign_type TEXT DEFAULT 'horaria'`
- **`admin.html`**: seletor de tipo (segmented control); horas ficam ocultas no modo Interativa
- **`campaign-popup.js`**: expõe `window._showInteractiveCampaign(onSim, onNao)` quando o tipo é interativa; não agenda slots de hora
- **`script.js`**: `persistExecuted` verifica `window._showInteractiveCampaign` antes de executar; `_doSaveExecuted` aceita parâmetro `sadEmojis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_