### PR TITLE
feat: vendas complementares – banner escovas + campeã nacional

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -902,7 +902,9 @@
                   ? '<span style="background:#fef9c3;color:#854d0e;font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;">Agendada</span>'
                   : '<span style="background:#f1f5f9;color:#94a3b8;font-size:11px;font-weight:700;padding:2px 8px;border-radius:6px;">Inativa</span>');
               return '<tr><td>' + (c.title || '—') + '</td><td>' + _fmtDate(c.start_date) + '</td><td>' + _fmtDate(c.end_date) + '</td><td>' + badge + '</td>' +
-                '<td style="white-space:nowrap;"><button onclick="campAdmin.edit(' + c.id + ')" style="background:#1e40af;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;margin-right:4px;">Editar</button>' +
+                '<td style="white-space:nowrap;">' +
+                '<button onclick="campAdmin.preview(' + c.id + ')" style="background:#7c3aed;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;margin-right:4px;">▶ Pré-visualizar</button>' +
+                '<button onclick="campAdmin.edit(' + c.id + ')" style="background:#1e40af;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;margin-right:4px;">Editar</button>' +
                 '<button onclick="campAdmin.del(' + c.id + ')" style="background:#dc2626;color:#fff;border:none;padding:5px 12px;border-radius:6px;font-size:12px;cursor:pointer;">Eliminar</button></td></tr>';
             }).join('') +
           '</tbody></table>';
@@ -1057,6 +1059,54 @@
               preview.innerHTML = '';
             }
             document.getElementById('campForm').style.display = 'block';
+          })
+          .catch(function (e) { alert('Erro: ' + e.message); });
+      },
+
+      preview: function (id) {
+        _AUTH.authenticatedFetch('/.netlify/functions/campaign?id=' + id)
+          .then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (!d.success || !d.campaign || !d.campaign.image_data) {
+              alert('Esta campanha não tem imagem definida.');
+              return;
+            }
+            var camp = d.campaign;
+            var secs = 5;
+            var toast = document.createElement('div');
+            toast.style.cssText = 'position:fixed;bottom:28px;left:50%;transform:translateX(-50%);background:#1e293b;color:#fff;padding:12px 28px;border-radius:12px;font-size:14px;font-weight:700;z-index:99998;pointer-events:none;';
+            toast.textContent = 'A abrir pré-visualização em ' + secs + 's…';
+            document.body.appendChild(toast);
+            var iv = setInterval(function () {
+              secs--;
+              if (secs > 0) { toast.textContent = 'A abrir pré-visualização em ' + secs + 's…'; }
+              else {
+                clearInterval(iv);
+                toast.remove();
+                var modal = document.getElementById('campPreviewModal');
+                if (!modal) {
+                  modal = document.createElement('div');
+                  modal.id = 'campPreviewModal';
+                  modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
+                  document.body.appendChild(modal);
+                  modal.addEventListener('click', function (e) { if (e.target === modal) modal.style.display = 'none'; });
+                }
+                var close = 'document.getElementById(\'campPreviewModal\').style.display=\'none\'';
+                if (camp.campaign_type === 'interativa') {
+                  modal.innerHTML = '<div style="position:relative;max-width:540px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);background:#fff;">' +
+                    '<img src="' + camp.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:60vh;object-fit:contain;background:#000;">' +
+                    '<div style="padding:18px 20px;display:flex;gap:12px;">' +
+                      '<button onclick="' + close + '" style="flex:1;background:#16a34a;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👍 Sim</button>' +
+                      '<button onclick="' + close + '" style="flex:1;background:#dc2626;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👎 Não</button>' +
+                    '</div></div>';
+                } else {
+                  modal.innerHTML = '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
+                    '<button onclick="' + close + '" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
+                    '<img src="' + camp.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;"></div>';
+                }
+                modal.style.display = 'flex';
+              }
+            }, 1000);
           })
           .catch(function (e) { alert('Erro: ' + e.message); });
       },

--- a/admin.html
+++ b/admin.html
@@ -422,6 +422,17 @@
       <div id="campForm" style="display:none;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:20px;margin-bottom:24px;">
         <h3 style="margin:0 0 16px;font-size:16px;">Campanha</h3>
         <input type="hidden" id="campId">
+        <input type="hidden" id="campType" value="horaria">
+        <div style="margin-bottom:14px;">
+          <label style="display:block;font-size:13px;font-weight:600;margin-bottom:8px;">Tipo de campanha</label>
+          <div style="display:inline-flex;border:1.5px solid #d1d5db;border-radius:8px;overflow:hidden;">
+            <button type="button" id="campTypeBtnHoraria" onclick="campAdmin._setType('horaria')"
+              style="padding:7px 18px;border:none;background:#2563eb;color:#fff;font-size:13px;font-weight:700;cursor:pointer;">⏰ Horária</button>
+            <button type="button" id="campTypeBtnInterativa" onclick="campAdmin._setType('interativa')"
+              style="padding:7px 18px;border:none;background:#fff;color:#374151;font-size:13px;font-weight:500;cursor:pointer;">👆 Interativa</button>
+          </div>
+          <p id="campTypeDesc" style="margin:6px 0 0;font-size:12px;color:#64748b;">Aparece automaticamente nas horas definidas.</p>
+        </div>
         <div style="display:grid;grid-template-columns:1fr 1fr 2fr;gap:12px;margin-bottom:12px;align-items:end;">
           <div>
             <label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Início *</label>
@@ -441,7 +452,7 @@
           <input type="file" id="campImageFile" accept="image/*" onchange="campAdmin.onImagePick(this)" style="font-size:13px;">
           <div id="campImagePreview" style="margin-top:10px;"></div>
         </div>
-        <div style="margin-bottom:14px;">
+        <div id="campHoursSection" style="margin-bottom:14px;">
           <label style="display:block;font-size:13px;font-weight:600;margin-bottom:8px;">Horas de exibição <span style="font-weight:400;color:#94a3b8;font-size:12px;">(seleciona uma ou mais; sem seleção usa 9h, 14h e 17h)</span></label>
           <div id="campHoursGrid" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
         </div>
@@ -902,6 +913,17 @@
     }
 
     window.campAdmin = {
+      _setType: function (t) {
+        document.getElementById('campType').value = t;
+        var isH = t === 'horaria';
+        document.getElementById('campTypeBtnHoraria').style.cssText = 'padding:7px 18px;border:none;cursor:pointer;font-size:13px;font-weight:' + (isH?'700':'500') + ';background:' + (isH?'#2563eb':'#fff') + ';color:' + (isH?'#fff':'#374151') + ';';
+        document.getElementById('campTypeBtnInterativa').style.cssText = 'padding:7px 18px;border:none;cursor:pointer;font-size:13px;font-weight:' + (!isH?'700':'500') + ';background:' + (!isH?'#7c3aed':'#fff') + ';color:' + (!isH?'#fff':'#374151') + ';';
+        document.getElementById('campTypeDesc').textContent = isH
+          ? 'Aparece automaticamente nas horas definidas.'
+          : 'Aparece quando um técnico/admin clica em "Serviço Realizado".';
+        document.getElementById('campHoursSection').style.display = isH ? '' : 'none';
+      },
+
       openForm: function () {
         document.getElementById('campId').value = '';
         document.getElementById('campTitle').value = '';
@@ -914,6 +936,7 @@
         _imageData = null;
         _selectedHours = [];
         _renderHourChips();
+        campAdmin._setType('horaria');
         document.getElementById('campForm').style.display = 'block';
       },
 
@@ -961,12 +984,14 @@
 
       save: function () {
         var id = document.getElementById('campId').value;
+        var campType = document.getElementById('campType').value || 'horaria';
         var body = {
           title: document.getElementById('campTitle').value.trim(),
           start_date: document.getElementById('campStart').value,
           end_date: document.getElementById('campEnd').value,
           active: document.getElementById('campActive').checked,
-          display_hours: _selectedHours.length ? _selectedHours.slice().sort().join(',') : null
+          campaign_type: campType,
+          display_hours: campType === 'horaria' && _selectedHours.length ? _selectedHours.slice().sort().join(',') : null
         };
         if (!body.start_date || !body.end_date) {
           alert('Preenche as datas de início e fim.');
@@ -1019,12 +1044,12 @@
             _selectedHours = c.display_hours
               ? String(c.display_hours).split(',').map(function(s) {
                   s = s.trim();
-                  // Convert legacy integer format "9" → "09:00"
                   if (/^\d+$/.test(s)) return (s.length===1?'0':'')+s+':00';
                   return s;
                 }).filter(Boolean)
               : [];
             _renderHourChips();
+            campAdmin._setType(c.campaign_type || 'horaria');
             var preview = document.getElementById('campImagePreview');
             if (c.image_data) {
               preview.innerHTML = '<img src="' + c.image_data + '" style="max-width:320px;max-height:200px;border-radius:8px;border:1px solid #e2e8f0;margin-top:4px;"><p style="font-size:12px;color:#64748b;margin:4px 0 0;">Carrega um novo ficheiro para substituir a imagem atual.</p>';

--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -25,6 +25,7 @@
     } catch (e) {}
   }
 
+  // ── Modal horária (só imagem + fechar) ───────────────────────────────────
   function _showModal() {
     if (!_campaign || !_campaign.image_data) return;
     var modal = document.getElementById('campaignPopupModal');
@@ -32,26 +33,58 @@
       modal = document.createElement('div');
       modal.id = 'campaignPopupModal';
       modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
-      modal.innerHTML =
-        '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
-          '<button id="campPopClose" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
-          '<img id="campPopImg" src="" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;">' +
-        '</div>';
       document.body.appendChild(modal);
-      modal.querySelector('#campPopClose').addEventListener('click', function () { modal.style.display = 'none'; });
       modal.addEventListener('click', function (e) { if (e.target === modal) modal.style.display = 'none'; });
     }
-    modal.querySelector('#campPopImg').src = _campaign.image_data;
+    modal.innerHTML =
+      '<div style="position:relative;max-width:640px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);">' +
+        '<button id="campPopClose" style="position:absolute;top:10px;right:10px;z-index:10;background:rgba(0,0,0,0.55);color:#fff;border:none;width:34px;height:34px;border-radius:50%;font-size:19px;line-height:34px;text-align:center;cursor:pointer;font-weight:700;">✕</button>' +
+        '<img src="' + _campaign.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:88vh;object-fit:contain;background:#000;">' +
+      '</div>';
+    modal.querySelector('#campPopClose').addEventListener('click', function () { modal.style.display = 'none'; });
     modal.style.display = 'flex';
   }
 
+  // ── Modal interativa (imagem + Sim / Não) ────────────────────────────────
+  function _showInteractiveModal(onSim, onNao) {
+    if (!_campaign || !_campaign.image_data) {
+      // Sem campanha ativa — executar diretamente com emojis normais
+      if (onSim) onSim();
+      return;
+    }
+    var modal = document.getElementById('campaignPopupModal');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.id = 'campaignPopupModal';
+      modal.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.78);padding:16px;box-sizing:border-box;';
+      document.body.appendChild(modal);
+    }
+    modal.innerHTML =
+      '<div style="position:relative;max-width:540px;width:100%;border-radius:16px;overflow:hidden;box-shadow:0 24px 64px rgba(0,0,0,0.7);background:#fff;">' +
+        '<img src="' + _campaign.image_data + '" alt="Campanha" style="width:100%;display:block;max-height:60vh;object-fit:contain;background:#000;">' +
+        '<div style="padding:18px 20px;display:flex;gap:12px;">' +
+          '<button id="campPopSim" style="flex:1;background:#16a34a;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👍 Sim</button>' +
+          '<button id="campPopNao" style="flex:1;background:#dc2626;color:#fff;border:none;border-radius:10px;padding:13px;font-size:15px;font-weight:800;cursor:pointer;">👎 Não</button>' +
+        '</div>' +
+      '</div>';
+    modal.querySelector('#campPopSim').addEventListener('click', function () {
+      modal.style.display = 'none';
+      if (onSim) onSim();
+    });
+    modal.querySelector('#campPopNao').addEventListener('click', function () {
+      modal.style.display = 'none';
+      if (onNao) onNao();
+    });
+    modal.style.display = 'flex';
+  }
+
+  // ── Slots horários ───────────────────────────────────────────────────────
   function _scheduleSlot(slot) {
     var now = new Date();
-    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, 0, 0, 0);
+    var fire = new Date(now.getFullYear(), now.getMonth(), now.getDate(), slot.h, slot.m, 0, 0);
     var ms = fire - now;
 
     if (ms <= 0) {
-      // Already past — show if within last 30 min and not yet shown
       if (ms > -30 * 60 * 1000 && !_wasShown(slot.key)) {
         _markShown(slot.key);
         _showModal();
@@ -72,12 +105,10 @@
     if (_campaign && _campaign.display_hours) {
       var parsed = String(_campaign.display_hours).split(',').map(function (s) {
         s = s.trim();
-        // Legacy integer format "9" → h:9 m:0
         if (/^\d+$/.test(s)) {
           var h = parseInt(s, 10);
           return isNaN(h) ? null : { h: h, m: 0, key: 'h' + h + 'm0' };
         }
-        // HH:MM format "09:30"
         var parts = s.split(':');
         if (parts.length === 2) {
           var hh = parseInt(parts[0], 10), mm = parseInt(parts[1], 10);
@@ -87,18 +118,27 @@
       }).filter(Boolean);
       if (parsed.length > 0) slots = parsed;
     }
-    // Default slots when no hours defined in campaign
     if (!slots) slots = [{ h: 9, m: 0, key: 'h9m0' }, { h: 14, m: 0, key: 'h14m0' }, { h: 17, m: 0, key: 'h17m0' }];
     return slots;
   }
 
+  // ── Init ─────────────────────────────────────────────────────────────────
   function _init() {
     fetch('/.netlify/functions/campaign')
       .then(function (r) { return r.json(); })
       .then(function (d) {
         if (!d.success || !d.campaign) return;
         _campaign = d.campaign;
-        _buildSlots().forEach(_scheduleSlot);
+
+        if (_campaign.campaign_type === 'interativa') {
+          // Expor função para script.js usar quando clicam em "Serviço Realizado"
+          window._showInteractiveCampaign = function (onSim, onNao) {
+            _showInteractiveModal(onSim, onNao);
+          };
+        } else {
+          // Horária: agendar slots normais
+          _buildSlots().forEach(_scheduleSlot);
+        }
       })
       .catch(function () {});
   }

--- a/netlify/functions/campaign.js
+++ b/netlify/functions/campaign.js
@@ -22,6 +22,7 @@ async function ensureTable(client) {
     )
   `);
   await client.query(`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS display_hours TEXT`);
+  await client.query(`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS campaign_type TEXT NOT NULL DEFAULT 'horaria'`);
 }
 
 function verifyAdmin(event) {
@@ -67,7 +68,7 @@ exports.handler = async (event) => {
       // Public: active campaign for today (no auth required)
       const today = new Date().toISOString().slice(0, 10);
       const { rows } = await client.query(
-        `SELECT id, title, start_date, end_date, image_data, display_hours
+        `SELECT id, title, start_date, end_date, image_data, display_hours, campaign_type
          FROM campaigns
          WHERE active = true AND start_date <= $1 AND end_date >= $1
          ORDER BY created_at DESC LIMIT 1`,
@@ -83,9 +84,9 @@ exports.handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'start_date e end_date são obrigatórios' }) };
       }
       const { rows } = await client.query(
-        `INSERT INTO campaigns (title, start_date, end_date, image_data, active, display_hours)
-         VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false, d.display_hours || null]
+        `INSERT INTO campaigns (title, start_date, end_date, image_data, active, display_hours, campaign_type)
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+        [d.title || '', d.start_date, d.end_date, d.image_data || null, d.active !== false, d.display_hours || null, d.campaign_type || 'horaria']
       );
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, id: rows[0].id }) };
     }
@@ -98,13 +99,13 @@ exports.handler = async (event) => {
       const hasImage = d.image_data !== undefined;
       if (hasImage) {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5, display_hours=$6 WHERE id=$7`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, d.display_hours || null, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, image_data=$5, display_hours=$6, campaign_type=$7 WHERE id=$8`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.image_data, d.display_hours || null, d.campaign_type || 'horaria', id]
         );
       } else {
         await client.query(
-          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, display_hours=$5 WHERE id=$6`,
-          [d.title || '', d.start_date, d.end_date, d.active !== false, d.display_hours || null, id]
+          `UPDATE campaigns SET title=$1, start_date=$2, end_date=$3, active=$4, display_hours=$5, campaign_type=$6 WHERE id=$7`,
+          [d.title || '', d.start_date, d.end_date, d.active !== false, d.display_hours || null, d.campaign_type || 'horaria', id]
         );
       }
       return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };

--- a/netlify/functions/powering-kpis.js
+++ b/netlify/functions/powering-kpis.js
@@ -64,23 +64,22 @@ exports.handler = async (event) => {
       return { statusCode: 200, headers, body: JSON.stringify({ total: lojas.length, lojas }) };
     }
 
-    // Vendas complementares
+    // Vendas complementares — devolve TODAS as lojas + lojaId da loja atual
+    // O frontend usa lojaId para filtrar a loja corrente e calcular a campeã nacional
     if (p.action === 'vendas-complementares') {
       const now2 = new Date();
       const mes = parseInt(p.mes || now2.getMonth() + 1);
       const ano = parseInt(p.ano || now2.getFullYear());
-      let lojaIdFiltro = p.loja_id ? parseInt(p.loja_id) : null;
-      if (!lojaIdFiltro && p.portal_id) {
+      let lojaId = p.loja_id ? parseInt(p.loja_id) : null;
+      if (!lojaId && p.portal_id) {
         const { rows } = await pool.query(
           'SELECT powering_loja_id FROM portals WHERE id = $1 LIMIT 1',
           [parseInt(p.portal_id)]
         );
-        lojaIdFiltro = rows[0]?.powering_loja_id ?? null;
+        lojaId = rows[0]?.powering_loja_id ?? null;
       }
-      let path = `/vendas-complementares?mes=${mes}&ano=${ano}`;
-      if (lojaIdFiltro) path += `&lojaId=${lojaIdFiltro}`;
-      const data = await fetchPowering(path);
-      return { statusCode: 200, headers, body: JSON.stringify({ success: true, mes, ano, ...data }) };
+      const data = await fetchPowering(`/vendas-complementares?mes=${mes}&ano=${ano}`);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, mes, ano, lojaId, ...data }) };
     }
 
     const now = new Date();

--- a/netlify/functions/powering-kpis.js
+++ b/netlify/functions/powering-kpis.js
@@ -64,6 +64,25 @@ exports.handler = async (event) => {
       return { statusCode: 200, headers, body: JSON.stringify({ total: lojas.length, lojas }) };
     }
 
+    // Vendas complementares
+    if (p.action === 'vendas-complementares') {
+      const now2 = new Date();
+      const mes = parseInt(p.mes || now2.getMonth() + 1);
+      const ano = parseInt(p.ano || now2.getFullYear());
+      let lojaIdFiltro = p.loja_id ? parseInt(p.loja_id) : null;
+      if (!lojaIdFiltro && p.portal_id) {
+        const { rows } = await pool.query(
+          'SELECT powering_loja_id FROM portals WHERE id = $1 LIMIT 1',
+          [parseInt(p.portal_id)]
+        );
+        lojaIdFiltro = rows[0]?.powering_loja_id ?? null;
+      }
+      let path = `/vendas-complementares?mes=${mes}&ano=${ano}`;
+      if (lojaIdFiltro) path += `&lojaId=${lojaIdFiltro}`;
+      const data = await fetchPowering(path);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, mes, ano, ...data }) };
+    }
+
     const now = new Date();
     const mesPedido = parseInt(p.mes || now.getMonth() + 1);
     const anoPedido = parseInt(p.ano || now.getFullYear());

--- a/netlify/functions/sync-portal.js
+++ b/netlify/functions/sync-portal.js
@@ -127,6 +127,10 @@ exports.handler = async (event) => {
          WHEN POSITION(${idx}::text IN ${col}) > 0 THEN ${col}
          ELSE ${col} || ' | ' || ${idx}::text END`;
 
+    // Set de matrículas em inserção para evitar duplicados em processamento concorrente.
+    // JavaScript é single-thread: o check+add é atómico antes de qualquer await.
+    const _inserting = new Set();
+
     async function processService(svc) {
       const plateNorm = norm(svc.plate);
       if (!plateNorm) { results.errors++; return; }
@@ -134,6 +138,9 @@ exports.handler = async (event) => {
       try {
         // Priorizar match por n_obra; fallback para plate
         const existing = (svc.n_obra && existingByNObra.get(String(svc.n_obra))) || existingByPlate.get(plateNorm);
+
+        // Outra tarefa concorrente já está a inserir esta matrícula → ignorar
+        if (!existing && _inserting.has(plateNorm)) { results.skipped++; return; }
 
         if (existing) {
           // Já agendado — atualizar dados e data se necessário
@@ -162,25 +169,35 @@ exports.handler = async (event) => {
           }
           results.updated++;
         } else {
-          // Não existe → criar
-          await pool.query(
-            `INSERT INTO appointments (
-               date, period, plate, car, service, locality, status,
-               notes, extra, phone, client_name, n_obra, km, sortIndex, "glassOrdered",
-               auto_imported, confirmed, portal_id, created_at, updated_at,
-               order_ref, reception_ref
-             ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,$11,null,1,false,$12,false,$13,$14,$15,$16,$17)`,
-            [
-              svc.date||null, svc.period||null,
-              String(svc.plate).trim(), svc.car||null, svc.service||null,
-              svc.status||'NE', svc.notes||null, svc.extra||null, svc.phone||null,
-              svc.client_name||null, svc.n_obra||null,
-              !!svc.date, portal_id,
-              svc.createdAt||now, now,
-              normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)
-            ]
-          );
-          results.created++;
+          // Marcar como em inserção antes do await — atómico no event loop JS
+          _inserting.add(plateNorm);
+          try {
+            const insertResult = await pool.query(
+              `INSERT INTO appointments (
+                 date, period, plate, car, service, locality, status,
+                 notes, extra, phone, client_name, n_obra, km, sortIndex, "glassOrdered",
+                 auto_imported, confirmed, portal_id, created_at, updated_at,
+                 order_ref, reception_ref
+               ) VALUES ($1,$2,$3,$4,$5,null,$6,$7,$8,$9,$10,$11,null,1,false,$12,false,$13,$14,$15,$16,$17)
+               RETURNING id`,
+              [
+                svc.date||null, svc.period||null,
+                String(svc.plate).trim(), svc.car||null, svc.service||null,
+                svc.status||'NE', svc.notes||null, svc.extra||null, svc.phone||null,
+                svc.client_name||null, svc.n_obra||null,
+                !!svc.date, portal_id,
+                svc.createdAt||now, now,
+                normalizeOrderRef(svc.order_ref), normalizeReceptionRef(svc.reception_ref)
+              ]
+            );
+            // Atualizar mapas para que tarefas posteriores no mesmo batch não dupliquem
+            const newId = insertResult.rows?.[0]?.id;
+            existingByPlate.set(plateNorm, { id: newId, date: null });
+            if (svc.n_obra) existingByNObra.set(String(svc.n_obra), { id: newId, date: null, n_obra: svc.n_obra, plate_norm: plateNorm });
+            results.created++;
+          } finally {
+            _inserting.delete(plateNorm);
+          }
         }
 
         // Sincronizar car e n_obra no mural mycar_services se a matrícula constar

--- a/powering-banner.js
+++ b/powering-banner.js
@@ -217,18 +217,126 @@
     const sel = document.getElementById('portalSwitcherSelect');
     if (!sel || sel._pegListenerAttached) return;
     sel._pegListenerAttached = true;
-    sel.addEventListener('change', rebuildBanner);
+    sel.addEventListener('change', () => { rebuildBanner(); rebuildBanner2(); });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // BANNER 2 — Escovas da loja actual + Campeã nacional
+  // ═══════════════════════════════════════════════════════════════════════
+  const BANNER2_ID = 'poweringEGEscovasBanner';
+
+  async function fetchVendasCompl(portalId) {
+    const { mes, ano } = getMonthMeta();
+    const r = await window.authClient.authenticatedFetch(
+      `/.netlify/functions/powering-kpis?action=vendas-complementares&portal_id=${portalId}&mes=${mes}&ano=${ano}`
+    );
+    const d = await r.json();
+    if (!d.success) throw new Error(d.error || 'sem dados complementares');
+    return d;
+  }
+
+  function buildBanner2Shell() {
+    const el = document.createElement('div');
+    el.id = BANNER2_ID;
+    el.style.cssText = [
+      'background:#0b1e38',
+      'border-left:4px solid #f59e0b',
+      'border-top:1px solid #1e3a5f',
+      'padding:8px 16px',
+      'font-family:Figtree,system-ui,sans-serif',
+      'display:flex',
+      'align-items:center',
+    ].join(';');
+    el.innerHTML =
+      '<div style="flex:1;display:flex;align-items:center;gap:10px;">' +
+        '<div>' +
+          '<div style="font-size:9px;font-weight:700;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:1px;">🧹 Escovas este mês</div>' +
+          '<div id="peg2Escovas" style="font-size:21px;font-weight:900;color:#94a3b8;font-variant-numeric:tabular-nums;line-height:1;">—</div>' +
+        '</div>' +
+      '</div>' +
+      '<div style="flex:1;display:flex;align-items:center;gap:10px;border-left:1px solid #1e3a5f;padding-left:16px;min-width:0;">' +
+        '<div style="min-width:0;">' +
+          '<div style="font-size:9px;font-weight:700;color:#fbbf24;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:1px;">🏆 Loja campeã de vendas</div>' +
+          '<div id="peg2Campea" style="font-size:14px;font-weight:800;color:#fde68a;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;line-height:1.2;">—</div>' +
+        '</div>' +
+      '</div>';
+    return el;
+  }
+
+  var _fmtEur = function(v) {
+    return (v != null && !isNaN(v))
+      ? new Intl.NumberFormat('pt-PT', { style: 'currency', currency: 'EUR', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(v)
+      : '—';
+  };
+
+  function fillBanner2(data) {
+    var lista = data.lojas || data.resultados || data.data || [];
+    var currentId = parseInt(data.lojaId);
+
+    var lojaAtual = lista.find(function(l) { return parseInt(l.lojaId) === currentId; }) || {};
+    var escovasVal = lojaAtual.escovasVendas != null ? parseFloat(lojaAtual.escovasVendas) : null;
+
+    var campea = lista.reduce(function(best, l) {
+      if (!best) return l;
+      return (parseFloat(l.escovasVendas) || 0) > (parseFloat(best.escovasVendas) || 0) ? l : best;
+    }, null);
+
+    var elEscovas = document.getElementById('peg2Escovas');
+    var elCampea  = document.getElementById('peg2Campea');
+
+    if (elEscovas) {
+      elEscovas.textContent = _fmtEur(escovasVal);
+      elEscovas.style.color = (escovasVal || 0) > 0 ? '#4ade80' : '#94a3b8';
+    }
+    if (elCampea && campea) {
+      var isCurrent = !isNaN(currentId) && parseInt(campea.lojaId) === currentId;
+      elCampea.textContent = campea.lojaNome + ' — ' + _fmtEur(parseFloat(campea.escovasVendas));
+      elCampea.style.color = isCurrent ? '#4ade80' : '#fde68a';
+    }
+  }
+
+  function insertBanner2(el) {
+    var b1 = document.getElementById(BANNER_ID);
+    if (b1) {
+      b1.insertAdjacentElement('afterend', el);
+    } else {
+      insertBanner(el);
+    }
+  }
+
+  async function initBanner2() {
+    if (document.getElementById(BANNER2_ID)) return;
+    if (!window.authClient?.getUser?.()) return;
+    var { portalId } = getActivePortal();
+    if (!portalId) return;
+
+    var shell = buildBanner2Shell();
+    insertBanner2(shell);
+
+    try {
+      var data = await fetchVendasCompl(portalId);
+      fillBanner2(data);
+    } catch (e) {
+      console.warn('[PoweringEG escovas]', e.message);
+    }
+  }
+
+  function rebuildBanner2() {
+    document.getElementById(BANNER2_ID)?.remove();
+    setTimeout(() => initBanner2().catch(() => {}), 150);
   }
 
   // ── Triggers (sem guard de role — corre para todos) ───────────────────
   initBanner().catch(() => {});
-  window.addEventListener('portalReady',   () => {
+  initBanner2().catch(() => {});
+  window.addEventListener('portalReady', () => {
     attachSwitcherListener();
     initBanner().catch(() => {});
+    initBanner2().catch(() => {});
   });
-  window.addEventListener('portalChanged', rebuildBanner);
-  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); }, 900);
-  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); }, 2500);
-  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); }, 4000);
+  window.addEventListener('portalChanged', () => { rebuildBanner(); rebuildBanner2(); });
+  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); initBanner2().catch(() => {}); }, 900);
+  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); initBanner2().catch(() => {}); }, 2500);
+  setTimeout(() => { attachSwitcherListener(); initBanner().catch(() => {}); initBanner2().catch(() => {}); }, 4000);
 
 })();

--- a/script.js
+++ b/script.js
@@ -2047,7 +2047,7 @@ async function enforceSingleSecondOfDay(newId, date) {
   if (others.length > 0) renderAll();
 }
 
-async function _doSaveExecuted(id, executed, reason) {
+async function _doSaveExecuted(id, executed, reason, sadEmojis) {
   const i = appointments.findIndex(a => String(a.id) === String(id));
   if (i < 0) return;
   const prev = { executed: appointments[i].executed, not_done_reason: appointments[i].not_done_reason, glass_removed: appointments[i].glass_removed, glass_removed_date: appointments[i].glass_removed_date };
@@ -2059,7 +2059,8 @@ async function _doSaveExecuted(id, executed, reason) {
     appointments[i].glass_removed_date = null;
   }
   renderAll();
-  if (executed === true) fireRealizadoEmojis(); else if (executed === false) fireNaoRealizadoEmojis();
+  if (executed === true) { sadEmojis ? fireNaoRealizadoEmojis() : fireRealizadoEmojis(); }
+  else if (executed === false) fireNaoRealizadoEmojis();
   try {
     await window.apiClient.updateAppointment(id, { ...appointments[i], executed, not_done_reason: reason || null });
 
@@ -2096,6 +2097,14 @@ async function persistExecuted(id, executed) {
   }
   if (!executed) {
     openNotDoneModal(id);
+    return;
+  }
+  // Campanha interativa: mostrar popup com Sim/Não antes de gravar
+  if (window._showInteractiveCampaign) {
+    window._showInteractiveCampaign(
+      async function () { await _doSaveExecuted(id, true, null, false); },  // Sim → emojis alegres
+      async function () { await _doSaveExecuted(id, true, null, true); }    // Não → emojis tristes
+    );
     return;
   }
   await _doSaveExecuted(id, true, null);


### PR DESCRIPTION
## Resumo

- Novo endpoint proxy `?action=vendas-complementares` em `powering-kpis.js` — chama `GET /api/external/vendas-complementares` do PoweringEG, devolve todas as lojas + `lojaId` da loja ativa
- Segundo banner abaixo do banner PoweringEG existente:
  - **Esquerda**: vendas de escovas (€) da loja/SM selecionada este mês
  - **Direita**: loja campeã nacional (nome + valor) — muda para verde se a loja atual for a campeã

## Comportamento

- Atualiza automaticamente ao mudar de portal (via `portalChanged` / `portalSwitcherSelect`)
- Se a API não devolver dados, mantém traços sem quebrar o resto do banner
- Compatível com Loja, SM e Pesados (usa `portal_id` → resolve `powering_loja_id` via DB)


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_