### PR TITLE
fix: normalizar resposta array de vendas-complementares

### DIFF
--- a/netlify/functions/powering-kpis.js
+++ b/netlify/functions/powering-kpis.js
@@ -78,12 +78,16 @@ exports.handler = async (event) => {
         );
         lojaId = rows[0]?.powering_loja_id ?? null;
       }
-      const data = await fetchPowering(`/vendas-complementares?mes=${mes}&ano=${ano}`);
+      const raw = await fetchPowering(`/vendas-complementares?mes=${mes}&ano=${ano}`);
       // debug=1 devolve resposta raw para diagnosticar nomes de campos
       if (p.debug === '1') {
-        return { statusCode: 200, headers, body: JSON.stringify({ debug: true, lojaId, raw: data }) };
+        return { statusCode: 200, headers, body: JSON.stringify({ debug: true, lojaId, raw }) };
       }
-      return { statusCode: 200, headers, body: JSON.stringify({ success: true, mes, ano, lojaId, ...data }) };
+      // Normalizar: PoweringEG pode devolver array directo ou objecto com chave variável
+      const lista = Array.isArray(raw)
+        ? raw
+        : (raw.lojas || raw.resultados || raw.data || raw.items || raw.vendas || []);
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, mes, ano, lojaId, lojas: lista }) };
     }
 
     const now = new Date();

--- a/powering-banner.js
+++ b/powering-banner.js
@@ -277,12 +277,10 @@
   }
 
   function fillBanner2(data) {
-    console.log('[PEG escovas] raw data:', JSON.stringify(data).slice(0, 500));
-
-    // Tentar vários nomes de array possíveis
-    var lista = data.lojas || data.resultados || data.data || data.vendas || data.items || [];
+    // Proxy normaliza sempre para data.lojas
+    var lista = data.lojas || [];
     if (!Array.isArray(lista)) lista = [];
-    console.log('[PEG escovas] lista length:', lista.length, lista[0]);
+    console.log('[PEG escovas] lojas:', lista.length, lista[0]);
 
     var currentId = parseInt(data.lojaId);
 


### PR DESCRIPTION
## Problema
O banner de escovas mostrava traços porque o PoweringEG devolve um array direto para `/vendas-complementares`. Ao fazer `{ ...array }` no proxy, o array tornava-se `{0: ..., 1: ...}` em vez de `{lojas: [...]}` — o frontend não encontrava os dados.

## Fix
O proxy detecta se a resposta é array ou objecto e normaliza sempre para `{ lojas: [...] }`. O frontend passa a ler apenas `data.lojas`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_