### PR TITLE
fix: diagnóstico visível no banner de escovas

### DIFF
--- a/netlify/functions/powering-kpis.js
+++ b/netlify/functions/powering-kpis.js
@@ -26,8 +26,12 @@ function fetchPowering(path) {
         let data = '';
         res.on('data', c => data += c);
         res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`PoweringEG HTTP ${res.statusCode}: ${data.slice(0, 120)}`));
+            return;
+          }
           try { resolve(JSON.parse(data)); }
-          catch(e) { reject(new Error('Resposta inválida do PoweringEG')); }
+          catch(e) { reject(new Error(`Resposta inválida: ${data.slice(0, 80)}`)); }
         });
       }
     );

--- a/powering-banner.js
+++ b/powering-banner.js
@@ -338,9 +338,18 @@
 
     try {
       var data = await fetchVendasCompl(portalId);
+      var lista = data.lojas || [];
+      if (lista.length === 0) {
+        // Diagnóstico visível: API respondeu mas sem lojas
+        var elDbg = document.getElementById('peg2Campea');
+        if (elDbg) { elDbg.textContent = 'API OK — 0 lojas (ver debug=1)'; elDbg.style.color = '#fb923c'; elDbg.style.fontSize = '10px'; }
+      }
       fillBanner2(data);
     } catch (e) {
       console.warn('[PoweringEG escovas]', e.message);
+      // Mostrar erro no banner para diagnóstico sem consola
+      var elErr = document.getElementById('peg2Campea');
+      if (elErr) { elErr.textContent = e.message.slice(0, 60); elErr.style.color = '#f87171'; elErr.style.fontSize = '10px'; }
     }
   }
 


### PR DESCRIPTION
Mostra erro ou aviso visível no banner de escovas sem precisar de consola — permite diagnosticar se o problema é HTTP, JSON inválido, ou 0 lojas devolvidas pela API.


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_