### PR TITLE
fix: botão Check-up Viatura volta a aparecer nos cards mobile (Braga)

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
-  <script src="/vehicle-checkup-patch.js?v=3"></script>
+  <script src="/vehicle-checkup-patch.js?v=4"></script>
   <script src="/campaign-popup.js?v=2026-06-19c"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -265,39 +265,37 @@
     });
   }
 
-  // ── Hook renderAll ────────────────────────────────────────────────────────
-  function hookRenderAll() {
-    const orig = window.renderAll;
-    if (typeof orig === 'function') {
-      window.renderAll = function () {
-        orig.apply(this, arguments);
-        setTimeout(injectCheckupButtons, 70);
+  // ── Hook renderAll + renderMobileDay ─────────────────────────────────────
+  function hookRenders() {
+    function wrap(fn, delay) {
+      return function () {
+        fn.apply(this, arguments);
+        setTimeout(injectCheckupButtons, delay);
       };
-    } else {
-      window.addEventListener('portalReady', function () {
-        setTimeout(function () {
-          const o = window.renderAll;
-          if (typeof o === 'function') {
-            window.renderAll = function () {
-              o.apply(this, arguments);
-              setTimeout(injectCheckupButtons, 70);
-            };
-          }
-        }, 500);
-      }, { once: true });
+    }
+    if (typeof window.renderAll === 'function') {
+      window.renderAll = wrap(window.renderAll, 70);
+    }
+    // renderMobileDay is called directly on mobile day navigation (prevDay/nextDay)
+    if (typeof window.renderMobileDay === 'function') {
+      window.renderMobileDay = wrap(window.renderMobileDay, 80);
     }
   }
 
   function init() {
-    if (!isBraga()) return;
-    hookRenderAll();
-    console.log('🔍 Vehicle Check-up Patch carregado (Braga)');
+    // Always hook renders; isBraga() is checked inside injectCheckupButtons
+    hookRenders();
+    console.log('🔍 Vehicle Check-up Patch carregado');
   }
 
-  if (window.portalConfig) {
+  if (typeof window.renderAll === 'function') {
+    // renderAll already defined — hook now
     init();
   } else {
-    window.addEventListener('portalReady', init, { once: true });
+    // Wait for scripts to finish defining renderAll
+    window.addEventListener('portalReady', function () {
+      setTimeout(init, 100);
+    }, { once: true });
   }
 
 })();


### PR DESCRIPTION
## Problema
O botão "Check-up Viatura" desapareceu dos cards mobile do portal Braga.

## Causa raiz
Dois bugs no `vehicle-checkup-patch.js`:

1. **Hook nunca instalado nalguns casos**: `init()` chamava `hookRenderAll()` apenas se `isBraga()` fosse true na altura do carregamento. Se o `portalConfig` ainda não estivesse disponível, o listener `portalReady` adicionado era `{ once: true }` — mas se `portalReady` disparasse antes dos scripts de patch carregarem, o hook nunca era instalado.

2. **Navegação entre dias não reinjetava botões**: No mobile, os botões de navegação (`prevDay`/`nextDay`) chamam `renderMobileDay()` diretamente, sem passar por `renderAll()`. Como o hook estava apenas em `renderAll`, ao mudar de dia os botões desapareciam.

## Solução

- `hookRenders()` agora faz wrap tanto de `window.renderAll` como de `window.renderMobileDay`
- A verificação `isBraga()` foi removida do `init()` — o hook é instalado sempre; a verificação continua dentro de `injectCheckupButtons()` para garantir que o botão só aparece no Braga
- A condição de arranque passou a verificar se `window.renderAll` já está definida (em vez de `window.portalConfig`), que é mais fiável
- Bump cache buster `v3 → v4`

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_