### PR TITLE
fix: check-up viatura sem duplicação de texto e com opção de galeria

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
-  <script src="/vehicle-checkup-patch.js?v=4"></script>
+  <script src="/vehicle-checkup-patch.js?v=5"></script>
   <script src="/campaign-popup.js?v=2026-06-19c"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -68,7 +68,7 @@
            style="border:2px ${has ? 'solid #16a34a' : 'dashed #cbd5e1'};border-radius:10px;padding:12px;text-align:center;cursor:pointer;min-height:90px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;background:${has ? '#f0fdf4' : '#f8fafc'};">
         <div style="font-size:28px;">${has ? '✅' : '📷'}</div>
         <div style="font-size:12px;font-weight:700;color:${has ? '#16a34a' : '#64748b'};">${label}</div>
-        <input type="file" id="vcFileInput${i}" accept="image/*" capture="environment" style="display:none;" onchange="window._vcOnPhoto(${i},this)">
+        <input type="file" id="vcFileInput${i}" accept="image/*" style="display:none;" onchange="window._vcOnPhoto(${i},this)">
       </div>`;
     }).join('');
     const btn = document.getElementById('vcAnalyzeBtn');
@@ -186,14 +186,8 @@
 
     if (!selected.length) { window._vcClose(); return; }
 
-    const today = new Date().toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric' });
-    const lines = selected.map(d => `• ${d.description} (${d.angle})`).join('\n');
-    const prefix = `[Check-up ${today}]\n${lines}`;
-
     const appts = window.appointments || [];
     const appt = appts.find(a => String(a.id) === String(_apptId));
-    const existing = appt?.notes || '';
-    const newNotes = existing ? prefix + '\n\n' + existing : prefix;
     const newDamageDetails = selected.map(d => d.description).join('; ');
 
     document.getElementById('vcBody').innerHTML = `<p style="text-align:center;padding:30px;color:#64748b;">A guardar…</p>`;
@@ -208,7 +202,6 @@
         headers: { 'Content-Type': 'application/json', ...(tok ? { Authorization: 'Bearer ' + tok } : {}) },
         body: JSON.stringify({
           ...(appt || { plate: _plate }),
-          notes: newNotes,
           damage_details: newDamageDetails,
           _portalId: portalId
         })
@@ -216,7 +209,7 @@
       const json = await res.json();
       if (!json.success) throw new Error(json.error || 'Erro ao guardar');
 
-      if (appt) { appt.notes = newNotes; appt.damage_details = newDamageDetails; }
+      if (appt) { appt.damage_details = newDamageDetails; }
       if (typeof renderAll === 'function') renderAll();
 
       document.getElementById('vcBody').innerHTML = `


### PR DESCRIPTION
## Problema
1. Após guardar um check-up, o texto dos danos aparecia duplicado no card — uma vez nas notas (`[Check-up 21/06/2026] • ...`) e outra vez no campo de danos (🔍 ...)
2. O sistema abria sempre a câmara diretamente, sem opção de escolher foto da galeria

## Solução

- **Duplicação**: `_vcSave` deixou de escrever nas `notes`. Os danos ficam apenas em `damage_details`, que é o campo mostrado com a lupa 🔍 no card.
- **Câmara vs galeria**: Removido `capture="environment"` dos inputs de ficheiro — agora o iOS/Android mostra o menu padrão com opção de câmara ou galeria.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_