### PR TITLE
fix: notas com JSON do extra não aparecem nos cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-15e"></script>
+  <script src="script.js?v=2026-06-21a"></script>
   <script src="script-tail.js?v=2026-06-15a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>

--- a/script.js
+++ b/script.js
@@ -1768,8 +1768,17 @@ async function load(){
       if (a.extra && typeof a.extra === 'string') {
         try { _extraObj = JSON.parse(a.extra); } catch(e) { _extraObj = null; }
       }
+      // Clean notes: if it accidentally contains the extra JSON, clear it
+      let _notes = a.notes || '';
+      if (_notes.trim().startsWith('{') && _notes.trim().endsWith('}')) {
+        try {
+          const _nObj = JSON.parse(_notes.trim());
+          if ('eurocode' in _nObj || 'photo_url' in _nObj || 'history' in _nObj) _notes = '';
+        } catch(e) {}
+      }
       return {
         ...a,
+        notes: _notes,
         address: a.address || a.morada || a.addr || null,
         createdAt: a.createdAt || a.created_at || null,
         extra_services: extras,


### PR DESCRIPTION
## Problema
O card do 95-TR-22 (e potencialmente outros) mostrava JSON bruto nas notas:
```
{"eurocode":"7302AGACMVZ1C","photo_url":"","history":"[2026-06-18 11:23] coordenador: Editado"}
```

## Causa
Em algum momento, o campo `extra` (que armazena eurocode/photo_url/history como JSON) foi guardado acidentalmente no campo `notes`. Uma vez corrompido, auto-perpetua-se porque operações como glass-removed e checkup fazem spread do objeto appointment inteiro (incluindo `notes` com o JSON) em cada save.

## Solução
Na normalização de appointments ao carregar (`script.js`), antes de render: se `notes` for um JSON válido com chaves `eurocode`, `photo_url` ou `history`, é limpo (definido como `''`).

Isto:
1. Remove imediatamente o JSON visível nos cards
2. Na próxima operação que guarda o appointment, escreve `notes = null` na DB em vez de perpetuar o JSON

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_