### PR TITLE
fix: limpar notes corrompido com JSON no servidor (PUT appointments)

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -360,7 +360,17 @@ exports.handler = async (event) => {
         data.plate ? String(data.plate).trim() : null,
         data.car ? String(data.car).trim() : null,
         data.service || null, data.locality || null, data.status || 'NE',
-        data.notes || null, data.address || null, data.extra || null,
+        // Clean notes if it accidentally contains the extra JSON (eurocode/photo_url/history)
+        (function() {
+          const n = data.notes || null;
+          if (!n) return n;
+          const t = n.trim();
+          if (t.startsWith('{') && t.endsWith('}')) {
+            try { const o = JSON.parse(t); if ('eurocode' in o || 'photo_url' in o || 'history' in o) return null; } catch(e) {}
+          }
+          return n;
+        })(),
+        data.address || null, data.extra || null,
         data.phone || null, data.km || null, data.sortIndex || null,
         data.glassOrdered !== undefined ? data.glassOrdered : null,
         data.vehicleType || data.vehicle_type || 'L',


### PR DESCRIPTION
## Problema
O JSON nas `notes` do 95-TR-22 persistia mesmo após o PR #392 (fix frontend).

## Causa
O fix frontend (#392) limpa as notes ao carregar, mas só funciona se o browser carregar o novo `script.js`. Com cache antigo, o JSON continua a ser exibido E a ser preservado em cada operação que faz PUT (ex: clicar em "Retirar Vidro").

## Solução
No servidor (`netlify/functions/appointments.js`), no handler PUT, se `data.notes` contiver um JSON com chaves `eurocode`, `photo_url` ou `history`, é substituído por `null` antes de gravar na BD.

Assim, na próxima operação sobre este appointment (qualquer PUT), o campo `notes` fica limpo na BD de forma permanente — independente do cache do browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_