### PR TITLE
fix: notas JSON limpas também no refresh silencioso (script-tail)

### DIFF
--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-21a"></script>
-  <script src="script-tail.js?v=2026-06-15a"></script>
+  <script src="script-tail.js?v=2026-06-21a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -1002,6 +1002,13 @@ async function _silentRefreshAppointments() {
       if (a.sortIndex === null || a.sortIndex === undefined) {
         a.sortIndex = (a.sortindex !== null && a.sortindex !== undefined) ? a.sortindex : 1;
       }
+      // Clean notes if it accidentally contains extra JSON (eurocode/photo_url/history)
+      if (a.notes) {
+        var _nt = a.notes.trim();
+        if (_nt.startsWith('{') && _nt.endsWith('}')) {
+          try { var _no = JSON.parse(_nt); if ('eurocode' in _no || 'photo_url' in _no || 'history' in _no) a.notes = ''; } catch(e) {}
+        }
+      }
     });
     // Replace the module-level appointments array in-place so renderAll() picks it up
     appointments.length = 0;


### PR DESCRIPTION
## Causa real do bug persistente

O `_silentRefreshAppointments` em `script-tail.js` faz polling periódico dos appointments e substitui o array de dados directamente — sem passar pela normalização do `script.js`. Por isso, mesmo com os fixes anteriores (PR #392, #393), os cards continuavam a mostrar JSON bruto porque o refresh silencioso reescrevia os dados não normalizados.

## Solução

Adicionada a mesma limpeza de `notes` no loop `fresh.forEach` do `_silentRefreshAppointments`: se `notes` for JSON com `eurocode`/`photo_url`/`history`, é limpo antes de entrar no array `appointments`.

Combinado com o fix server-side do #393, qualquer save futuro também limpa a BD permanentemente.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_