### PR TITLE
fix: limpar notes corrompidas na BD directamente ao fazer GET

### DIFF
--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -227,6 +227,17 @@ exports.handler = async (event) => {
         ORDER BY date ASC NULLS LAST, sortIndex ASC NULLS LAST, created_at ASC
       `;
       const { rows } = await pool.query(q, [portalId]);
+
+      // Fire-and-forget: clean any notes that accidentally contain extra JSON
+      pool.query(
+        `UPDATE appointments SET notes = NULL
+         WHERE portal_id = $1
+           AND notes IS NOT NULL
+           AND notes LIKE '{%}'
+           AND (notes LIKE '%"eurocode"%' OR notes LIKE '%"photo_url"%' OR notes LIKE '%"history"%')`,
+        [portalId]
+      ).catch(() => {});
+
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
     }
 


### PR DESCRIPTION
## Problema persistente

Mesmo com os fixes anteriores no frontend e no PUT handler, o 94-MU-56 (e outros) continuavam a mostrar JSON porque os registos corrompidos na BD não eram limpos sem um save explícito de cada card.

## Solução: limpeza na BD ao fazer GET

Quando o GET de appointments é chamado (no polling de 60s), dispara agora um `UPDATE` assíncrono (fire-and-forget) que coloca `notes = NULL` em todos os registos do portal onde `notes` contenha o padrão JSON do campo `extra` (`{%}` com `eurocode`/`photo_url`/`history`).

Resultado: na primeira chamada ao endpoint após o deploy, todos os registos afetados ficam limpos na BD permanentemente — sem precisar de editar cada appointment manualmente.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_