### PR TITLE
fix: includes() mais robusto para limpar notes com JSON corrompido

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,8 +794,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-21a"></script>
-  <script src="script-tail.js?v=2026-06-21a"></script>
+  <script src="script.js?v=2026-06-21b"></script>
+  <script src="script-tail.js?v=2026-06-21b"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -229,12 +229,10 @@ exports.handler = async (event) => {
       const { rows } = await pool.query(q, [portalId]);
 
       // Fire-and-forget: clean notes that accidentally contain extra JSON (eurocode/photo_url/history)
-      // Uses TRIM + regex to be resilient to leading/trailing whitespace/newlines
       pool.query(
         `UPDATE appointments SET notes = NULL
          WHERE portal_id = $1
            AND notes IS NOT NULL
-           AND TRIM(notes) ~ '^\\{.*\\}$'
            AND notes LIKE '%"eurocode":%'`,
         [portalId]
       ).catch(() => {});
@@ -376,10 +374,7 @@ exports.handler = async (event) => {
         (function() {
           const n = data.notes || null;
           if (!n) return n;
-          const t = n.trim();
-          if (t.startsWith('{') && t.endsWith('}')) {
-            try { const o = JSON.parse(t); if ('eurocode' in o || 'photo_url' in o || 'history' in o) return null; } catch(e) {}
-          }
+          if (n.includes('"eurocode":') || n.includes('"photo_url":') || n.includes('"history":')) return null;
           return n;
         })(),
         data.address || null, data.extra || null,

--- a/script-tail.js
+++ b/script-tail.js
@@ -350,12 +350,7 @@ window.reloadAppointments = async function() {
     const raw = await window.apiClient.getAppointments();
     appointments = raw.map(a => {
       var _notes = a.notes || '';
-      if (_notes) {
-        var _nt = _notes.trim();
-        if (_nt.startsWith('{') && _nt.endsWith('}')) {
-          try { var _no = JSON.parse(_nt); if ('eurocode' in _no || 'photo_url' in _no || 'history' in _no) _notes = ''; } catch(e) {}
-        }
-      }
+      if (_notes && (_notes.includes('"eurocode":') || _notes.includes('"photo_url":') || _notes.includes('"history":'))) _notes = '';
       return {
         ...a,
         notes: _notes || null,
@@ -1013,12 +1008,7 @@ async function _silentRefreshAppointments() {
         a.sortIndex = (a.sortindex !== null && a.sortindex !== undefined) ? a.sortindex : 1;
       }
       // Clean notes if it accidentally contains extra JSON (eurocode/photo_url/history)
-      if (a.notes) {
-        var _nt = a.notes.trim();
-        if (_nt.startsWith('{') && _nt.endsWith('}')) {
-          try { var _no = JSON.parse(_nt); if ('eurocode' in _no || 'photo_url' in _no || 'history' in _no) a.notes = ''; } catch(e) {}
-        }
-      }
+      if (a.notes && (a.notes.includes('"eurocode":') || a.notes.includes('"photo_url":') || a.notes.includes('"history":'))) a.notes = '';
     });
     // Replace the module-level appointments array in-place so renderAll() picks it up
     appointments.length = 0;
@@ -1407,8 +1397,8 @@ function bootApp() {
         // Re-fetch completo e redesenha
         appointments = await window.apiClient.getAppointments();
         appointments = appointments.map(a => {
-          var _n = (a.notes || '').trim();
-          if (_n.startsWith('{') && _n.endsWith('}')) { try { var _o = JSON.parse(_n); if ('eurocode' in _o || 'photo_url' in _o || 'history' in _o) a = { ...a, notes: null }; } catch(e) {} }
+          var _n = a.notes || '';
+          if (_n && (_n.includes('"eurocode":') || _n.includes('"photo_url":') || _n.includes('"history":'))) a = { ...a, notes: null };
           return { ...a, date: a.date ? String(a.date).slice(0, 10) : null, address: a.address || a.morada || a.addr || null, sortIndex: a.sortIndex || 1, id: a.id ?? (Date.now() + Math.random()) };
         });
         // Fallback: se o novo serviço ainda não chegou na re-fetch, adicionar manualmente

--- a/script.js
+++ b/script.js
@@ -1770,12 +1770,7 @@ async function load(){
       }
       // Clean notes: if it accidentally contains the extra JSON, clear it
       let _notes = a.notes || '';
-      if (_notes.trim().startsWith('{') && _notes.trim().endsWith('}')) {
-        try {
-          const _nObj = JSON.parse(_notes.trim());
-          if ('eurocode' in _nObj || 'photo_url' in _nObj || 'history' in _nObj) _notes = '';
-        } catch(e) {}
-      }
+      if (_notes.includes('"eurocode":') || _notes.includes('"photo_url":') || _notes.includes('"history":')) _notes = '';
       return {
         ...a,
         notes: _notes,


### PR DESCRIPTION
## Problema

A limpeza anterior usava `JSON.parse()` para detetar notes com JSON corrompido (`{eurocode, photo_url, history}`). Se o JSON tiver newlines literais (e.g. histórico multi-linha), o `JSON.parse()` falha silenciosamente e a note corrupta fica visível no cartão.

O regex SQL `TRIM(notes) ~ '^\{.*\}$'` também falhava com newlines no meio do campo.

## Solução

- Substituído `JSON.parse()` por `includes('"eurocode":')` em todos os 4 sítios:
  - `script.js` (normalização inicial)
  - `script-tail.js` (`reloadAppointments`, `_silentRefreshAppointments`, re-fetch pós-save)
  - `netlify/functions/appointments.js` (handler PUT)
- SQL do GET handler simplificado: removido regex, apenas `notes LIKE '%"eurocode":%'`
- Cache busters atualizados: `?v=2026-06-21b`

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_