### PR TITLE
fix: tamanho dos banners PoweringEG desktop mais equilibrado

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,7 +816,7 @@
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
   <script src="incomplete-services-alert.js?v=2026-06-01c"></script>
   <script src="agenda-bot.js?v=2026-04-09"></script>
-  <script src="powering-banner.js?v=2026-06-22a"></script>
+  <script src="powering-banner.js?v=2026-06-22b"></script>
   <script src="rota-do-dia-map.js?v=2026-06-15c"></script>
   <script src="timeline-rota.js?v=2026-05-14g"></script>
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>

--- a/powering-banner.js
+++ b/powering-banner.js
@@ -79,16 +79,15 @@
         }
         @media (min-width: 768px) {
           #${BANNER_ID} {
-            padding: 18px 28px 22px;
-            border-left-width: 6px;
+            padding: 12px 20px 16px;
           }
-          #${BANNER_ID} .peg-head { margin-bottom: 14px; }
-          #${BANNER_ID} .peg-name { font-size: 15px; letter-spacing: 1px; }
-          #${BANNER_ID} .peg-month { font-size: 14px; }
-          #${BANNER_ID} .peg-grid { gap: 8px 24px; }
-          #${BANNER_ID} .peg-lbl { font-size: 12px; letter-spacing: 0.8px; margin-bottom: 4px; }
-          #${BANNER_ID} .peg-val { font-size: 42px; }
-          #${BANNER_ID} .peg-skel { height: 38px; }
+          #${BANNER_ID} .peg-head { margin-bottom: 10px; }
+          #${BANNER_ID} .peg-name { font-size: 12px; }
+          #${BANNER_ID} .peg-month { font-size: 12px; }
+          #${BANNER_ID} .peg-grid { gap: 6px 16px; }
+          #${BANNER_ID} .peg-lbl { font-size: 10px; margin-bottom: 2px; }
+          #${BANNER_ID} .peg-val { font-size: 30px; }
+          #${BANNER_ID} .peg-skel { height: 28px; }
         }
       </style>
       <div class="peg-head">
@@ -263,13 +262,11 @@
     el.innerHTML =
       '<style>' +
         '@media(min-width:768px){' +
-          '#' + BANNER2_ID + '{padding:18px 28px!important;border-left-width:6px!important;gap:0!important;}' +
-          '#' + BANNER2_ID + ' .p2-lbl{font-size:13px!important;margin-bottom:5px!important;}' +
-          '#' + BANNER2_ID + ' .p2-val{font-size:42px!important;}' +
-          '#' + BANNER2_ID + ' .p2-camp-lbl{font-size:13px!important;margin-bottom:5px!important;}' +
-          '#' + BANNER2_ID + ' .p2-camp-val{font-size:24px!important;}' +
-          '#' + BANNER2_ID + ' .p2-left{padding-right:24px!important;}' +
-          '#' + BANNER2_ID + ' .p2-right{padding-left:24px!important;}' +
+          '#' + BANNER2_ID + '{padding:12px 20px!important;}' +
+          '#' + BANNER2_ID + ' .p2-lbl{font-size:10px!important;}' +
+          '#' + BANNER2_ID + ' .p2-val{font-size:30px!important;}' +
+          '#' + BANNER2_ID + ' .p2-camp-lbl{font-size:10px!important;}' +
+          '#' + BANNER2_ID + ' .p2-camp-val{font-size:18px!important;}' +
         '}' +
       '</style>' +
       '<div class="p2-left" style="flex:0 0 auto;display:flex;align-items:center;gap:10px;padding-right:14px;">' +


### PR DESCRIPTION
Reduzido o exagero da PR anterior: valores passam de 42px → 30px, padding mais contido, campeão de 24px → 18px. Mobile mantém inalterado.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_