### PR TITLE
fix: filtrar estados PHC na importação Excel

### DIFF
--- a/excel-import.js
+++ b/excel-import.js
@@ -120,17 +120,19 @@ class ExcelImporter {
           row: err.row,
           error: err.errors.join(', ')
         }));
-        
+
         const processedData = results.success.map(item => item.data);
-        
+
         console.log('✅ Dados processados (Expressglass):', {
           valid: processedData.length,
-          errors: this.validationErrors.length
+          errors: this.validationErrors.length,
+          ignored: (results.ignored || []).length
         });
-        
+
         return {
           data: processedData,
-          errors: this.validationErrors
+          errors: this.validationErrors,
+          ignored: results.ignored || []
         };
         
       } catch (error) {

--- a/index.html
+++ b/index.html
@@ -807,8 +807,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="excel-templates.js?v=2026-04-09"></script>
   <script src="template-personalizado.js?v=2026-04-09"></script>
-  <script src="template-expressglass-completo.js?v=2026-04-09"></script>
-  <script src="excel-import.js?v=2026-06-05a"></script>
+  <script src="template-expressglass-completo.js?v=2026-06-22a"></script>
+  <script src="excel-import.js?v=2026-06-22a"></script>
   <script src="excel-import-ui.js?v=2026-06-05a"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="reports-widget.js?v=2026-06-09a"></script>

--- a/template-expressglass-completo.js
+++ b/template-expressglass-completo.js
@@ -202,33 +202,53 @@ class ExpressglassFileProcessor {
   async processFile(data) {
     const results = {
       success: [],
-      errors: []
+      errors: [],
+      ignored: []
     };
-    
+
+    const ALLOWED_STATUSES = new Set([
+      'AUTORIZADO',
+      'AUTORIZADO SEM DADOS',
+      'Consulta / Orçamento',
+      'INCIDÊNCIA',
+      'PEDIDO RETIFICACAO',
+      'RECUSADO',
+      'STAND BY'
+    ]);
+
     const template = window.templateManager?.getTemplate(this.templateId);
     if (!template) {
       throw new Error('Template Expressglass Completo não encontrado');
     }
-    
+
     data.forEach((row, index) => {
       try {
+        const phcStatus = (row[7] || '').toString().trim();
+
+        // Ignorar estados que não devem ser importados
+        if (!ALLOWED_STATUSES.has(phcStatus)) {
+          results.ignored.push({ row: index + 2, plate: row[8] || '?', reason: phcStatus });
+          return;
+        }
+
         // Validar linha
         const validationErrors = this.validateRow(row);
         if (validationErrors.length > 0) {
           results.errors.push({
-            row: index + 2, // +2 porque índice começa em 0 e primeira linha são cabeçalhos
+            row: index + 2,
             errors: validationErrors
           });
           return;
         }
-        
+
         // Processar linha
         const processed = this.processRow(row, template);
+        processed.phc_status = phcStatus;
         results.success.push({
           row: index + 2,
           data: processed
         });
-        
+
       } catch (error) {
         results.errors.push({
           row: index + 2,
@@ -236,7 +256,7 @@ class ExpressglassFileProcessor {
         });
       }
     });
-    
+
     return results;
   }
 }


### PR DESCRIPTION
## O quê

A importação Excel do PHC passará a filtrar por estado, importando apenas os estados que fazem sentido agendar.

## Estados importados
- AUTORIZADO
- AUTORIZADO SEM DADOS
- Consulta / Orçamento
- INCIDÊNCIA
- PEDIDO RETIFICACAO
- RECUSADO
- STAND BY

## Estados ignorados (novidade)
Serviço Pronto, Serviço Realizado, Pedido Autorização, SEM EFEITO, ORÇAMENTO, REVISAR, ANULADO, etc.

No Excel de Braga SM (42 registos): 25 importados, 17 ignorados.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_