### PR TITLE
fix: campanha só marca como vista se tiver imagem carregada

### DIFF
--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -27,7 +27,11 @@
 
   // ── Modal horária (só imagem + fechar) ───────────────────────────────────
   function _showModal() {
-    if (!_campaign || !_campaign.image_data) return;
+    if (!_campaign) return;
+    if (!_campaign.image_data) {
+      console.warn('[Campaign] Campanha ativa mas sem imagem — verifique o admin.');
+      return;
+    }
     var modal = document.getElementById('campaignPopupModal');
     if (!modal) {
       modal = document.createElement('div');
@@ -138,7 +142,7 @@
         } else {
           // Horária: se a campanha ainda não foi mostrada hoje, mostrar imediatamente
           var shownToday = _wasShown('daily');
-          if (!shownToday) {
+          if (!shownToday && _campaign.image_data) {
             _markShown('daily');
             _showModal();
           }

--- a/index.html
+++ b/index.html
@@ -800,7 +800,7 @@
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=5"></script>
-  <script src="/campaign-popup.js?v=2026-06-22c"></script>
+  <script src="/campaign-popup.js?v=2026-06-22d"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>


### PR DESCRIPTION
## Problema
Se a campanha EPI (ou qualquer outra) foi guardada no admin sem imagem, o `_showModal()` falhava silenciosamente mas a chave `'daily'` ficava marcada no localStorage — fazendo com que o utilizador nunca visse o popup nesse dia.

## Fix
- `_markShown('daily')` agora só é chamado se `_campaign.image_data` existir
- Adicionado `console.warn` para debug quando a campanha está ativa mas não tem imagem

## Verificar no admin
Se a campanha EPI ainda não aparecer após esta correção, abrir o admin → Campanhas → editar a campanha EPI e verificar se tem imagem carregada. Se não tiver, carregar a imagem e guardar.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_