### PR TITLE
fix: campanha horária e interativa funcionam em simultâneo

### DIFF
--- a/campaign-popup.js
+++ b/campaign-popup.js
@@ -131,24 +131,32 @@
     fetch('/.netlify/functions/campaign')
       .then(function (r) { return r.json(); })
       .then(function (d) {
-        if (!d.success || !d.campaign) return;
-        _campaign = d.campaign;
+        if (!d.success) return;
 
-        if (_campaign.campaign_type === 'interativa') {
-          // Expor função para script.js usar quando clicam em "Serviço Realizado"
+        // Campanha interativa (Serviço Realizado)
+        var interactive = d.interactiveCampaign || (d.campaign && d.campaign.campaign_type === 'interativa' ? d.campaign : null);
+        if (interactive) {
+          var _interactiveCampaign = interactive;
           window._showInteractiveCampaign = function (onSim, onNao) {
+            var prev = _campaign;
+            _campaign = _interactiveCampaign;
             _showInteractiveModal(onSim, onNao);
+            _campaign = prev;
           };
-        } else {
-          // Horária: se a campanha ainda não foi mostrada hoje, mostrar imediatamente
-          var shownToday = _wasShown('daily');
-          if (!shownToday && _campaign.image_data) {
-            _markShown('daily');
-            _showModal();
-          }
-          // Agendar slots futuros normalmente
-          _buildSlots().forEach(_scheduleSlot);
         }
+
+        // Campanha horária (popup automático)
+        var horaria = d.campaign && d.campaign.campaign_type !== 'interativa' ? d.campaign : null;
+        if (!horaria) return;
+        _campaign = horaria;
+
+        var shownToday = _wasShown('daily');
+        if (!shownToday && _campaign.image_data) {
+          _markShown('daily');
+          _showModal();
+        }
+        // Agendar slots futuros normalmente
+        _buildSlots().forEach(_scheduleSlot);
       })
       .catch(function () {});
   }

--- a/index.html
+++ b/index.html
@@ -800,7 +800,7 @@
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=5"></script>
-  <script src="/campaign-popup.js?v=2026-06-22d"></script>
+  <script src="/campaign-popup.js?v=2026-06-22e"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>

--- a/netlify/functions/campaign.js
+++ b/netlify/functions/campaign.js
@@ -66,15 +66,19 @@ exports.handler = async (event) => {
       }
 
       // Public: active campaign for today (no auth required)
+      // Return horária and interativa campaigns separately so both can be used simultaneously
       const today = new Date().toISOString().slice(0, 10);
       const { rows } = await client.query(
         `SELECT id, title, start_date, end_date, image_data, display_hours, campaign_type
          FROM campaigns
          WHERE active = true AND start_date <= $1 AND end_date >= $1
-         ORDER BY created_at DESC LIMIT 1`,
+         ORDER BY created_at DESC`,
         [today]
       );
-      return { statusCode: 200, headers, body: JSON.stringify({ success: true, campaign: rows[0] || null }) };
+      const horaria = rows.find(r => r.campaign_type !== 'interativa') || null;
+      const interativa = rows.find(r => r.campaign_type === 'interativa') || null;
+      // Keep backwards compat: `campaign` = horária (for automatic popup)
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, campaign: horaria, interactiveCampaign: interativa }) };
     }
 
     if (event.httpMethod === 'POST') {


### PR DESCRIPTION
## Problema
O sistema tinha duas campanhas ativas em simultâneo: **EPI** (Horária) e **Valeo** (provavelmente Interativa). O backend devolvia apenas UMA — a mais recentemente criada. Se a Valeo era Interativa, o popup automático da EPI nunca aparecia para ninguém.

## Fix
**Backend** (`campaign.js`): remove o `LIMIT 1`, separa por tipo e devolve:
- `campaign` → primeira campanha horária ativa (para popup automático)
- `interactiveCampaign` → primeira campanha interativa ativa (para Serviço Realizado)

**Frontend** (`campaign-popup.js`): usa `campaign` para o popup automático e `interactiveCampaign` para o modal de Sim/Não — independentemente um do outro.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_