### PR TITLE
fix: checkup da viatura abre câmara em vez da galeria

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
-  <script src="/vehicle-checkup-patch.js?v=5"></script>
+  <script src="/vehicle-checkup-patch.js?v=6"></script>
   <script src="/campaign-popup.js?v=2026-06-22e"></script>
   <script src="/multi-service-patch.js?v=2026-05-15b"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>

--- a/vehicle-checkup-patch.js
+++ b/vehicle-checkup-patch.js
@@ -68,7 +68,7 @@
            style="border:2px ${has ? 'solid #16a34a' : 'dashed #cbd5e1'};border-radius:10px;padding:12px;text-align:center;cursor:pointer;min-height:90px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;background:${has ? '#f0fdf4' : '#f8fafc'};">
         <div style="font-size:28px;">${has ? '✅' : '📷'}</div>
         <div style="font-size:12px;font-weight:700;color:${has ? '#16a34a' : '#64748b'};">${label}</div>
-        <input type="file" id="vcFileInput${i}" accept="image/*" style="display:none;" onchange="window._vcOnPhoto(${i},this)">
+        <input type="file" id="vcFileInput${i}" accept="image/*" capture="environment" style="display:none;" onchange="window._vcOnPhoto(${i},this)">
       </div>`;
     }).join('');
     const btn = document.getElementById('vcAnalyzeBtn');


### PR DESCRIPTION
Adicionado `capture="environment"` ao input do checkup para forçar a abertura da câmara traseira em dispositivos móveis, em vez de abrir a galeria.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_