### PR TITLE
feat: banner localidade dominante no mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-22h"></script>
-  <script src="script-tail.js?v=2026-06-21b"></script>
+  <script src="script-tail.js?v=2026-06-22i"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -313,6 +313,21 @@ async function renderMobileDay(){
 
   // Resumo do dia (só SM)
   const summary = buildDaySummary(currentMobileDay, true);
+
+  // Localidade dominante (só SM)
+  var _localBanner = '';
+  if (!isLoja()) {
+    const counts = {};
+    items.forEach(a => { if (a.locality) counts[a.locality] = (counts[a.locality] || 0) + 1; });
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    if (sorted.length > 0) {
+      _localBanner = '<div style="background:#1e293b;border-radius:10px;padding:8px 14px;margin-bottom:8px;display:flex;align-items:center;justify-content:space-between;">' +
+        '<span style="font-size:10px;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.5px;">Local.Dominante</span>' +
+        '<span style="font-size:17px;font-weight:800;color:#fbbf24;">' + sorted[0][0] + ' <span style="font-size:12px;font-weight:600;color:rgba(255,255,255,0.45);">×' + sorted[0][1] + '</span></span>' +
+        '</div>';
+    }
+  }
+
   const allServices = items.map(buildMobileCard).join('');
 
   // Botão Rota — só se houver serviços com morada
@@ -328,7 +343,7 @@ async function renderMobileDay(){
       🗺️ Ver Rota do Dia
     </button>` : '';
 
-  list.innerHTML = _toggleRow + _bmBanner + _rlBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
+  list.innerHTML = _toggleRow + _bmBanner + _rlBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + _localBanner + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
   highlightSearchResults();
   window.guiaAT?.injectBadges();
 }


### PR DESCRIPTION
## Resumo

- Adiciona banner de **localidade dominante** no mobile (`renderMobileDay`) para portais SM
- Banner aparece entre o resumo do dia e o botão de rota
- Mesmo estilo do desktop: fundo escuro `#1e293b`, label "Local.Dominante" a branco, localidade a amarelo `#fbbf24` (17px), contagem a cinza

## Teste

- [ ] Abrir o calendário mobile num portal SM com agendamentos
- [ ] Verificar que o banner aparece com a localidade mais frequente do dia
- [ ] Confirmar que não aparece em portais Loja (`isLoja()`)


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_