### PR TITLE
fix: vidros 'pending' invisíveis na aba de Receção

### DIFF
--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
   <script src="script.js?v=2026-06-22h"></script>
-  <script src="script-tail.js?v=2026-06-21b"></script>
+  <script src="script-tail.js?v=2026-06-22i"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/index.html
+++ b/index.html
@@ -2249,24 +2249,27 @@
 
   async function _loadCoordList() {
     try {
-      const [resConf, resMiss] = await Promise.all([
+      const [resConf, resMiss, resPend] = await Promise.all([
         fetch(API + '/glass-reception?status=confirmed', { headers: authHeaders() }),
-        fetch(API + '/glass-reception?status=missing', { headers: authHeaders() })
+        fetch(API + '/glass-reception?status=missing', { headers: authHeaders() }),
+        fetch(API + '/glass-reception?status=pending', { headers: authHeaders() })
       ]);
-      const [jsonConf, jsonMiss] = await Promise.all([resConf.json(), resMiss.json()]);
+      const [jsonConf, jsonMiss, jsonPend] = await Promise.all([resConf.json(), resMiss.json(), resPend.json()]);
       if (!jsonConf.success) throw new Error(jsonConf.error);
       const confirmed = jsonConf.data || [];
       const missing = jsonMiss.success ? (jsonMiss.data || []) : [];
-      _renderCoordList(confirmed, missing);
+      const pending = jsonPend.success ? (jsonPend.data || []) : [];
+      _renderCoordList(confirmed, missing, pending);
     } catch (e) {
       const el = document.getElementById('grTabContent');
       if (el) el.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
     }
   }
 
-  function _renderCoordList(items, missing) {
+  function _renderCoordList(items, missing, pending) {
     missing = missing || [];
-    const total = items.length + missing.length;
+    pending = pending || [];
+    const total = items.length + missing.length + pending.length;
     const badge = document.getElementById('grCoordBadge');
     if (badge) { badge.textContent = total + ' pendente' + (total !== 1 ? 's' : ''); badge.style.display = total ? '' : 'none'; }
 
@@ -2281,6 +2284,28 @@
         </div>`;
       return;
     }
+
+    const pendingHtml = pending.length === 0 ? '' : `
+      <div style="margin-bottom:6px;font-size:12px;font-weight:700;color:#1d4ed8;text-transform:uppercase;letter-spacing:.5px;">🔍 Por associar a agendamento</div>
+      ${pending.map(r => `
+        <div id="grRow${r.id}" style="border:2px solid #3b82f6;border-radius:12px;padding:14px;margin-bottom:10px;background:#eff6ff;">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
+            <span style="font-family:monospace;font-weight:800;font-size:14px;background:#1d4ed8;color:#fff;padding:3px 10px;border-radius:6px;">${(r.order_ref || r.eurocode || '—').toUpperCase()}</span>
+            <span style="font-size:11px;color:#1d4ed8;margin-left:auto;">${fmtDate(r.created_at)}</span>
+          </div>
+          <div style="display:flex;gap:14px;font-size:12px;color:#1e40af;flex-wrap:wrap;margin-bottom:10px;">
+            <span>🏪 ${r.portal_label || r.portal_name || '—'}</span>
+            <span>👤 ${r.technician_name || '—'}</span>
+            ${r.order_ref ? `<span>📦 ${r.order_ref}</span>` : ''}
+            ${r.eurocode  ? `<span>🔢 ${r.eurocode}</span>` : ''}
+          </div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;">
+            <button onclick="window.glassReception._markReceived(${r.id})" style="background:#16a34a;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">✅ Rececionado</button>
+            <button onclick="window.glassReception._rejectReception(${r.id},'${(r.order_ref||r.eurocode||'').replace(/'/g,"\\'")}')" style="background:#dc2626;color:#fff;font-weight:700;font-size:13px;padding:8px 18px;border-radius:8px;border:none;cursor:pointer;">❌ Rejeitar</button>
+          </div>
+        </div>
+      `).join('')}
+    `;
 
     const confirmedHtml = items.map(r => `
       <div id="grRow${r.id}" style="border:1px solid #e2e8f0;border-radius:12px;padding:14px;margin-bottom:10px;background:#fff;">
@@ -2324,7 +2349,7 @@
       `).join('')}
     `;
 
-    content.innerHTML = confirmedHtml + missingHtml;
+    content.innerHTML = pendingHtml + confirmedHtml + missingHtml;
   }
 
   // ── RETURNS / DAMAGED ────────────────────────────────────────────────────

--- a/script-tail.js
+++ b/script-tail.js
@@ -313,6 +313,21 @@ async function renderMobileDay(){
 
   // Resumo do dia (só SM)
   const summary = buildDaySummary(currentMobileDay, true);
+
+  // Localidade dominante (só SM)
+  var _localBanner = '';
+  if (!isLoja()) {
+    const counts = {};
+    items.forEach(a => { if (a.locality) counts[a.locality] = (counts[a.locality] || 0) + 1; });
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    if (sorted.length > 0) {
+      _localBanner = '<div style="background:#1e293b;border-radius:10px;padding:8px 14px;margin-bottom:8px;display:flex;align-items:center;justify-content:space-between;">' +
+        '<span style="font-size:10px;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.5px;">Local.Dominante</span>' +
+        '<span style="font-size:17px;font-weight:800;color:#fbbf24;">' + sorted[0][0] + ' <span style="font-size:12px;font-weight:600;color:rgba(255,255,255,0.45);">×' + sorted[0][1] + '</span></span>' +
+        '</div>';
+    }
+  }
+
   const allServices = items.map(buildMobileCard).join('');
 
   // Botão Rota — só se houver serviços com morada
@@ -328,7 +343,7 @@ async function renderMobileDay(){
       🗺️ Ver Rota do Dia
     </button>` : '';
 
-  list.innerHTML = _toggleRow + _bmBanner + _rlBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
+  list.innerHTML = _toggleRow + _bmBanner + _rlBanner + (summary ? `<div class="mobile-day-summary">${summary}</div>` : '') + _localBanner + rotaBtn + allServices || '<p style="text-align:center;color:#6b7280;margin:20px;">Nenhum serviço agendado</p>';
   highlightSearchResults();
   window.guiaAT?.injectBadges();
 }


### PR DESCRIPTION
## Problema

O alerta "Vidros por tratar" dizia haver 11 vidros por recepcionar, mas ao abrir a Receção de Vidros aparecia "Sem vidros pendentes". 

**Causa**: o alerta contava registos com `status IN ('pending','confirmed')`, mas a aba de Receção só carregava `status=confirmed` e `status=missing`. Os vidros com `status='pending'` (escaneados pelo técnico sem agendamento associado) eram invisíveis.

## Fix

- `_loadCoordList()` passa a fazer 3 fetches em paralelo: `confirmed`, `missing` **e `pending`**
- `_renderCoordList()` mostra uma nova secção azul "Por associar a agendamento" para os registos `pending`, com botões "✅ Rececionado" e "❌ Rejeitar"


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_