### PR TITLE
fix: esconder JSON cru do campo extra nos cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,8 +794,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-22h"></script>
-  <script src="script-tail.js?v=2026-06-22i"></script>
+  <script src="script.js?v=2026-06-22j"></script>
+  <script src="script-tail.js?v=2026-06-22j"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -88,7 +88,7 @@ const telBtn = phone ? `
     a.second_of_day ? `<span class="m-chip" style="background:#f97316;color:#fff;font-weight:700;">⭐ 2.º</span>` : ''
   ].filter(Boolean).join('');
   let _extraDisp = '';
-  if (a.extra) { try { _extraDisp = JSON.parse(a.extra).eurocode || ''; } catch(e) { const _m = a.extra.match(/"eurocode"\s*:\s*"([^"]+)"/); _extraDisp = _m ? _m[1] : a.extra; } }
+  if (a.extra) { try { const _p = typeof a.extra === 'string' ? JSON.parse(a.extra) : a.extra; _extraDisp = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : ''; } catch(e) { _extraDisp = ''; } }
   const _mRole = window.authClient?.getUser?.()?.role;
   const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const mEncRecFooter = ''; // movido para o semáforo de stock (coluna direita)

--- a/script.js
+++ b/script.js
@@ -2629,9 +2629,12 @@ function buildDesktopCard(a){
   const service = a.service || 'PB';
   const car = (a.car || '').toUpperCase();
   const clientNameStr = a.client_name ? a.client_name : '';
-  let _extraDisplay = a.extra || '';
-  if (_extraDisplay) {
-    try { const _p = JSON.parse(_extraDisplay); _extraDisplay = _p.eurocode || ''; } catch(e) {}
+  let _extraDisplay = '';
+  if (a.extra) {
+    try {
+      const _p = typeof a.extra === 'string' ? JSON.parse(a.extra) : a.extra;
+      _extraDisplay = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : '';
+    } catch(e) { _extraDisplay = ''; }
   }
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Problema

Os cards de agendamento mostravam o JSON cru do campo `extra` no subtítulo:
`{"eurocode":"","photo_url":"","history":"[2026-06-22 15:19] coordenador: Editado"}`

**Causa**: o `catch(e) {}` estava vazio — se o `JSON.parse` falhasse (ou se `a.extra` já fosse um objeto e não uma string), `_extraDisplay` ficava com o valor original (o JSON/objeto cru).

## Fix

- Trata `a.extra` como string ou objeto (para quando a API já o retorna parsed)
- Na catch, força `_extraDisplay = ''` em vez de não fazer nada
- Mesmo fix aplicado em `script.js` (desktop) e `script-tail.js` (mobile)


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_