### PR TITLE
fix: localidade dominante só quando tem maioria clara

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,8 +794,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-22j"></script>
-  <script src="script-tail.js?v=2026-06-22j"></script>
+  <script src="script.js?v=2026-06-22k"></script>
+  <script src="script-tail.js?v=2026-06-22k"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="/glass-removed-patch.js?v=5"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -321,9 +321,12 @@ async function renderMobileDay(){
     items.forEach(a => { if (a.locality) counts[a.locality] = (counts[a.locality] || 0) + 1; });
     const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
     if (sorted.length > 0) {
+      const dominant = sorted.length === 1 || sorted[0][1] > sorted[1][1] ? sorted[0] : null;
       _localBanner = '<div style="background:#1e293b;border-radius:10px;padding:8px 14px;margin-bottom:8px;display:flex;align-items:center;justify-content:space-between;">' +
         '<span style="font-size:10px;font-weight:600;color:rgba(255,255,255,0.5);text-transform:uppercase;letter-spacing:0.5px;">Local.Dominante</span>' +
-        '<span style="font-size:17px;font-weight:800;color:#fbbf24;">' + sorted[0][0] + ' <span style="font-size:12px;font-weight:600;color:rgba(255,255,255,0.45);">×' + sorted[0][1] + '</span></span>' +
+        (dominant
+          ? '<span style="font-size:17px;font-weight:800;color:#fbbf24;">' + dominant[0] + ' <span style="font-size:12px;font-weight:600;color:rgba(255,255,255,0.45);">×' + dominant[1] + '</span></span>'
+          : '<span style="font-size:18px;font-weight:700;color:rgba(255,255,255,0.25);">—</span>') +
         '</div>';
     }
   }

--- a/script.js
+++ b/script.js
@@ -2846,13 +2846,13 @@ function renderSchedule(){
       const counts = {};
       dayAppts.forEach(a => { counts[a.locality] = (counts[a.locality] || 0) + 1; });
       const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
-      const dominant = sorted[0];
-      const cell = dominant
+      const dominant = sorted.length > 0 && (sorted.length === 1 || sorted[0][1] > sorted[1][1]) ? sorted[0] : null;
+      const cell = sorted.length === 0 ? '' : dominant
         ? `<div style="text-align:center;line-height:1.3;">
              <div style="font-size:9px;font-weight:600;color:rgba(255,255,255,0.5);letter-spacing:0.5px;text-transform:uppercase;">Local.Dominante</div>
              <div style="font-size:17px;font-weight:800;color:#fbbf24;white-space:nowrap;">${dominant[0]} <span style="font-size:12px;font-weight:600;color:rgba(255,255,255,0.45);">×${dominant[1]}</span></div>
            </div>`
-        : '';
+        : `<div style="text-align:center;font-size:18px;font-weight:700;color:rgba(255,255,255,0.25);">—</div>`;
       return `<td${isToday(d) ? ' class="is-today"' : ''}>${cell}</td>`;
     }).join('');
     tbody.appendChild(localityRow);


### PR DESCRIPTION
## Mudança

Localidade dominante só aparece quando tem **estritamente mais** serviços que as outras.

- Em empate (ex: 2 em Ponte de Lima e 2 em Guimarães) → mostra `—`
- Só uma localidade → é dominante por defeito
- Desktop e mobile atualizados


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_