### PR TITLE
fix: erro vazio na confirmação de receção de vidro

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-22k"></script>
+  <script src="script.js?v=2026-06-23b"></script>
   <script src="script-tail.js?v=2026-06-22k"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
@@ -1997,7 +1997,7 @@
         body: JSON.stringify({ appointment_id: appointmentId, order_ref: orderRef, eurocode, raw_label_text: window._grRawText || null })
       });
       const json = await res.json();
-      if (!json.success) throw new Error(json.error);
+      if (!json.success) throw new Error(json.error || json.message || `Erro HTTP ${res.status}`);
 
       // Update in-memory appointment so card turns green immediately
       let apt = null;

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -434,8 +434,9 @@ exports.handler = async (event) => {
 
   } catch (err) {
     console.error('glass-reception:', err);
-    const code = err.message.includes('autenticado') ? 401 : 500;
-    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: err.message }) };
+    const msg = (err && err.message) ? err.message : String(err || 'Erro interno');
+    const code = msg.includes('autenticado') ? 401 : 500;
+    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: msg }) };
   } finally {
     if (client) client.release();
   }


### PR DESCRIPTION
## Problema

Ao confirmar receção de vidro aparecia "Erro:" sem mensagem.

**Causa**: o backend retornava `{ success: false, error: '' }` (ou sem campo `error`), e no frontend `new Error('')` cria um erro com `message` vazia.

## Fix

- Frontend: `json.error || json.message || 'Erro HTTP N'` para garantir sempre uma mensagem visível
- Backend: `err.message` protegido para caso `err` não seja um Error object


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_