### PR TITLE
fix: separar botão receção vidro do painel coordenador no mobile

### DIFF
--- a/agenda-bot.js
+++ b/agenda-bot.js
@@ -158,7 +158,7 @@
 
     widget.innerHTML = `
       <!-- Botão Receção Vidros -->
-      <button id="recBotBtn" onclick="window.glassReception?.openCoordPanel()" style="
+      <button id="recBotBtn" onclick="window.glassReception?.openScan()" style="
         width:52px;height:52px;border-radius:50%;border:none;cursor:pointer;
         background:linear-gradient(135deg,#1d4ed8,#0f172a);
         color:#fff;font-size:22px;

--- a/index.html
+++ b/index.html
@@ -275,6 +275,9 @@
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
             Admin
           </a>
+          <button id="btnRececaoVidrosMobile" style="display:none;" class="guia-at-upload-btn" onclick="window.glassReception?.openCoordPanel()" title="Painel de Receção de Vidros">
+            📦 Receção Vidros
+          </button>
         </div>
       </div>
 
@@ -815,7 +818,7 @@
   <script src="glass-alert.js?v=2026-04-09"></script>
   <script src="glass-alert-urgent.js?v=2026-05-05"></script>
   <script src="incomplete-services-alert.js?v=2026-06-01c"></script>
-  <script src="agenda-bot.js?v=2026-06-23a"></script>
+  <script src="agenda-bot.js?v=2026-06-23b"></script>
   <script src="powering-banner.js?v=2026-06-22b"></script>
   <script src="rota-do-dia-map.js?v=2026-06-15c"></script>
   <script src="timeline-rota.js?v=2026-05-14g"></script>
@@ -3296,10 +3299,12 @@
     const user = window.authClient?.getUser?.() || JSON.parse(localStorage.getItem('user_data') || 'null');
     if (!user) return;
     const role = user.role || '';
-    // Coordinator/admin: show desk button + poll badge
+    // Coordinator/admin: show desk button + mobile panel button + poll badge
     if (role === 'admin' || role === 'coordenador') {
       const btn = document.getElementById('btnRececaoVidros');
       if (btn) btn.style.display = '';
+      const mobileBtn = document.getElementById('btnRececaoVidrosMobile');
+      if (mobileBtn) mobileBtn.style.display = '';
       _pollPendingBadge();
       setInterval(_pollPendingBadge, 60000);
       setTimeout(_checkGlassAlerts, 4000);

--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-22k"></script>
+  <script src="script.js?v=2026-06-23b"></script>
   <script src="script-tail.js?v=2026-06-22k"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
@@ -1997,7 +1997,7 @@
         body: JSON.stringify({ appointment_id: appointmentId, order_ref: orderRef, eurocode, raw_label_text: window._grRawText || null })
       });
       const json = await res.json();
-      if (!json.success) throw new Error(json.error);
+      if (!json.success) throw new Error(json.error || json.message || `Erro HTTP ${res.status}`);
 
       // Update in-memory appointment so card turns green immediately
       let apt = null;

--- a/index.html
+++ b/index.html
@@ -259,10 +259,6 @@
       <div id="guiaATUploadArea" style="padding:6px 14px 0; display:none; flex-direction:column; gap:6px;">
         <input type="file" id="guiaATFileInput" accept=".pdf,image/*" style="display:none" onchange="guiaAT.handleFileSelected(this)">
         <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
-          <button id="guiaATUploadBtn" class="guia-at-upload-btn" onclick="guiaAT.toggleMenu(this)">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            Guia AT
-          </button>
           <button id="ecReminderBtnHoje" class="ec-rem-trigger-btn" onclick="ecReminder.showToday()" title="Ver Eurocodes de hoje">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
             Hoje

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -434,8 +434,9 @@ exports.handler = async (event) => {
 
   } catch (err) {
     console.error('glass-reception:', err);
-    const code = err.message.includes('autenticado') ? 401 : 500;
-    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: err.message }) };
+    const msg = (err && err.message) ? err.message : String(err || 'Erro interno');
+    const code = msg.includes('autenticado') ? 401 : 500;
+    return { statusCode: code, headers, body: JSON.stringify({ success: false, error: msg }) };
   } finally {
     if (client) client.release();
   }


### PR DESCRIPTION
## Mudança

- Botão 📦 no widget mobile reverte para `openScan()` (receção de vidro)
- Novo botão "📦 Receção Vidros" no menu mobile (junto a "Admin") que abre `openCoordPanel()`, visível apenas para coordenador e admin — equivalente ao botão do desktop


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_