### PR TITLE
feat: eurocode_cache — aprende tipo e carro a cada receção confirmada

### DIFF
--- a/index.html
+++ b/index.html
@@ -1675,13 +1675,14 @@
 
   function _step1() { renderStep1(); }
 
-  async function _doSearch(orderRef, eurocode, rawText, photoBase64, plate, allEurocodes) {
+  async function _doSearch(orderRef, eurocode, rawText, photoBase64, plate, allEurocodes, skipEcSelection) {
+    if (!skipEcSelection) window._grLabelSelectedEurocodes = null;
     eurocode = _prefixedEurocode(eurocode);
     const allPrefixed = [...new Set((allEurocodes || []).map(_prefixedEurocode).filter(Boolean))];
     const extraEurocodes = allPrefixed.filter(e => e !== eurocode);
 
     // If multiple distinct eurocodes found, ask which ones are being received
-    if (extraEurocodes.length > 0) {
+    if (extraEurocodes.length > 0 && !skipEcSelection) {
       const body = document.getElementById('grScanBody');
       if (body) {
         const allEcs = [eurocode, ...extraEurocodes];
@@ -1693,7 +1694,8 @@
           });
           delete window[cbKey];
           if (!selected.length) { alert('Seleciona pelo menos um eurocode.'); return; }
-          _doSearch(orderRef, selected[0], rawText, null, plate || null, selected.length > 1 ? selected : null);
+          window._grLabelSelectedEurocodes = selected;
+          _doSearch(orderRef, selected[0], rawText, null, plate || null, selected.length > 1 ? selected : null, true);
         };
         body.innerHTML = `
           <div style="padding:16px 4px;">
@@ -2063,11 +2065,21 @@
 
       _pollPendingBadge();
 
+      const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
+      const receivedNorm = normEc(eurocode);
+
+      // Check if label had multiple selected eurocodes — receive them all on this appointment
+      const labelSelected = window._grLabelSelectedEurocodes || [];
+      const labelRemaining = labelSelected.filter(e => normEc(e) !== receivedNorm);
+      window._grLabelSelectedEurocodes = null;
+      if (labelRemaining.length > 0) {
+        _askExtraEurocode(labelRemaining, 0, appointmentId, plate, orderRef, []);
+        return;
+      }
+
       // Check if this appointment has additional eurocodes that need receiving
       if (apt && eurocode) {
         const allEuros = _extractAllEurocodes(apt);
-        const normEc = s => (s || '').toLowerCase().replace(/i/g, '1').replace(/o/g, '0');
-        const receivedNorm = normEc(eurocode);
         const remaining = allEuros.filter(e => normEc(e) !== receivedNorm);
         if (remaining.length > 0) {
           _askExtraEurocode(remaining, 0, appointmentId, plate, orderRef, []);

--- a/index.html
+++ b/index.html
@@ -2678,7 +2678,7 @@
     }
 
     if (!results.length) {
-      if (card) card.innerHTML = `<p style="font-size:12px;color:#94a3b8;text-align:center;padding:8px;">Nenhum processo encontrado — preenche os dados manualmente.</p>`;
+      _rejectReturnMatch();
       return;
     }
 

--- a/index.html
+++ b/index.html
@@ -1368,6 +1368,8 @@
     window._grReturnDamagePhotos = [];
     window._grReturnLabelPhoto = null;
     window._grReturnAppointmentId = null;
+    window._grReturnForPortalId = null;
+    window._grReturnForPortalName = null;
     const isPartido = reason === 'partido';
     document.getElementById('grScanBody').innerHTML = `
       <div style="background:${isPartido ? '#fef2f2' : '#fffbeb'};border:2px solid ${isPartido ? '#dc2626' : '#f59e0b'};border-radius:10px;padding:10px 14px;margin-bottom:14px;">
@@ -1536,7 +1538,7 @@
     try {
       const res = await fetch(API + '/glass-reception', {
         method: 'POST', headers: authHeaders(),
-        body: JSON.stringify({ is_return: true, return_reason: effectiveReason, eurocode: eurocode || null, label_photo: labelPhoto, damage_photos: damagePhotos.length ? damagePhotos : null, order_ref: orderRef, carrier_guide: carrierGuide, appointment_id: window._grReturnAppointmentId || null })
+        body: JSON.stringify({ is_return: true, return_reason: effectiveReason, eurocode: eurocode || null, label_photo: labelPhoto, damage_photos: damagePhotos.length ? damagePhotos : null, order_ref: orderRef, carrier_guide: carrierGuide, appointment_id: window._grReturnAppointmentId || null, portal_id: window._grReturnForPortalId || null, portal_name: window._grReturnForPortalName || null })
       });
       const text = await res.text();
       let json;
@@ -2701,7 +2703,7 @@
             </button>
             <button onclick="window.glassReception._rejectReturnMatch()"
               style="background:#e2e8f0;color:#374151;font-weight:700;font-size:13px;padding:10px;border-radius:8px;border:none;cursor:pointer;">
-              ❓ Não tenho a certeza
+              ❌ Não
             </button>
           </div>
         </div>`;
@@ -2726,7 +2728,7 @@
           }).join('')}
           <button onclick="window.glassReception._rejectReturnMatch()"
             style="margin-top:8px;background:#e2e8f0;color:#374151;font-weight:700;font-size:12px;padding:8px;border-radius:8px;border:none;cursor:pointer;width:100%;">
-            ❌ Nenhum destes
+            ❌ Não é nenhum destes
           </button>
         </div>`;
     }
@@ -2746,10 +2748,46 @@
       </div>`;
   }
 
-  function _rejectReturnMatch() {
+  async function _rejectReturnMatch() {
     window._grReturnAppointmentId = null;
+    window._grReturnForPortalId = null;
+    window._grReturnForPortalName = null;
     const card = document.getElementById('grReturnMatchCard');
-    if (card) card.innerHTML = '';
+    if (!card) return;
+    card.innerHTML = `<p style="text-align:center;padding:8px;color:#64748b;font-size:12px;">A carregar lojas…</p>`;
+    let portals = [];
+    try {
+      const res = await fetch(API + '/glass-reception?list_portals=true', { headers: authHeaders() });
+      const json = await res.json();
+      if (json.success) portals = json.data;
+    } catch(_) {}
+    if (!portals.length) { card.innerHTML = ''; return; }
+    card.innerHTML = `
+      <div style="background:#fff7ed;border:2px solid #f59e0b;border-radius:10px;padding:12px 14px;">
+        <p style="font-size:12px;font-weight:700;color:#92400e;margin:0 0 10px 0;">🏪 A que loja pertence esta devolução?</p>
+        <div style="display:flex;flex-direction:column;gap:6px;">
+          ${portals.map(p => `
+            <button onclick="window.glassReception._selectReturnPortal(${p.id},'${(p.name||'').replace(/'/g,"\\'")}')"
+              style="background:#fff;color:#374151;border:2px solid #e2e8f0;border-radius:8px;padding:10px 14px;font-size:13px;font-weight:700;cursor:pointer;text-align:left;">
+              🏪 ${p.name}
+            </button>
+          `).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  function _selectReturnPortal(id, name) {
+    window._grReturnForPortalId = id;
+    window._grReturnForPortalName = name;
+    const card = document.getElementById('grReturnMatchCard');
+    if (card) card.innerHTML = `
+      <div style="background:#fff7ed;border:2px solid #f59e0b;border-radius:10px;padding:10px 14px;display:flex;align-items:center;gap:10px;">
+        <span style="font-size:18px;">🏪</span>
+        <span style="font-size:13px;font-weight:700;color:#92400e;">${name}</span>
+        <button onclick="window.glassReception._rejectReturnMatch()" style="margin-left:auto;background:none;border:none;font-size:18px;cursor:pointer;color:#64748b;">✕</button>
+      </div>
+    `;
   }
 
   async function _devolvido(id) {

--- a/index.html
+++ b/index.html
@@ -3452,7 +3452,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -29,6 +29,14 @@ function verifyToken(event) {
   return jwt.verify(h.substring(7), JWT_SECRET);
 }
 
+function parseEurocode(raw) {
+  if (!raw) return { canonical: null, glassType: 'rede' };
+  const s = String(raw).trim();
+  if (s.startsWith('#')) return { canonical: s.slice(1).toUpperCase(), glassType: 'complementar' };
+  if (s.startsWith('*')) return { canonical: s.slice(1).toUpperCase(), glassType: 'oem' };
+  return { canonical: s.toUpperCase(), glassType: 'rede' };
+}
+
 async function ensureTable(client) {
   await client.query(`
     CREATE TABLE IF NOT EXISTS glass_receptions (
@@ -52,6 +60,16 @@ async function ensureTable(client) {
   await client.query(`ALTER TABLE glass_receptions ADD COLUMN IF NOT EXISTS damage_photos JSONB`);
   await client.query(`ALTER TABLE glass_receptions ADD COLUMN IF NOT EXISTS label_photo TEXT`);
   await client.query(`ALTER TABLE glass_receptions ADD COLUMN IF NOT EXISTS carrier_guide TEXT`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS eurocode_cache (
+      eurocode    TEXT PRIMARY KEY,
+      glass_types TEXT[] DEFAULT '{}',
+      car_models  TEXT[] DEFAULT '{}',
+      seen_count  INT DEFAULT 1,
+      last_seen   TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
 }
 
 exports.handler = async (event) => {
@@ -292,7 +310,7 @@ exports.handler = async (event) => {
       let resolvedPortalName = d.portal_name || null;
       if (d.appointment_id) {
         const aptRow = await client.query(
-          `SELECT a.portal_id, p.name AS portal_name FROM appointments a LEFT JOIN portals p ON p.id = a.portal_id WHERE a.id = $1`,
+          `SELECT a.portal_id, a.car, p.name AS portal_name FROM appointments a LEFT JOIN portals p ON p.id = a.portal_id WHERE a.id = $1`,
           [d.appointment_id]
         );
         if (aptRow.rows.length) {
@@ -354,6 +372,29 @@ exports.handler = async (event) => {
             `UPDATE appointments SET glass_eurocode = $1 WHERE id = $2 AND (glass_eurocode IS NULL OR glass_eurocode = '')`,
             [d.eurocode, d.appointment_id]
           );
+        }
+      }
+
+      // Learn eurocode → glass type + car model from confirmed receptions
+      if (d.appointment_id && !d.is_return && d.eurocode) {
+        const { canonical, glassType } = parseEurocode(d.eurocode);
+        const carModel = aptRow.rows[0]?.car || null;
+        if (canonical) {
+          await client.query(`
+            INSERT INTO eurocode_cache (eurocode, glass_types, car_models, seen_count, last_seen)
+            VALUES ($1, ARRAY[$2]::text[], $3::text[], 1, NOW())
+            ON CONFLICT (eurocode) DO UPDATE SET
+              glass_types = (
+                SELECT array_agg(DISTINCT g) FROM unnest(array_append(eurocode_cache.glass_types, $2)) g
+              ),
+              car_models = CASE
+                WHEN $4::text IS NULL OR $4::text = ANY(eurocode_cache.car_models)
+                THEN eurocode_cache.car_models
+                ELSE array_append(eurocode_cache.car_models, $4::text)
+              END,
+              seen_count = eurocode_cache.seen_count + 1,
+              last_seen  = NOW()
+          `, [canonical, glassType, carModel ? [carModel] : [], carModel]).catch(() => {});
         }
       }
 


### PR DESCRIPTION
## Resumo

- Nova tabela `eurocode_cache` criada automaticamente via `ensureTable`
- Função `parseEurocode` extrai o eurocode canónico (sem `#`/`*`) e o tipo de vidro (rede/complementar/oem)
- A cada receção confirmada com `appointment_id`, faz UPSERT na cache:
  - Adiciona o tipo de vidro ao array `glass_types` (sem duplicados)
  - Adiciona o modelo de carro ao array `car_models` (sem duplicados)
  - Incrementa `seen_count`
- `#8595AGAMVZ1P`, `*8595AGAMVZ1P` e `8595AGAMVZ1P` enriquecem todos o mesmo registo canónico `8595AGAMVZ1P`

## Base para inventário futuro

Com `seen_count`, `glass_types` e `car_models` acumulados, a cache será a fonte de enriquecimento para um ecrã de inventário por loja.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_