### PR TITLE
feat: separador Inventário no painel do coordenador

### DIFF
--- a/index.html
+++ b/index.html
@@ -2275,6 +2275,10 @@
                 style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
           💔 Danificados
         </button>
+        <button id="grTabInventory" onclick="window.glassReception._switchTab('inventory')"
+                style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
+          🗃️ Inventário
+        </button>
       </div>
       <div id="grTabContent" style="padding-top:12px;"></div>
     `;
@@ -2286,7 +2290,7 @@
   }
 
   async function _switchTab(tab) {
-    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged' };
+    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged', inventory: 'grTabInventory' };
     Object.entries(tabs).forEach(([key, id]) => {
       const btn = document.getElementById(id);
       if (!btn) return;
@@ -2306,6 +2310,9 @@
     } else if (tab === 'damaged') {
       content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar…</p>`;
       await _loadReturns('partido');
+    } else if (tab === 'inventory') {
+      content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar inventário…</p>`;
+      await _loadInventory();
     } else {
       await _openHistory();
     }
@@ -2817,6 +2824,90 @@
       if (!json.success) throw new Error(json.error || json.message || "Erro desconhecido");
       document.getElementById('grRow' + id)?.remove();
     } catch (e) { alert('Erro: ' + e.message); }
+  }
+
+  // ── INVENTORY ─────────────────────────────────────────────────────────────
+  async function _loadInventory(portalId) {
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+
+    let portals = [];
+    try {
+      const res = await fetch(API + '/glass-reception?list_portals=true', { headers: authHeaders() });
+      const json = await res.json();
+      if (json.success) portals = json.data;
+    } catch(_) {}
+
+    const portalFilter = portalId ? `&portal_id=${portalId}` : '';
+    let data = [];
+    try {
+      const res = await fetch(API + '/glass-reception?inventory=true' + portalFilter, { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || json.message || 'Erro');
+      data = json.data || [];
+    } catch(e) {
+      content.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+      return;
+    }
+
+    const currentPortalId = window.portalConfig?.id;
+    const portalOpts = portals.map(p =>
+      `<option value="${p.id}" ${(portalId ? parseInt(portalId) : currentPortalId) === p.id ? 'selected' : ''}>${p.name}</option>`
+    ).join('');
+
+    const typeBadge = t => {
+      const map = { rede: ['#0f172a','Rede'], complementar: ['#f59e0b','Comp.'], oem: ['#7c3aed','OEM'] };
+      const [bg, label] = map[t] || ['#94a3b8', t];
+      return `<span style="background:${bg};color:#fff;font-size:10px;font-weight:700;padding:2px 6px;border-radius:6px;margin-right:3px;">${label}</span>`;
+    };
+
+    const rows = data.map(r => {
+      const types = (r.glass_types || []).map(typeBadge).join('');
+      const cars = (r.car_models || []).join(', ') || '—';
+      const stockColor = r.in_stock > 0 ? '#16a34a' : r.in_stock === 0 ? '#64748b' : '#dc2626';
+      return `
+        <tr style="border-bottom:1px solid #f1f5f9;">
+          <td style="padding:10px 8px;font-family:monospace;font-weight:700;font-size:13px;">${r.eurocode}</td>
+          <td style="padding:10px 8px;">${types}</td>
+          <td style="padding:10px 8px;font-size:12px;color:#374151;max-width:180px;">${cars}</td>
+          <td style="padding:10px 8px;text-align:center;font-weight:800;font-size:16px;color:${stockColor};">${r.in_stock}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.received}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.consumed}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.returned}</td>
+        </tr>`;
+    }).join('');
+
+    content.innerHTML = `
+      <div style="margin-bottom:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+        <select id="grInvPortalFilter" onchange="window.glassReception._loadInventory(this.value||undefined)"
+          style="padding:8px 12px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;font-weight:600;background:#fff;flex:1;min-width:160px;">
+          <option value="">Todas as lojas</option>
+          ${portalOpts}
+        </select>
+        <span style="font-size:12px;color:#94a3b8;">${data.length} eurocode${data.length !== 1 ? 's' : ''} conhecidos</span>
+      </div>
+      ${data.length === 0 ? `
+        <div style="text-align:center;padding:40px;color:#94a3b8;">
+          <div style="font-size:40px;margin-bottom:12px;">🗃️</div>
+          <p style="font-size:14px;font-weight:600;">Ainda sem dados. Regista receções para preencher o inventário.</p>
+        </div>` : `
+      <div style="overflow-x:auto;">
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+          <thead>
+            <tr style="background:#f8fafc;border-bottom:2px solid #e2e8f0;">
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;white-space:nowrap;">EUROCODE</th>
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;">TIPO</th>
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;">CARROS</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#16a34a;font-weight:700;">EM STOCK</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">RECEBIDO</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">USADO</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">DEVOL.</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`}
+    `;
   }
 
   // ── HISTORY ───────────────────────────────────────────────────────────────
@@ -3452,7 +3543,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -238,6 +238,45 @@ exports.handler = async (event) => {
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: Object.values(latest) }) };
       }
 
+      // ── Inventory: eurocode_cache × glass_receptions ─────────────────────────
+      if (p.inventory === 'true') {
+        const isAdmin = user.role === 'admin';
+        const portalIds = user.portalIds?.length ? user.portalIds
+          : (user.portalId ? [user.portalId] : []);
+
+        const portalFilter = p.portal_id ? [parseInt(p.portal_id)]
+          : (isAdmin ? null : portalIds);
+
+        const { rows: invRows } = await client.query(`
+          SELECT
+            ec.eurocode,
+            ec.glass_types,
+            ec.car_models,
+            ec.seen_count,
+            ec.last_seen,
+            COALESCE(r.received, 0)::int  AS received,
+            COALESCE(r.consumed, 0)::int  AS consumed,
+            COALESCE(r.returned, 0)::int  AS returned,
+            GREATEST(0, COALESCE(r.received,0) - COALESCE(r.consumed,0) - COALESCE(r.returned,0))::int AS in_stock
+          FROM eurocode_cache ec
+          LEFT JOIN (
+            SELECT
+              UPPER(regexp_replace(eurocode, '^[#*]+', '')) AS canonical_ec,
+              COUNT(*) FILTER (WHERE is_return = false AND status NOT IN ('missing','return')) AS received,
+              COUNT(*) FILTER (WHERE is_return = false AND status = 'consumed') AS consumed,
+              COUNT(*) FILTER (WHERE is_return = true AND status NOT IN ('devolvido','reported')) AS returned
+            FROM glass_receptions
+            WHERE eurocode IS NOT NULL
+            ${portalFilter ? 'AND portal_id = ANY($1)' : ''}
+            GROUP BY canonical_ec
+          ) r ON r.canonical_ec = ec.eurocode
+          ORDER BY ec.seen_count DESC, ec.eurocode ASC
+          LIMIT 500
+        `, portalFilter ? [portalFilter] : []);
+
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: invRows }) };
+      }
+
       // ── Returns query (is_return=true, filtered by reason) ───────────────────
       if (p.returns) {
         const isErradoGroup = p.returns === 'errado_cancelado';


### PR DESCRIPTION
## Resumo

**Backend** — novo endpoint `GET /glass-reception?inventory=true`:
- Cruza `eurocode_cache` com `glass_receptions`
- Calcula por eurocode: recebido, consumido, devoluções, **em stock**
- Suporta filtro por `portal_id`

**Frontend** — novo separador "🗃️ Inventário" no painel do coordenador:
- Tabela com: Eurocode | Tipo (Rede/Comp./OEM) | Carros | Em Stock | Recebido | Usado | Devol.
- Dropdown para filtrar por loja
- Stock em verde se > 0, cinzento se 0

O inventário vai crescendo automaticamente à medida que se registam receções.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_