### PR TITLE
feat: confirmação substituição/reparação ao marcar Realizado no Mycar Center

### DIFF
--- a/index.html
+++ b/index.html
@@ -2275,6 +2275,10 @@
                 style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
           💔 Danificados
         </button>
+        <button id="grTabInventory" onclick="window.glassReception._switchTab('inventory')"
+                style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
+          🗃️ Inventário
+        </button>
       </div>
       <div id="grTabContent" style="padding-top:12px;"></div>
     `;
@@ -2286,7 +2290,7 @@
   }
 
   async function _switchTab(tab) {
-    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged' };
+    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged', inventory: 'grTabInventory' };
     Object.entries(tabs).forEach(([key, id]) => {
       const btn = document.getElementById(id);
       if (!btn) return;
@@ -2306,6 +2310,9 @@
     } else if (tab === 'damaged') {
       content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar…</p>`;
       await _loadReturns('partido');
+    } else if (tab === 'inventory') {
+      content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar inventário…</p>`;
+      await _loadInventory();
     } else {
       await _openHistory();
     }
@@ -2817,6 +2824,90 @@
       if (!json.success) throw new Error(json.error || json.message || "Erro desconhecido");
       document.getElementById('grRow' + id)?.remove();
     } catch (e) { alert('Erro: ' + e.message); }
+  }
+
+  // ── INVENTORY ─────────────────────────────────────────────────────────────
+  async function _loadInventory(portalId) {
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+
+    let portals = [];
+    try {
+      const res = await fetch(API + '/glass-reception?list_portals=true', { headers: authHeaders() });
+      const json = await res.json();
+      if (json.success) portals = json.data;
+    } catch(_) {}
+
+    const portalFilter = portalId ? `&portal_id=${portalId}` : '';
+    let data = [];
+    try {
+      const res = await fetch(API + '/glass-reception?inventory=true' + portalFilter, { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || json.message || 'Erro');
+      data = json.data || [];
+    } catch(e) {
+      content.innerHTML = `<p style="color:#dc2626;text-align:center;padding:20px;">Erro: ${e.message}</p>`;
+      return;
+    }
+
+    const currentPortalId = window.portalConfig?.id;
+    const portalOpts = portals.map(p =>
+      `<option value="${p.id}" ${(portalId ? parseInt(portalId) : currentPortalId) === p.id ? 'selected' : ''}>${p.name}</option>`
+    ).join('');
+
+    const typeBadge = t => {
+      const map = { rede: ['#0f172a','Rede'], complementar: ['#f59e0b','Comp.'], oem: ['#7c3aed','OEM'] };
+      const [bg, label] = map[t] || ['#94a3b8', t];
+      return `<span style="background:${bg};color:#fff;font-size:10px;font-weight:700;padding:2px 6px;border-radius:6px;margin-right:3px;">${label}</span>`;
+    };
+
+    const rows = data.map(r => {
+      const types = (r.glass_types || []).map(typeBadge).join('');
+      const cars = (r.car_models || []).join(', ') || '—';
+      const stockColor = r.in_stock > 0 ? '#16a34a' : r.in_stock === 0 ? '#64748b' : '#dc2626';
+      return `
+        <tr style="border-bottom:1px solid #f1f5f9;">
+          <td style="padding:10px 8px;font-family:monospace;font-weight:700;font-size:13px;">${r.eurocode}</td>
+          <td style="padding:10px 8px;">${types}</td>
+          <td style="padding:10px 8px;font-size:12px;color:#374151;max-width:180px;">${cars}</td>
+          <td style="padding:10px 8px;text-align:center;font-weight:800;font-size:16px;color:${stockColor};">${r.in_stock}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.received}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.consumed}</td>
+          <td style="padding:10px 8px;text-align:center;font-size:12px;color:#64748b;">${r.returned}</td>
+        </tr>`;
+    }).join('');
+
+    content.innerHTML = `
+      <div style="margin-bottom:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+        <select id="grInvPortalFilter" onchange="window.glassReception._loadInventory(this.value||undefined)"
+          style="padding:8px 12px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;font-weight:600;background:#fff;flex:1;min-width:160px;">
+          <option value="">Todas as lojas</option>
+          ${portalOpts}
+        </select>
+        <span style="font-size:12px;color:#94a3b8;">${data.length} eurocode${data.length !== 1 ? 's' : ''} conhecidos</span>
+      </div>
+      ${data.length === 0 ? `
+        <div style="text-align:center;padding:40px;color:#94a3b8;">
+          <div style="font-size:40px;margin-bottom:12px;">🗃️</div>
+          <p style="font-size:14px;font-weight:600;">Ainda sem dados. Regista receções para preencher o inventário.</p>
+        </div>` : `
+      <div style="overflow-x:auto;">
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+          <thead>
+            <tr style="background:#f8fafc;border-bottom:2px solid #e2e8f0;">
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;white-space:nowrap;">EUROCODE</th>
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;">TIPO</th>
+              <th style="padding:8px;text-align:left;font-size:11px;color:#64748b;font-weight:700;">CARROS</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#16a34a;font-weight:700;">EM STOCK</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">RECEBIDO</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">USADO</th>
+              <th style="padding:8px;text-align:center;font-size:11px;color:#64748b;font-weight:700;">DEVOL.</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`}
+    `;
   }
 
   // ── HISTORY ───────────────────────────────────────────────────────────────
@@ -3452,7 +3543,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/mycar.html
+++ b/mycar.html
@@ -611,6 +611,25 @@
   </div>
 </div>
 
+<!-- MODAL: CONFIRMAÇÃO REALIZADO -->
+<div class="modal-overlay" id="realizado-modal" onclick="if(event.target===this)closeRealizadoModal()">
+  <div class="modal" style="max-width:400px">
+    <div class="modal-header">
+      <div class="modal-header-info">
+        <div class="modal-title">✓ Marcar como Realizado</div>
+        <div class="modal-subtitle">Que tipo de serviço foi executado?</div>
+      </div>
+      <button class="modal-close" onclick="closeRealizadoModal()">×</button>
+    </div>
+    <div style="padding:24px;display:flex;flex-direction:column;gap:14px">
+      <button class="btn btn-success" style="padding:16px;font-size:1rem;font-weight:700;border-radius:10px"
+        onclick="confirmWorkType('substituicao')">🔧 Substituição</button>
+      <button class="btn" style="padding:16px;font-size:1rem;font-weight:700;border-radius:10px;background:#ede9fe;color:#6366f1;border:1px solid #c4b5fd"
+        onclick="confirmWorkType('reparacao')">🛠️ Reparação</button>
+    </div>
+  </div>
+</div>
+
 <!-- MODAL: IMPORTAR -->
 <div class="modal-overlay import-modal" id="import-modal">
   <div class="modal">
@@ -882,7 +901,11 @@ function renderDetailBody(plate) {
     <div class="service-card status-${svc.status}" id="svc-card-${svc.id}">
       <div class="service-card-header">
         <span style="font-weight:700;font-size:.9rem">#${svc.id}</span>
-        <span class="status-badge ${svc.status}">${svc.status}</span>
+        <div style="display:flex;align-items:center;gap:6px">
+          ${svc.work_type === 'substituicao' ? '<span style="background:#dcfce7;color:#166534;font-size:.75rem;font-weight:700;padding:2px 8px;border-radius:10px">🔧 Substituição</span>' : ''}
+          ${svc.work_type === 'reparacao' ? '<span style="background:#ede9fe;color:#5b21b6;font-size:.75rem;font-weight:700;padding:2px 8px;border-radius:10px">🛠️ Reparação</span>' : ''}
+          <span class="status-badge ${svc.status}">${svc.status}</span>
+        </div>
       </div>
       <div class="service-meta">
         <div class="meta-item">
@@ -929,7 +952,7 @@ function renderDetailBody(plate) {
           ${svc.status === 'pendente' ? 'disabled style="opacity:.45"' : ''}>⏳ Pendente</button>
         <button class="btn btn-sm" style="background:#ede9fe;color:#6366f1;border:1px solid #c4b5fd" onclick="updateStatus(${svc.id}, 'encomendado')"
           ${svc.status === 'encomendado' ? 'disabled style="opacity:.45"' : ''}>📦 Encomendado</button>
-        <button class="btn btn-success btn-sm" onclick="updateStatus(${svc.id}, 'realizado')"
+        <button class="btn btn-success btn-sm" onclick="confirmRealizado(${svc.id})"
           ${svc.status === 'realizado' ? 'disabled style="opacity:.45"' : ''}>✓ Realizado</button>
         <button class="btn btn-sm" style="background:#cffafe;color:#0891b2;border:1px solid #a5f3fc" onclick="updateStatus(${svc.id}, 'faturado')"
           ${svc.status === 'faturado' ? 'disabled style="opacity:.45"' : ''}>🧾 Faturado</button>
@@ -947,12 +970,33 @@ function closeDetail() {
 }
 
 // ─── STATUS UPDATE ────────────────────────────────────────────────────────────
-async function updateStatus(id, status) {
+let _realizadoPendingId = null;
+
+function confirmRealizado(id) {
+  _realizadoPendingId = id;
+  document.getElementById('realizado-modal').classList.add('open');
+}
+
+function closeRealizadoModal() {
+  _realizadoPendingId = null;
+  document.getElementById('realizado-modal').classList.remove('open');
+}
+
+async function confirmWorkType(workType) {
+  const id = _realizadoPendingId;
+  closeRealizadoModal();
+  if (id == null) return;
+  await updateStatus(id, 'realizado', workType);
+}
+
+async function updateStatus(id, status, workType) {
   try {
+    const body = { id, status };
+    if (workType) body.work_type = workType;
     const res = await fetch(`${API_BASE}/mycar-services`, {
       method: 'PATCH',
       headers: authHeaders(),
-      body: JSON.stringify({ id, status })
+      body: JSON.stringify(body)
     });
     const json = await res.json();
     if (!json.success) throw new Error(json.error);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -238,6 +238,45 @@ exports.handler = async (event) => {
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: Object.values(latest) }) };
       }
 
+      // ── Inventory: eurocode_cache × glass_receptions ─────────────────────────
+      if (p.inventory === 'true') {
+        const isAdmin = user.role === 'admin';
+        const portalIds = user.portalIds?.length ? user.portalIds
+          : (user.portalId ? [user.portalId] : []);
+
+        const portalFilter = p.portal_id ? [parseInt(p.portal_id)]
+          : (isAdmin ? null : portalIds);
+
+        const { rows: invRows } = await client.query(`
+          SELECT
+            ec.eurocode,
+            ec.glass_types,
+            ec.car_models,
+            ec.seen_count,
+            ec.last_seen,
+            COALESCE(r.received, 0)::int  AS received,
+            COALESCE(r.consumed, 0)::int  AS consumed,
+            COALESCE(r.returned, 0)::int  AS returned,
+            GREATEST(0, COALESCE(r.received,0) - COALESCE(r.consumed,0) - COALESCE(r.returned,0))::int AS in_stock
+          FROM eurocode_cache ec
+          LEFT JOIN (
+            SELECT
+              UPPER(regexp_replace(eurocode, '^[#*]+', '')) AS canonical_ec,
+              COUNT(*) FILTER (WHERE is_return = false AND status NOT IN ('missing','return')) AS received,
+              COUNT(*) FILTER (WHERE is_return = false AND status = 'consumed') AS consumed,
+              COUNT(*) FILTER (WHERE is_return = true AND status NOT IN ('devolvido','reported')) AS returned
+            FROM glass_receptions
+            WHERE eurocode IS NOT NULL
+            ${portalFilter ? 'AND portal_id = ANY($1)' : ''}
+            GROUP BY canonical_ec
+          ) r ON r.canonical_ec = ec.eurocode
+          ORDER BY ec.seen_count DESC, ec.eurocode ASC
+          LIMIT 500
+        `, portalFilter ? [portalFilter] : []);
+
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: invRows }) };
+      }
+
       // ── Returns query (is_return=true, filtered by reason) ───────────────────
       if (p.returns) {
         const isErradoGroup = p.returns === 'errado_cancelado';

--- a/netlify/functions/mycar-services.js
+++ b/netlify/functions/mycar-services.js
@@ -41,6 +41,7 @@ async function ensureTable(client) {
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMP`);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
   await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS n_obra VARCHAR(50)`);
+  await client.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS work_type VARCHAR(20)`);
   await client.query(`ALTER TABLE mycar_services DROP CONSTRAINT IF EXISTS mycar_services_status_check`);
   await client.query(`UPDATE mycar_services SET status = 'realizado' WHERE status = 'tratado'`);
   await client.query(`ALTER TABLE mycar_services ADD CONSTRAINT mycar_services_status_check CHECK (status IN ('pendente', 'encomendado', 'realizado', 'faturado', 'rejeitado'))`);
@@ -119,7 +120,7 @@ exports.handler = async (event) => {
 
     // PATCH - atualizar status de um serviço (ou marcar como visto)
     if (event.httpMethod === 'PATCH') {
-      const { id, status, notas, obs_tecnico, viewed } = JSON.parse(event.body || '{}');
+      const { id, status, notas, obs_tecnico, viewed, work_type } = JSON.parse(event.body || '{}');
 
       // Marcar como visto (pode ser sem status)
       if (id && viewed && !status) {
@@ -148,6 +149,10 @@ exports.handler = async (event) => {
       if (obs_tecnico !== undefined) {
         setClauses.push(`obs_tecnico = $${idx++}`);
         params.push(obs_tecnico);
+      }
+      if (work_type !== undefined) {
+        setClauses.push(`work_type = $${idx++}`);
+        params.push(work_type);
       }
       params.push(id);
 


### PR DESCRIPTION
## Resumo

- Quando o técnico clica em **✓ Realizado** no mural Mycar Center, aparece um modal de confirmação com dois botões: **🔧 Substituição** e **🛠️ Reparação**
- A escolha é guardada no campo `work_type` na base de dados (`mycar_services`)
- O tipo de serviço é exibido como badge colorido no card do serviço (verde para substituição, roxo para reparação)

## Alterações

- **`mycar.html`**: modal de confirmação, funções `confirmRealizado` / `confirmWorkType` / `closeRealizadoModal`, `updateStatus` aceita `workType`, badge no header do card
- **`netlify/functions/mycar-services.js`**: coluna `work_type` via `ALTER TABLE`, aceita e guarda `work_type` no PATCH

## Plano de testes

- [ ] Clicar em "✓ Realizado" num card → modal aparece com dois botões
- [ ] Clicar "Substituição" → status atualiza para realizado, badge verde aparece no card
- [ ] Clicar "Reparação" → badge roxo aparece no card
- [ ] Fechar modal (X ou clique fora) → ação cancelada, estado não muda
- [ ] Verificar campo `work_type` na base de dados após cada ação

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_