### PR TITLE
feat: Fechar Ficha — pedido de fecho com eurocode a devolver

### DIFF
--- a/close-request-patch.js
+++ b/close-request-patch.js
@@ -1,0 +1,145 @@
+// close-request-patch.js — Fechar Ficha com devolução de eurocode
+(function () {
+
+  // ── Injectar painel no modal de agendamento ─────────────────────────────────
+  function injectClosePanel() {
+    if (document.getElementById('closeRequestPanel')) return;
+
+    var actions = document.querySelector('.form-actions');
+    if (!actions) return;
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'btnFecharFicha';
+    btn.style.cssText =
+      'display:none;background:#dc2626;color:#fff;border:none;border-radius:8px;' +
+      'padding:10px 16px;font-size:14px;font-weight:700;cursor:pointer;order:-1;';
+    btn.innerHTML = '🔒 Fechar Ficha';
+    actions.insertBefore(btn, actions.firstChild);
+
+    var panel = document.createElement('div');
+    panel.id = 'closeRequestPanel';
+    panel.style.cssText =
+      'display:none;background:#fef2f2;border:2px solid #dc2626;border-radius:12px;' +
+      'padding:18px 20px;margin-bottom:12px;';
+    panel.innerHTML =
+      '<div style="font-size:14px;font-weight:800;color:#991b1b;margin-bottom:14px;">🔒 Fechar Ficha</div>' +
+      '<div style="margin-bottom:12px;">' +
+        '<label style="font-size:12px;font-weight:700;color:#991b1b;display:block;margin-bottom:4px;">Eurocode a devolver</label>' +
+        '<input id="closeReqEurocode" type="text" placeholder="Ex: 3556AGSVW" ' +
+          'style="width:100%;border:1.5px solid #fca5a5;border-radius:8px;padding:8px 12px;font-size:13px;box-sizing:border-box;">' +
+      '</div>' +
+      '<div style="margin-bottom:14px;">' +
+        '<label style="font-size:12px;font-weight:700;color:#991b1b;display:block;margin-bottom:4px;">Notas (opcional)</label>' +
+        '<textarea id="closeReqNotes" rows="2" placeholder="Motivo do fecho…" ' +
+          'style="width:100%;border:1.5px solid #fca5a5;border-radius:8px;padding:8px 12px;font-size:13px;resize:vertical;box-sizing:border-box;"></textarea>' +
+      '</div>' +
+      '<div style="display:flex;gap:10px;justify-content:flex-end;">' +
+        '<button type="button" id="closeReqCancel" ' +
+          'style="background:#e5e7eb;color:#374151;border:none;border-radius:8px;padding:8px 18px;font-weight:700;font-size:13px;cursor:pointer;">Cancelar</button>' +
+        '<button type="button" id="closeReqConfirm" ' +
+          'style="background:#dc2626;color:#fff;border:none;border-radius:8px;padding:8px 18px;font-weight:700;font-size:13px;cursor:pointer;">🔒 Confirmar Fecho</button>' +
+      '</div>';
+
+    actions.parentNode.insertBefore(panel, actions);
+
+    btn.addEventListener('click', openClosePanel);
+    document.getElementById('closeReqCancel').addEventListener('click', closeClosePanel);
+    document.getElementById('closeReqConfirm').addEventListener('click', doCloseRequest);
+  }
+
+  function openClosePanel() {
+    var eurocode = (document.getElementById('appointmentExtra') || {}).value || '';
+    document.getElementById('closeReqEurocode').value = eurocode.trim();
+    document.getElementById('closeReqNotes').value = '';
+    document.getElementById('closeRequestPanel').style.display = 'block';
+    document.getElementById('btnFecharFicha').style.display = 'none';
+  }
+
+  function closeClosePanel() {
+    var panel = document.getElementById('closeRequestPanel');
+    var btn   = document.getElementById('btnFecharFicha');
+    if (panel) panel.style.display = 'none';
+    if (btn)   btn.style.display = '';
+  }
+
+  async function doCloseRequest() {
+    var apptId = window._currentEditingId;
+    if (!apptId) {
+      var form = document.getElementById('appointmentForm');
+      apptId = form && form.dataset.editId;
+    }
+    if (!apptId) {
+      if (typeof showToast === 'function') showToast('Guarda o agendamento primeiro', 'warning');
+      return;
+    }
+
+    var eurocode = document.getElementById('closeReqEurocode').value.trim();
+    var notes    = document.getElementById('closeReqNotes').value.trim();
+    var appt     = (window.appointments || []).find(function (a) { return String(a.id) === String(apptId); });
+    var plate    = (appt && appt.plate)     || (document.getElementById('appointmentPlate')    || {}).value || '';
+    var orderRef = (appt && appt.order_ref) || (document.getElementById('appointmentOrderRef') || {}).value || '';
+    var nObra    = (appt && appt.n_obra)    || (document.getElementById('appointmentNObra')    || {}).value || '';
+
+    var confirmBtn = document.getElementById('closeReqConfirm');
+    confirmBtn.disabled = true;
+    confirmBtn.textContent = 'A guardar…';
+
+    try {
+      if (!window.glassReception || !window.glassReception._requestClose) throw new Error('Módulo não disponível');
+      await window.glassReception._requestClose(apptId, eurocode, plate, orderRef, nObra, notes);
+      closeClosePanel();
+      document.getElementById('btnFecharFicha').style.display = 'none';
+      if (typeof showToast === 'function') showToast('✅ Ficha marcada para fecho pelo coordenador', 'success');
+    } catch (e) {
+      if (typeof showToast === 'function') showToast('❌ ' + (e.message || 'Erro'), 'error');
+    } finally {
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = '🔒 Confirmar Fecho';
+    }
+  }
+
+  // ── Mostrar/esconder botão conforme modo ──────────────────────────────────
+  function syncCloseBtn(isEdit) {
+    injectClosePanel();
+    var btn = document.getElementById('btnFecharFicha');
+    if (!btn) return;
+    btn.style.display = isEdit ? '' : 'none';
+    closeClosePanel();
+  }
+
+  // ── Hook em editAppointment ───────────────────────────────────────────────
+  function hookEditAppointment() {
+    var orig = window.editAppointment;
+    if (!orig || orig._crpHooked) return;
+    window.editAppointment = function (id) {
+      orig.call(this, id);
+      setTimeout(function () { syncCloseBtn(true); }, 120);
+    };
+    window.editAppointment._crpHooked = true;
+    // preserve transfer-sm-patch hook flag
+    if (orig._tsmHooked) window.editAppointment._tsmHooked = true;
+  }
+
+  function hookCancelEdit() {
+    var orig = window.cancelEdit;
+    if (!orig || orig._crpHooked) return;
+    window.cancelEdit = function () {
+      orig.apply(this, arguments);
+      setTimeout(function () { syncCloseBtn(false); }, 50);
+    };
+    window.cancelEdit._crpHooked = true;
+  }
+
+  function init() {
+    hookEditAppointment();
+    hookCancelEdit();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    setTimeout(init, 200);
+  }
+
+})();

--- a/index.html
+++ b/index.html
@@ -797,6 +797,7 @@
   <script src="script-tail.js?v=2026-06-22k"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
+  <script src="close-request-patch.js?v=1"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=7"></script>
   <script src="/campaign-popup.js?v=2026-06-22e"></script>
@@ -2279,6 +2280,10 @@
                 style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
           🗃️ Inventário
         </button>
+        <button id="grTabCloseReqs" onclick="window.glassReception._switchTab('closeReqs')"
+                style="padding:10px 14px;border:none;border-bottom:3px solid transparent;margin-bottom:-2px;font-weight:600;cursor:pointer;color:#94a3b8;background:transparent;font-size:12px;white-space:nowrap;">
+          🔒 Fichas a Fechar
+        </button>
       </div>
       <div id="grTabContent" style="padding-top:12px;"></div>
     `;
@@ -2290,7 +2295,7 @@
   }
 
   async function _switchTab(tab) {
-    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged', inventory: 'grTabInventory' };
+    const tabs = { pending: 'grTabPending', history: 'grTabHistory', returns: 'grTabReturns', damaged: 'grTabDamaged', inventory: 'grTabInventory', closeReqs: 'grTabCloseReqs' };
     Object.entries(tabs).forEach(([key, id]) => {
       const btn = document.getElementById(id);
       if (!btn) return;
@@ -2313,6 +2318,9 @@
     } else if (tab === 'inventory') {
       content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar inventário…</p>`;
       await _loadInventory();
+    } else if (tab === 'closeReqs') {
+      content.innerHTML = `<p style="text-align:center;padding:20px;color:#64748b;">A carregar fichas a fechar…</p>`;
+      await _loadCloseRequests();
     } else {
       await _openHistory();
     }
@@ -2827,6 +2835,95 @@
   }
 
   // ── INVENTORY ─────────────────────────────────────────────────────────────
+  // ── FICHAS A FECHAR ──────────────────────────────────────────────────────────
+  async function _requestClose(appointmentId, eurocode, plate, orderRef, nObra, notes) {
+    const res = await fetch(API + '/glass-reception', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'close_request', appointment_id: appointmentId, eurocode, plate, order_ref: orderRef, n_obra: nObra, notes })
+    });
+    const json = await res.json();
+    if (!json.success) throw new Error(json.error || 'Erro ao guardar pedido de fecho');
+    return json.data;
+  }
+
+  async function _processCloseRequest(id) {
+    const res = await fetch(API + '/glass-reception', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'process_close_request', id })
+    });
+    const json = await res.json();
+    if (!json.success) throw new Error(json.error || 'Erro ao processar pedido');
+    return json;
+  }
+
+  async function _loadCloseRequests() {
+    const content = document.getElementById('grTabContent');
+    if (!content) return;
+    try {
+      const res = await fetch(API + '/glass-reception?close_requests=true', { headers: authHeaders() });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      const rows = json.data || [];
+      if (!rows.length) {
+        content.innerHTML = `<div style="text-align:center;padding:40px;color:#64748b;">
+          <div style="font-size:32px;margin-bottom:8px;">✅</div>
+          <div style="font-weight:700;">Sem fichas pendentes de fecho</div>
+        </div>`;
+        return;
+      }
+      const fmtDate = d => d ? new Date(d).toLocaleDateString('pt-PT') : '—';
+      content.innerHTML = `
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+          <thead>
+            <tr style="background:#fef2f2;color:#991b1b;">
+              <th style="padding:10px;text-align:left;font-weight:700;">Matrícula</th>
+              <th style="padding:10px;text-align:left;font-weight:700;">Serviço</th>
+              <th style="padding:10px;text-align:left;font-weight:700;font-family:monospace;">Eurocode</th>
+              <th style="padding:10px;text-align:left;font-weight:700;">FS</th>
+              <th style="padding:10px;text-align:left;font-weight:700;">Notas</th>
+              <th style="padding:10px;text-align:left;font-weight:700;">Data</th>
+              <th style="padding:10px;text-align:left;font-weight:700;">Por</th>
+              <th style="padding:10px;text-align:center;font-weight:700;">Ação</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map(r => `
+              <tr style="border-bottom:1px solid #fecaca;" id="cr-row-${r.id}">
+                <td style="padding:10px;font-weight:700;">${r.apt_plate || r.plate || '—'}</td>
+                <td style="padding:10px;color:#374151;">${r.apt_service || '—'}</td>
+                <td style="padding:10px;font-family:monospace;font-size:12px;">${r.eurocode || '—'}</td>
+                <td style="padding:10px;color:#2563eb;font-weight:700;">${r.n_obra ? 'FS' + r.n_obra : '—'}</td>
+                <td style="padding:10px;color:#6b7280;font-size:12px;">${r.notes || '—'}</td>
+                <td style="padding:10px;color:#6b7280;">${fmtDate(r.created_at)}</td>
+                <td style="padding:10px;color:#6b7280;font-size:12px;">${r.requested_by || '—'}</td>
+                <td style="padding:10px;text-align:center;">
+                  <button onclick="window.glassReception._handleProcessClose(${r.id})"
+                    style="background:#16a34a;color:#fff;border:none;border-radius:8px;padding:7px 14px;font-size:12px;font-weight:700;cursor:pointer;">
+                    ✅ Tratado
+                  </button>
+                </td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>`;
+    } catch (e) {
+      content.innerHTML = `<p style="color:#dc2626;padding:20px;text-align:center;">Erro: ${e.message}</p>`;
+    }
+  }
+
+  async function _handleProcessClose(id) {
+    try {
+      await _processCloseRequest(id);
+      const row = document.getElementById('cr-row-' + id);
+      if (row) row.style.opacity = '0.4';
+      setTimeout(() => { if (row) row.remove(); }, 600);
+    } catch (e) {
+      alert('Erro: ' + e.message);
+    }
+  }
+
   async function _loadInventory(portalId) {
     const content = document.getElementById('grTabContent');
     if (!content) return;
@@ -3433,6 +3530,7 @@
       if ((data.damaged || 0) > 0) items.push({ n: data.damaged, label: `danificado${data.damaged > 1 ? 's' : ''} por tratar`, icon: '💔', tab: 'damaged' });
       if ((data.returns || 0) > 0) items.push({ n: data.returns, label: `devoluç${data.returns > 1 ? 'ões' : 'ão'} por tratar`, icon: '↩️', tab: 'returns' });
       if ((data.missing || 0) > 0) items.push({ n: data.missing, label: `receç${data.missing > 1 ? 'ões' : 'ão'} incompleta${data.missing > 1 ? 's' : ''}`, icon: '⚠️', tab: 'missing' });
+      if ((data.close_requests || 0) > 0) items.push({ n: data.close_requests, label: `ficha${data.close_requests > 1 ? 's' : ''} a fechar`, icon: '🔒', tab: 'closeReqs' });
       if (!items.length) return;
       document.getElementById('grAlertItems').innerHTML = items.map(it => `
         <div style="display:flex;align-items:center;justify-content:space-between;padding:11px 12px;background:#f8fafc;border-radius:10px;margin-bottom:8px;">
@@ -3543,7 +3641,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception, _requestClose, _loadCloseRequests, _processCloseRequest, _handleProcessClose };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -70,6 +70,25 @@ async function ensureTable(client) {
       last_seen   TIMESTAMPTZ DEFAULT NOW()
     )
   `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS close_requests (
+      id             SERIAL PRIMARY KEY,
+      appointment_id INTEGER REFERENCES appointments(id) ON DELETE SET NULL,
+      eurocode       TEXT,
+      plate          TEXT,
+      order_ref      TEXT,
+      n_obra         TEXT,
+      portal_id      INTEGER,
+      portal_name    TEXT,
+      notes          TEXT,
+      status         VARCHAR(20) DEFAULT 'pending',
+      requested_by   TEXT,
+      created_at     TIMESTAMPTZ DEFAULT NOW(),
+      done_at        TIMESTAMPTZ,
+      done_by        TEXT
+    )
+  `);
 }
 
 exports.handler = async (event) => {
@@ -141,12 +160,18 @@ exports.handler = async (event) => {
             WHERE gr.status = 'missing' ${portalCond}`, vals),
         ]);
 
+        const closeR = await client.query(
+          `SELECT COUNT(*) AS n FROM close_requests WHERE status = 'pending' ${portalCond.replace(/gr\./g, '')}`,
+          vals
+        );
+
         return { statusCode: 200, headers, body: JSON.stringify({
           success: true,
           pending: parseInt(pendR.rows[0].n, 10) || 0,
           damaged: parseInt(damR.rows[0].n, 10) || 0,
           returns: parseInt(retR.rows[0].n, 10) || 0,
           missing: parseInt(missR.rows[0].n, 10) || 0,
+          close_requests: parseInt(closeR.rows[0].n, 10) || 0,
         })};
       }
 
@@ -174,6 +199,26 @@ exports.handler = async (event) => {
         return { statusCode: 200, headers, body: JSON.stringify({
           success: true, data: rows, count: rows.length
         })};
+      }
+
+      // ── Close requests list ───────────────────────────────────────────────────
+      if (p.close_requests === 'true') {
+        const isAdmin = user.role === 'admin';
+        const portalIds = user.portalIds?.length ? user.portalIds : (user.portalId ? [user.portalId] : []);
+        const portalCond = isAdmin ? '' : `AND cr.portal_id = ANY($1)`;
+        const vals = isAdmin ? [] : [portalIds];
+        const { rows: crRows } = await client.query(`
+          SELECT cr.*,
+                 a.plate   AS apt_plate,
+                 a.car     AS apt_car,
+                 a.service AS apt_service
+          FROM close_requests cr
+          LEFT JOIN appointments a ON a.id = cr.appointment_id
+          WHERE cr.status = 'pending'
+          ${portalCond}
+          ORDER BY cr.created_at DESC
+        `, vals);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: crRows }) };
       }
 
       // ── History query ─────────────────────────────────────────────────────────
@@ -340,6 +385,59 @@ exports.handler = async (event) => {
     // ── POST ───────────────────────────────────────────────────────────────────
     if (event.httpMethod === 'POST') {
       const d = JSON.parse(event.body || '{}');
+
+      // ── Criar pedido de fecho de ficha ────────────────────────────────────────
+      if (d.action === 'close_request') {
+        const { appointment_id, eurocode, plate, order_ref, n_obra, notes, portal_id, portal_name } = d;
+        const reqBy = user.name || user.email || null;
+        const pid = portal_id || user.portalId || null;
+        const { rows: crRows } = await client.query(`
+          INSERT INTO close_requests (appointment_id, eurocode, plate, order_ref, n_obra, portal_id, portal_name, notes, requested_by)
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          RETURNING *
+        `, [appointment_id || null, eurocode || null, plate || null, order_ref || null,
+            n_obra || null, pid, portal_name || null, notes || null, reqBy]);
+        return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: crRows[0] }) };
+      }
+
+      // ── Processar pedido de fecho (coordenador marca como Tratado) ────────────
+      if (d.action === 'process_close_request') {
+        const { id } = d;
+        const { rows: crRows } = await client.query(`SELECT * FROM close_requests WHERE id = $1`, [id]);
+        if (!crRows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Pedido não encontrado' }) };
+        const cr = crRows[0];
+
+        // 1. Remover eurocode do stock: marcar glass_reception como consumed
+        if (cr.appointment_id) {
+          const ecCond = cr.eurocode
+            ? `AND UPPER(REGEXP_REPLACE(eurocode, '^[#*]+', '')) = UPPER(REGEXP_REPLACE($2, '^[#*]+', ''))`
+            : '';
+          const ecVals = cr.eurocode ? [cr.appointment_id, cr.eurocode] : [cr.appointment_id];
+          await client.query(`
+            UPDATE glass_receptions
+            SET status = 'consumed', updated_at = NOW()
+            WHERE appointment_id = $1
+              AND is_return = false
+              AND status NOT IN ('consumed','missing','return')
+              ${ecCond}
+          `, ecVals).catch(() => {});
+
+          // 2. Fechar o agendamento
+          await client.query(
+            `UPDATE appointments SET executed = true, updated_at = NOW() WHERE id = $1`,
+            [cr.appointment_id]
+          ).catch(() => {});
+        }
+
+        // 3. Marcar pedido como tratado
+        const doneBy = user.name || user.email || null;
+        await client.query(
+          `UPDATE close_requests SET status = 'done', done_at = NOW(), done_by = $1 WHERE id = $2`,
+          [doneBy, id]
+        );
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
+      }
+
       const status = d.status === 'missing' ? 'missing' : (d.is_return ? 'return' : (d.appointment_id ? 'confirmed' : 'pending'));
 
       // When linked to an appointment, always derive portal from the appointment


### PR DESCRIPTION
## Resumo

**Fluxo completo de fecho de ficha:**

1. No modal de agendamento, aparece o botão **🔒 Fechar Ficha**
2. Ao clicar, abre um painel com o eurocode pré-preenchido + campo de notas
3. Ao confirmar, cria um registo pendente na tabela `close_requests`
4. O coordenador vê todos os pedidos no novo tab **🔒 Fichas a Fechar** no painel coordenador
5. Ao clicar **✅ Tratado**:
   - Remove o eurocode do stock (`glass_receptions` → status `consumed`)
   - Fecha o agendamento (`appointments.executed = true`)
   - Marca o pedido como feito

## Alertas

O sistema de alertas do coordenador já inclui a contagem de fichas a fechar pendentes.

## Ficheiros alterados

- `netlify/functions/glass-reception.js` — tabela `close_requests`, endpoints GET/POST
- `index.html` — tab "Fichas a Fechar", funções `_requestClose`/`_loadCloseRequests`/`_processCloseRequest`, alertas
- `close-request-patch.js` — novo ficheiro que injeta botão "Fechar Ficha" no modal de agendamento

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_