### PR TITLE
feat: botão 'Preencher histórico' para backfill do eurocode_cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -2982,6 +2982,10 @@
           ${portalOpts}
         </select>
         <span style="font-size:12px;color:#94a3b8;">${data.length} eurocode${data.length !== 1 ? 's' : ''} conhecidos</span>
+        <button onclick="window.glassReception._backfillCache()" id="btnBackfillCache"
+          style="background:#f1f5f9;border:1px solid #cbd5e1;border-radius:8px;padding:7px 12px;font-size:12px;font-weight:600;cursor:pointer;color:#374151;white-space:nowrap;">
+          🔄 Preencher histórico
+        </button>
       </div>
       ${data.length === 0 ? `
         <div style="text-align:center;padding:40px;color:#94a3b8;">
@@ -3005,6 +3009,24 @@
         </table>
       </div>`}
     `;
+  }
+
+  async function _backfillCache() {
+    const btn = document.getElementById('btnBackfillCache');
+    if (btn) { btn.disabled = true; btn.textContent = '⏳ A preencher…'; }
+    try {
+      const res = await fetch(API + '/glass-reception', {
+        method: 'PUT',
+        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'backfill_cache' })
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      await _loadInventory(document.getElementById('grInvPortalFilter')?.value || undefined);
+    } catch(e) {
+      alert('Erro: ' + e.message);
+      if (btn) { btn.disabled = false; btn.textContent = '🔄 Preencher histórico'; }
+    }
   }
 
   // ── HISTORY ───────────────────────────────────────────────────────────────
@@ -3641,7 +3663,7 @@
     });
   }
 
-  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception, _requestClose, _loadCloseRequests, _processCloseRequest, _handleProcessClose };
+  window.glassReception = { openScan, closeScan, openCoordPanel, closeCoord, _renderChoice, _renderReturnChoice, _renderReturnEurocode, _selectSubReason, _selectGlassType, _onReturnLabel, _onDamagePhoto, _removeDamagePhoto, _submitReturn, _onPhoto, _manualSearch, _step1, _doSearch, _toggleStoreFilter, _showConfirm, _confirmReception, _showOrphanConfirm, _confirmOrphanReception, _markReceived, _rejectReception, _reportAxial, _reportAxialErrado, _printReturn, _retryReturnSearch, _doReturnSearch, _confirmReturnMatch, _rejectReturnMatch, _selectReturnPortal, _loadInventory, _devolvido, _deleteReturn, _switchTab, _loadHistory, _exportCSV, _printHistory, _dismissAlert, _listPhcItems, _printPhcList, _checkPhcStock, _deleteReception, _requestClose, _loadCloseRequests, _processCloseRequest, _handleProcessClose, _backfillCache };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initVisibility);

--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -542,6 +542,46 @@ exports.handler = async (event) => {
     if (event.httpMethod === 'PUT') {
       const d = JSON.parse(event.body || '{}');
 
+      // Backfill eurocode_cache from existing glass_receptions + appointments
+      if (d.action === 'backfill_cache') {
+        const { rows: bRows } = await client.query(`
+          INSERT INTO eurocode_cache (eurocode, glass_types, car_models, seen_count, last_seen)
+          SELECT
+            UPPER(regexp_replace(gr.eurocode, '^[#*]+', '')) AS canonical,
+            array_agg(DISTINCT CASE
+              WHEN gr.eurocode LIKE '#%' THEN 'complementar'
+              WHEN gr.eurocode LIKE '*%' THEN 'oem'
+              ELSE 'rede'
+            END) AS glass_types,
+            COALESCE(
+              array_agg(DISTINCT a.car) FILTER (WHERE a.car IS NOT NULL AND TRIM(a.car) != ''),
+              '{}'::text[]
+            ) AS car_models,
+            COUNT(*) AS seen_count,
+            MAX(gr.created_at) AS last_seen
+          FROM glass_receptions gr
+          LEFT JOIN appointments a ON a.id = gr.appointment_id
+          WHERE gr.eurocode IS NOT NULL
+            AND gr.is_return = false
+          GROUP BY canonical
+          ON CONFLICT (eurocode) DO UPDATE SET
+            glass_types = (
+              SELECT array_agg(DISTINCT g)
+              FROM unnest(eurocode_cache.glass_types || EXCLUDED.glass_types) g
+              WHERE g IS NOT NULL
+            ),
+            car_models = (
+              SELECT array_agg(DISTINCT c)
+              FROM unnest(COALESCE(eurocode_cache.car_models,'{}') || COALESCE(EXCLUDED.car_models,'{}')) c
+              WHERE c IS NOT NULL AND TRIM(c) != ''
+            ),
+            seen_count = GREATEST(eurocode_cache.seen_count, EXCLUDED.seen_count),
+            last_seen  = GREATEST(eurocode_cache.last_seen,  EXCLUDED.last_seen)
+          RETURNING eurocode
+        `);
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, count: bRows.length }) };
+      }
+
       // Bulk sync: mark glasses consumed when linked appointment is Realizado
       if (d.action === 'sync_stock') {
         let allowedIds;


### PR DESCRIPTION
Adiciona botão **🔄 Preencher histórico** no tab Inventário que faz backfill do `eurocode_cache` a partir de todas as `glass_receptions` + `appointments` existentes.\n\nApós clicar, o inventário passa a mostrar TIPO e CARROS para os eurocodes históricos. Daqui para a frente cada nova receção já preenche automaticamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_