### PR TITLE
Inventário: linha separada por eurocode completo (Rede vs Comp.)

### DIFF
--- a/netlify/functions/glass-reception.js
+++ b/netlify/functions/glass-reception.js
@@ -296,29 +296,34 @@ exports.handler = async (event) => {
 
         const { rows: invRows } = await client.query(`
           SELECT
-            r.canonical_ec                     AS eurocode,
-            COALESCE(ec.glass_types,    '{}')  AS glass_types,
+            r.eurocode,
+            CASE
+              WHEN r.eurocode LIKE '#%' THEN ARRAY['complementar']::text[]
+              WHEN r.eurocode LIKE '*%' THEN ARRAY['oem']::text[]
+              ELSE ARRAY['rede']::text[]
+            END                                AS glass_types,
             COALESCE(ec.service_types,  '{}')  AS service_types,
             COALESCE(ec.car_models,     '{}')  AS car_models,
-            COALESCE(ec.seen_count,  0)     AS seen_count,
+            COALESCE(ec.seen_count,  0)        AS seen_count,
             ec.last_seen,
-            COALESCE(r.received, 0)::int    AS received,
-            COALESCE(r.consumed, 0)::int    AS consumed,
-            COALESCE(r.returned, 0)::int    AS returned,
+            COALESCE(r.received, 0)::int       AS received,
+            COALESCE(r.consumed, 0)::int       AS consumed,
+            COALESCE(r.returned, 0)::int       AS returned,
             GREATEST(0, COALESCE(r.received,0) - COALESCE(r.consumed,0) - COALESCE(r.returned,0))::int AS in_stock
           FROM (
             SELECT
-              UPPER(regexp_replace(eurocode, '^[#*]+', '')) AS canonical_ec,
+              UPPER(TRIM(eurocode)) AS eurocode,
               COUNT(*) FILTER (WHERE is_return = false AND status NOT IN ('missing','return')) AS received,
               COUNT(*) FILTER (WHERE is_return = false AND status = 'consumed')               AS consumed,
               COUNT(*) FILTER (WHERE is_return = true  AND status NOT IN ('devolvido','reported')) AS returned
             FROM glass_receptions
             WHERE eurocode IS NOT NULL
             ${portalFilter ? 'AND portal_id = ANY($1)' : ''}
-            GROUP BY canonical_ec
+            GROUP BY UPPER(TRIM(eurocode))
           ) r
-          LEFT JOIN eurocode_cache ec ON ec.eurocode = r.canonical_ec
-          ORDER BY r.received DESC, r.canonical_ec ASC
+          LEFT JOIN eurocode_cache ec
+            ON ec.eurocode = UPPER(regexp_replace(r.eurocode, '^[#*]+', ''))
+          ORDER BY r.received DESC, r.eurocode ASC
           LIMIT 500
         `, portalFilter ? [portalFilter] : []);
 


### PR DESCRIPTION
## Problema

`#7275AGAMV1P` (Complementar) e `7275AGAMV1P` (Rede) estavam a ser agrupados na mesma linha porque a query normalizava o canonical_ec retirando o prefixo. São eurocodes fisicamente diferentes e devem ter stock independente.

## Fix

- GROUP BY `UPPER(TRIM(eurocode))` — mantém o prefixo `#` / `*`
- `glass_types` derivado diretamente do prefixo (sempre correto, sem depender do cache)
- JOIN ao `eurocode_cache` continua a usar o canonical (sem prefixo) para obter `service_types` e `car_models`

## Resultado

- `7275AGAMV1P` → linha "Rede" com o seu stock
- `#7275AGAMV1P` → linha "Comp." com o seu stock


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_