### PR TITLE
Histórico: botão acessível no ecrã principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,9 @@
           <button id="btnRececaoVidrosMobile" style="display:none;" class="guia-at-upload-btn" onclick="window.glassReception?.openCoordPanel()" title="Painel de Receção de Vidros">
             📦 Receção Vidros
           </button>
+          <button id="btnHistoricoMobile" style="display:none;" class="guia-at-upload-btn" onclick="window.historicoModal?.open()" title="Histórico de Serviços">
+            🕘 Histórico
+          </button>
         </div>
       </div>
 
@@ -3719,6 +3722,9 @@
       const adminMobileBtn = document.getElementById('btnAdminPanelMobile');
       if (adminMobileBtn) adminMobileBtn.style.display = '';
     }
+    // All authenticated users: show Histórico button
+    const histBtn = document.getElementById('btnHistoricoMobile');
+    if (histBtn) histBtn.style.display = '';
   }
 
   // ── HELPERS ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problema

O modal "Histórico de Serviços" existia mas não havia nenhum botão para o abrir — estava inacessível.

## Fix

Adiciona botão **🕘 Histórico** na barra de ação principal (junto a Receção Vidros / Admin), visível para todos os utilizadores autenticados.


---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_