### PR TITLE
fix: histórico — mostrar Não Realizados em Todos e corrigir filtro por loja

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,7 @@
       if (!a.date) return false;
       if (from && a.date < from) return false;
       if (to   && a.date > to)   return false;
-      if (portal && (a.portal_name || '') !== portal) return false;
+      if (portal && String(a.portal_id || '') !== portal) return false;
       if (search) {
         const hay = [a.plate, a.car, a.client_name, a.locality, a.service, a.notes, a.portal_name].join(' ').toLowerCase();
         if (!hay.includes(search)) return false;
@@ -1083,7 +1083,7 @@
       return true;
     });
     const all  = base;
-    const rows = base.filter(a => status ? getStatus(a) === status : getStatus(a) !== 'nao_realizado');
+    const rows = status ? base.filter(a => getStatus(a) === status) : base;
     rows.sort((a, b) => {
       const av = _sortField === 'date' ? (a.date||'') : (a[_sortField]||'');
       const bv = _sortField === 'date' ? (b.date||'') : (b[_sortField]||'');
@@ -1157,7 +1157,7 @@
         if (portalEl) {
           const cur = portalEl.value;
           portalEl.innerHTML = '<option value="">Todas</option>' +
-            pJson.data.map(p => `<option value="${p.name.replace(/"/g,'&quot;')}" ${cur===p.name?'selected':''}>${p.name}</option>`).join('');
+            pJson.data.map(p => `<option value="${p.id}" ${cur===String(p.id)?'selected':''}>${p.name}</option>`).join('');
         }
       }
     } catch(e) { console.warn('histPortals fetch:', e); }
@@ -1215,7 +1215,7 @@
         if (portalEl && window._histPortals?.length) {
           const cur = portalEl.value;
           portalEl.innerHTML = '<option value="">Todas</option>' +
-            window._histPortals.map(p => `<option value="${p.name.replace(/"/g,'&quot;')}" ${cur===p.name?'selected':''}>${p.name}</option>`).join('');
+            window._histPortals.map(p => `<option value="${p.id}" ${cur===String(p.id)?'selected':''}>${p.name}</option>`).join('');
         }
         render();
       }


### PR DESCRIPTION
## Problemas corrigidos\n\n**Bug 1 — Não Realizados não apareciam com \"Todos\" selecionado**\n- `_getFiltered()` tinha `getStatus(a) !== 'nao_realizado'` como filtro padrão, excluindo sempre os Não Realizados quando nenhum estado estava selecionado\n- Corrigido: quando `status = ''` (Todos), mostra todos os registos sem exceção\n\n**Bug 2 — Filtro de loja não funcionava**\n- As options do dropdown usavam `p.name` (string) como value, e a comparação era `a.portal_name !== portal`\n- Sujeito a diferenças de encoding/espaços entre os dois datasets\n- Corrigido: options usam `p.id` (inteiro) como value, e a comparação é `String(a.portal_id) !== portal` — mais robusto e inequívoco

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_