### PR TITLE
fix: histórico — bypass 403 para admin sem portal e filtro por loja mais robusto

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,7 +1075,12 @@
       if (!a.date) return false;
       if (from && a.date < from) return false;
       if (to   && a.date > to)   return false;
-      if (portal && String(a.portal_id || '') !== portal) return false;
+      if (portal) {
+        const matchById   = String(a.portal_id || '') === portal;
+        const portalName  = (window._histPortals || []).find(p => String(p.id) === portal)?.name || '';
+        const matchByName = portalName && (a.portal_name || '') === portalName;
+        if (!matchById && !matchByName) return false;
+      }
       if (search) {
         const hay = [a.plate, a.car, a.client_name, a.locality, a.service, a.notes, a.portal_name].join(' ').toLowerCase();
         if (!hay.includes(search)) return false;

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -122,7 +122,8 @@ exports.handler = async (event) => {
     }
 
     const isCrossPortalSearch = !!(params.search_eurocode || params.search_order_ref || params.search_plate);
-    if (!portalId && !isCrossPortalSearch) {
+    const isHistoryRequest = params.history === 'true';
+    if (!portalId && !isCrossPortalSearch && !isHistoryRequest) {
       return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Utilizador sem portal atribuído' }) };
     }
 


### PR DESCRIPTION
## Problemas corrigidos\n\n**Bug 1 — Admin sem portal atribuído recebe 403 antes do history endpoint**\n- O check `!portalId` na linha 125 de `appointments.js` disparava antes do bloco `history=true` (linha 132)\n- Se admin tiver `portal_id = null` no JWT, nunca chegava a fazer a query de todos os portais\n- Corrigido: `isHistoryRequest` adicionado ao bypass (igual a `isCrossPortalSearch`)\n\n**Bug 2 — Filtro de loja falha se portal_id não corresponde**\n- Filtro frontend agora tenta primeiro por `portal_id`, depois por `portal_name` como fallback\n- Cobre casos onde agendamentos têm `portal_id` diferente do ID na tabela portals (dados legacy, importação, etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_