### PR TITLE
Fix export Excel: coluna ESTADO com cor e texto visível

### DIFF
--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.portal_name||'')}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(getLocality(a))}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.client_name||'')}</td>
-        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;"><span style="background:${statusColor[s]||'#6B7280'};color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;mso-background-alt:${statusColor[s]||'#6B7280'};">${esc(statusLabel[s]||s)}</span></td>
+        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;background:${statusColor[s]||'#6B7280'};color:#fff;font-weight:700;text-align:center;">${esc(statusLabel[s]||s)}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(nota)}</td>
       </tr>`;
     }).join('');


### PR DESCRIPTION
O Excel não renderizava o texto dentro de `<span>` com background inline, deixando a coluna ESTADO vazia. Fix: aplica a cor de fundo e texto diretamente na `<td>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_