### PR TITLE
Fix tempo do serviço OUT não gravava ao editar

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -341,6 +341,9 @@
           <option value="user_created">Utilizador criado</option>
           <option value="user_updated">Utilizador editado</option>
           <option value="user_deleted">Utilizador eliminado</option>
+          <option value="appt_created">Agendamento criado</option>
+          <option value="appt_updated">Agendamento editado</option>
+          <option value="appt_deleted">Agendamento eliminado</option>
         </select>
       </div>
       <div>
@@ -657,6 +660,9 @@
     user_created:   { label: '➕ Utilizador criado',  color: '#2563eb', bg: '#dbeafe' },
     user_updated:   { label: '✏️ Utilizador editado', color: '#d97706', bg: '#fef3c7' },
     user_deleted:   { label: '🗑️ Utilizador apagado', color: '#dc2626', bg: '#fee2e2' },
+    appt_created:   { label: '📅 Agendamento criado',  color: '#16a34a', bg: '#dcfce7' },
+    appt_updated:   { label: '✏️ Agendamento editado', color: '#d97706', bg: '#fef3c7' },
+    appt_deleted:   { label: '🗑️ Agendamento apagado', color: '#dc2626', bg: '#fee2e2' },
   };
 
   async function loadAuditLogs(page = 1) {

--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.portal_name||'')}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(getLocality(a))}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.client_name||'')}</td>
-        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;"><span style="background:${statusColor[s]||'#6B7280'};color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;mso-background-alt:${statusColor[s]||'#6B7280'};">${esc(statusLabel[s]||s)}</span></td>
+        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;background:${statusColor[s]||'#6B7280'};color:#fff;font-weight:700;text-align:center;">${esc(statusLabel[s]||s)}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(nota)}</td>
       </tr>`;
     }).join('');

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -34,6 +34,28 @@ function getUserFromToken(event) {
   return jwt.verify(token, JWT_SECRET);
 }
 
+// Regista uma acção sobre agendamentos no audit_log. Nunca lança — falha de log
+// não pode quebrar a operação principal.
+async function auditLog({ user, action, entity_id, details, event }) {
+  try {
+    const ip = event?.headers?.['x-forwarded-for']?.split(',')[0]?.trim() || null;
+    const ua = event?.headers?.['user-agent'] || null;
+    await pool.query(
+      `INSERT INTO audit_log (user_id, username, action, entity, entity_id, details, ip, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        user?.userId || null,
+        user?.username || null,
+        action,
+        'appointment',
+        entity_id != null ? String(entity_id) : null,
+        details ? JSON.stringify(details) : null,
+        ip, ua
+      ]
+    );
+  } catch (e) { console.warn('[audit appointments]', e.message); }
+}
+
 exports.handler = async (event) => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
@@ -343,6 +365,15 @@ exports.handler = async (event) => {
         data.comp_sales_faturado === true
       ];
       const { rows } = await pool.query(q, v);
+      await auditLog({
+        user, action: 'appt_created', entity_id: rows[0].id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
+          locality: rows[0].locality, service: rows[0].service,
+          confirmed: rows[0].confirmed, portal_id: rows[0].portal_id,
+          portal: user?.portalName || null
+        }
+      });
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 
@@ -448,6 +479,17 @@ exports.handler = async (event) => {
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };
+      await auditLog({
+        user, action: 'appt_updated', entity_id: id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car,
+          date_de: existingDate || '—', date_para: newDate || '—',
+          date_mudou: dateChanged,
+          locality: rows[0].locality, confirmed: rows[0].confirmed,
+          status: rows[0].status, portal_id: rows[0].portal_id,
+          portal: user?.portalName || null
+        }
+      });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 
@@ -471,6 +513,14 @@ exports.handler = async (event) => {
       );
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };
       console.log(`✅ DELETE - ${id} eliminado | plate: ${rows[0].plate} | car: ${rows[0].car} | locality: ${rows[0].locality} | date: ${rows[0].date}`);
+      await auditLog({
+        user, action: 'appt_deleted', entity_id: id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
+          locality: rows[0].locality, service: rows[0].service,
+          portal_id: rows[0].portal_id, portal: user?.portalName || null
+        }
+      });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -387,7 +387,7 @@ exports.handler = async (event) => {
       const isAdmin = user.role === 'admin';
       const isCoord = user.role === 'coordinator' || user.role === 'coordenador';
       const checkResult = await pool.query(
-        'SELECT id, portal_id, executed, not_done_reason, not_done_at, glass_removed, glass_removed_date, date FROM appointments WHERE id = $1',
+        'SELECT id, portal_id, executed, not_done_reason, not_done_at, glass_removed, glass_removed_date, date, custom_service_time FROM appointments WHERE id = $1',
         [id]
       );
       if (checkResult.rows.length === 0) {
@@ -431,7 +431,7 @@ exports.handler = async (event) => {
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
           glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36, reception_ref = $37,
           comp_sales_desc = $38, comp_sales_nif = $39, comp_sales_name = $40, comp_sales_faturado = $41,
-          order_ref = $42, glass_eurocode = $43
+          order_ref = $42, glass_eurocode = $43, custom_service_time = $44
         WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
@@ -475,7 +475,12 @@ exports.handler = async (event) => {
         data.comp_sales_name !== undefined ? (data.comp_sales_name || null) : null,
         data.comp_sales_faturado !== undefined ? (!!data.comp_sales_faturado) : false,
         data.order_ref !== undefined ? normalizeOrderRef(data.order_ref) : null,
-        data.glass_eurocode !== undefined ? (data.glass_eurocode || null) : null
+        data.glass_eurocode !== undefined ? (data.glass_eurocode || null) : null,
+        // Preservar tempo personalizado: usar o valor enviado; se não vier no payload,
+        // manter o que já está na BD (evita perder o tempo em updates parciais).
+        data.custom_service_time !== undefined
+          ? (data.custom_service_time ? parseInt(data.custom_service_time) : null)
+          : (existing.custom_service_time || null)
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };

--- a/netlify/functions/audit-log.js
+++ b/netlify/functions/audit-log.js
@@ -32,7 +32,7 @@ exports.handler = async (event) => {
     let i     = 1;
 
     if (action) { where.push(`action = $${i++}`); vals.push(action); }
-    if (user)   { where.push(`(username ILIKE $${i++} OR CAST(user_id AS TEXT) = $${i++})`); vals.push(`%${user}%`); vals.push(user); i++; }
+    if (user)   { where.push(`(username ILIKE $${i} OR CAST(user_id AS TEXT) = $${i+1})`); vals.push(`%${user}%`); vals.push(user); i += 2; }
 
     const whereClause = where.length ? 'WHERE ' + where.join(' AND ') : '';
 

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -59,6 +59,9 @@ exports.handler = async (event) => {
 
     const results = { created: 0, updated: 0, skipped: 0, errors: 0, details: [] };
 
+    // Data de hoje em formato YYYY-MM-DD (fuso servidor)
+    const todayStr = new Date().toISOString().slice(0, 10);
+
     // Garantir colunas car e n_obra em mycar_services
     try {
       await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
@@ -168,16 +171,20 @@ exports.handler = async (event) => {
             updateVals.push(newStatusUpgrade);
           }
 
-          // Se NÃO está na agenda mas Excel tem data → colocar na agenda
+          // Se NÃO está na agenda mas Excel tem data → colocar na agenda apenas se a data for futura
           if (!hasDateInDB && hasDateInExcel) {
-            updateFields.push(`date = $${idx++}`);
-            updateVals.push(svc.date);
-            updateFields.push(`period = $${idx++}`);
-            updateVals.push(svc.period || null);
-            updateFields.push(`auto_imported = $${idx++}`);
-            updateVals.push(true);
-            updateFields.push(`confirmed = $${idx++}`);
-            updateVals.push(false);
+            const isFuture = svc.date > todayStr;
+            if (isFuture) {
+              updateFields.push(`date = $${idx++}`);
+              updateVals.push(svc.date);
+              updateFields.push(`period = $${idx++}`);
+              updateVals.push(svc.period || null);
+              updateFields.push(`auto_imported = $${idx++}`);
+              updateVals.push(true);
+              updateFields.push(`confirmed = $${idx++}`);
+              updateVals.push(false);
+            }
+            // Se data <= hoje: fica como pendente sem data na agenda
           }
           // Se JÁ está na agenda → nunca mexer em date/period/confirmed
 
@@ -203,7 +210,9 @@ exports.handler = async (event) => {
 
         } else {
           // ── SERVIÇO NOVO ──
-          const hasAutoDate = !!svc.date;
+          // Data só vai para a agenda se for futura; datas de hoje ou anteriores ficam como pendente
+          const isFutureDate = svc.date && svc.date > todayStr;
+          const hasAutoDate = isFutureDate;
 
           const insertStatus = svc.reception_ref ? 'ST' : (svc.order_ref ? 'VE' : (svc.status || 'NE'));
           await pool.query(
@@ -215,8 +224,8 @@ exports.handler = async (event) => {
               $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23
             ) RETURNING id`,
             [
-              svc.date || null,
-              svc.period || null,
+              isFutureDate ? svc.date : null,
+              isFutureDate ? (svc.period || null) : null,
               String(svc.plate).trim(),
               svc.car || null,
               svc.service || null,

--- a/netlify/functions/reports.js
+++ b/netlify/functions/reports.js
@@ -31,6 +31,11 @@ exports.handler = async (event) => {
     return { statusCode: 400, headers, body: JSON.stringify({ error: 'portal_id, date_from, date_to obrigatórios' }) };
   }
 
+  // Contabilizar apenas até à data de hoje — nunca contar serviços agendados
+  // para dias futuros. Se o período pedido terminar no passado, mantém-se.
+  const today = new Date().toISOString().slice(0, 10);
+  const effectiveDateTo = dateTo > today ? today : dateTo;
+
   // Detail list for a specific KPI card
   if (params.list) {
     const type = params.list; // agendados | realizados | nao_realizados
@@ -40,20 +45,20 @@ exports.handler = async (event) => {
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3 AND executed = true
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     } else if (type === 'nao_realizados') {
       q = `SELECT date, plate, car, service, locality, period, not_done_reason,
                   GREATEST(0, ROUND(EXTRACT(EPOCH FROM (updated_at - date::timestamp)) / 86400)::int) AS days_to_close
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3 AND executed = false
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     } else {
       q = `SELECT date, plate, car, service, locality, period, not_done_reason
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     }
     try {
       const { rows } = await pool.query(q, vals);
@@ -74,7 +79,7 @@ exports.handler = async (event) => {
         COUNT(*) FILTER (WHERE date IS NULL) AS total_pendentes
       FROM appointments
       WHERE portal_id = $1
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 2. Por localidade
     const { rows: byLocality } = await pool.query(`
@@ -87,7 +92,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY locality
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 3. Por dia da semana
     const { rows: byWeekday } = await pool.query(`
@@ -100,7 +105,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY dow_num, dow_name
       ORDER BY dow_num
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 4. Por semana (evolução)
     const { rows: byWeek } = await pool.query(`
@@ -113,7 +118,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY week_start
       ORDER BY week_start
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 5. Por tipo de serviço
     const { rows: byService } = await pool.query(`
@@ -124,7 +129,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY service
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 6. Portal info
     const { rows: portalInfo } = await pool.query(
@@ -136,7 +141,7 @@ exports.handler = async (event) => {
       SELECT COUNT(DISTINCT date) AS dias_com_servicos
       FROM appointments
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 8. Totais de tempo (travel_time em minutos)
     const { rows: timeRows } = await pool.query(`
@@ -145,7 +150,7 @@ exports.handler = async (event) => {
         COUNT(*) FILTER (WHERE travel_time > 0) AS servicos_com_tempo
       FROM appointments
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 9. Serviços por comercial
     const { rows: byComercial } = await pool.query(`
@@ -166,7 +171,7 @@ exports.handler = async (event) => {
         AND a.commercial_user_id IS NOT NULL
       GROUP BY u.username
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 10. Motivos de não realização
     const { rows: byMotivo } = await pool.query(`
@@ -178,7 +183,7 @@ exports.handler = async (event) => {
         AND executed = false AND not_done_reason IS NOT NULL
       GROUP BY not_done_reason
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 11. Tempo de execução por tipo de serviço
     const { rows: byServiceTime } = await pool.query(`
@@ -191,7 +196,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY service
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 12. Equipa — check-in/check-out com serviços por dia
     let teamStats = [];
@@ -211,7 +216,7 @@ exports.handler = async (event) => {
         WHERE tc.portal_id = $1 AND tc.date BETWEEN $2::date AND $3::date
         GROUP BY tc.date, tc.checkin_at, tc.checkout_at, tc.checkin_auto, tc.checkout_auto
         ORDER BY tc.date ASC
-      `, [portalId, dateFrom, dateTo]);
+      `, [portalId, dateFrom, effectiveDateTo]);
       teamStats = rows;
     } catch(e) {
       console.error('teamStats query error:', e.message);

--- a/script.js
+++ b/script.js
@@ -2629,12 +2629,12 @@ function buildDesktopCard(a){
   const service = a.service || 'PB';
   const car = (a.car || '').toUpperCase();
   const clientNameStr = a.client_name ? a.client_name : '';
-  let _extraDisplay = '';
-  if (a.extra) {
+  let _extraDisplay = a.glass_eurocode || '';
+  if (!_extraDisplay && a.extra) {
     try {
       const _p = typeof a.extra === 'string' ? JSON.parse(a.extra) : a.extra;
-      _extraDisplay = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : '';
-    } catch(e) { _extraDisplay = ''; }
+      _extraDisplay = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : (typeof _p === 'string' ? _p : '');
+    } catch(e) { _extraDisplay = typeof a.extra === 'string' ? a.extra : ''; }
   }
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Problema\nNo serviço "Outros" (OUT), o coordenador define o tempo (ex.: 20 min), parece gravar, mas depois de refresh perde o tempo e passa a calcular o default de 90 min (1:30).\n\n## Causa\nA query de UPDATE (PUT) do `appointments.js` **não incluía** a coluna `custom_service_time`. Ao editar um agendamento para OUT e definir o tempo:\n- Localmente mostrava 20 (o payload tinha o valor) → "grava 20"\n- Mas na BD o campo ficava NULL (PUT nunca o escrevia)\n- Após refresh, o GET devolvia NULL → `getServiceTime` caía no default de 90 min = 1:30\n\n## Fix\n- Adicionado `custom_service_time = $44` ao UPDATE\n- O valor usa o que vem no payload; se o campo não for enviado (updates parciais a partir dos cards), preserva o valor existente na BD (lido no SELECT de verificação)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_