### PR TITLE
Admin: eliminar importados por confirmar com data passada

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1750,9 +1750,17 @@ async function loadSettings() {
       document.getElementById('timeREP_P').value = s.serviceTimes?.REP_P ?? 45;
       document.getElementById('timePOL_P').value = s.serviceTimes?.POL_P ?? 60;
       document.getElementById('timeRV_P').value = s.serviceTimes?.RV_P ?? 45;
+      // Autocarros
+      document.getElementById('timePB_A').value = s.serviceTimes?.PB_A ?? 150;
+      document.getElementById('timeLT_A').value = s.serviceTimes?.LT_A ?? 75;
+      document.getElementById('timeOC_A').value = s.serviceTimes?.OC_A ?? 105;
+      document.getElementById('timeREP_A').value = s.serviceTimes?.REP_A ?? 45;
+      document.getElementById('timePOL_A').value = s.serviceTimes?.POL_A ?? 60;
+      document.getElementById('timeRV_A').value = s.serviceTimes?.RV_A ?? 60;
       // Calibragem ADAS
       document.getElementById('timeCALIB_EXTRA_L').value = s.serviceTimes?.CALIB_EXTRA_L ?? 30;
       document.getElementById('timeCALIB_EXTRA_P').value = s.serviceTimes?.CALIB_EXTRA_P ?? 45;
+      document.getElementById('timeCALIB_EXTRA_A').value = s.serviceTimes?.CALIB_EXTRA_A ?? 45;
       // Rota
       document.getElementById('avgSpeed').value = s.avgSpeedKmh ?? 50;
       document.getElementById('fuelConsumption').value = s.fuelPer100km ?? 7.5;
@@ -1779,8 +1787,15 @@ async function saveSettings() {
       REP_P: parseInt(document.getElementById('timeREP_P').value) || 45,
       POL_P: parseInt(document.getElementById('timePOL_P').value) || 60,
       RV_P: parseInt(document.getElementById('timeRV_P').value) || 45,
+      PB_A: parseInt(document.getElementById('timePB_A').value) || 150,
+      LT_A: parseInt(document.getElementById('timeLT_A').value) || 75,
+      OC_A: parseInt(document.getElementById('timeOC_A').value) || 105,
+      REP_A: parseInt(document.getElementById('timeREP_A').value) || 45,
+      POL_A: parseInt(document.getElementById('timePOL_A').value) || 60,
+      RV_A: parseInt(document.getElementById('timeRV_A').value) || 60,
       CALIB_EXTRA_L: parseInt(document.getElementById('timeCALIB_EXTRA_L').value) || 30,
-      CALIB_EXTRA_P: parseInt(document.getElementById('timeCALIB_EXTRA_P').value) || 45
+      CALIB_EXTRA_P: parseInt(document.getElementById('timeCALIB_EXTRA_P').value) || 45,
+      CALIB_EXTRA_A: parseInt(document.getElementById('timeCALIB_EXTRA_A').value) || 45
     },
     avgSpeedKmh: parseFloat(document.getElementById('avgSpeed').value) || 50,
     fuelPer100km: parseFloat(document.getElementById('fuelConsumption').value) || 7.5,

--- a/admin-script.js
+++ b/admin-script.js
@@ -1823,6 +1823,34 @@ async function saveSettings() {
   }
 }
 
+async function cleanupImported() {
+  if (!confirm('Eliminar PERMANENTEMENTE todos os serviços importados por confirmar com data até hoje, em todas as lojas?\n\nEsta ação não pode ser revertida.')) return;
+  const btn = document.getElementById('btnCleanupImported');
+  const status = document.getElementById('cleanupImportedStatus');
+  if (btn) { btn.disabled = true; btn.style.opacity = '0.6'; }
+  if (status) { status.style.display = 'inline'; status.style.color = '#6b7280'; status.textContent = 'A eliminar...'; }
+  try {
+    const response = await authClient.authenticatedFetch('/.netlify/functions/cleanup-imported', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const data = await response.json();
+    if (data.success) {
+      if (status) { status.style.color = '#16a34a'; status.textContent = `✅ ${data.removed} serviço(s) eliminado(s)`; }
+      showToast(`${data.removed} serviço(s) importado(s) eliminado(s)`, 'success');
+    } else {
+      if (status) { status.style.color = '#dc2626'; status.textContent = '❌ ' + (data.error || 'Erro'); }
+      showToast(data.error || 'Erro ao limpar', 'error');
+    }
+  } catch (err) {
+    console.error('Erro ao limpar importados:', err);
+    if (status) { status.style.color = '#dc2626'; status.textContent = '❌ Erro de ligação'; }
+    showToast('Erro ao limpar importados', 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.style.opacity = '1'; }
+  }
+}
+
 // Carregar settings ao abrir a tab
 document.querySelectorAll('.nav-tab').forEach(tab => {
   tab.addEventListener('click', () => {

--- a/admin.html
+++ b/admin.html
@@ -196,11 +196,21 @@
             <div class="settings-field"><label>POL - Polimento</label><div class="input-suffix"><input type="number" id="timePOL_P" min="0" step="5" value="60"><span>min</span></div></div>
             <div class="settings-field"><label>RV - Retirar Vidro</label><div class="input-suffix"><input type="number" id="timeRV_P" min="0" step="5" value="45"><span>min</span></div></div>
           </div>
+          <h4 style="margin:20px 0 8px;color:#16a34a;font-size:14px;">🚌 Autocarros</h4>
+          <div class="settings-grid">
+            <div class="settings-field"><label>PB - Para-brisas</label><div class="input-suffix"><input type="number" id="timePB_A" min="0" step="5" value="150"><span>min</span></div></div>
+            <div class="settings-field"><label>LT - Lateral</label><div class="input-suffix"><input type="number" id="timeLT_A" min="0" step="5" value="75"><span>min</span></div></div>
+            <div class="settings-field"><label>OC - Óculo</label><div class="input-suffix"><input type="number" id="timeOC_A" min="0" step="5" value="105"><span>min</span></div></div>
+            <div class="settings-field"><label>REP - Reparação</label><div class="input-suffix"><input type="number" id="timeREP_A" min="0" step="5" value="45"><span>min</span></div></div>
+            <div class="settings-field"><label>POL - Polimento</label><div class="input-suffix"><input type="number" id="timePOL_A" min="0" step="5" value="60"><span>min</span></div></div>
+            <div class="settings-field"><label>RV - Retirar Vidro</label><div class="input-suffix"><input type="number" id="timeRV_A" min="0" step="5" value="60"><span>min</span></div></div>
+          </div>
           <h4 style="margin:20px 0 8px;color:#7c3aed;font-size:14px;">📡 Calibragem ADAS — tempo extra</h4>
           <p style="font-size:12px;color:#6b7280;margin:-4px 0 10px;">Minutos adicionados ao tempo base quando o serviço requer calibragem ADAS.</p>
           <div class="settings-grid">
             <div class="settings-field"><label>🚗 Ligeiro + calibragem</label><div class="input-suffix"><input type="number" id="timeCALIB_EXTRA_L" min="0" step="5" value="30"><span>min extra</span></div></div>
             <div class="settings-field"><label>🚛 Pesado + calibragem</label><div class="input-suffix"><input type="number" id="timeCALIB_EXTRA_P" min="0" step="5" value="45"><span>min extra</span></div></div>
+            <div class="settings-field"><label>🚌 Autocarro + calibragem</label><div class="input-suffix"><input type="number" id="timeCALIB_EXTRA_A" min="0" step="5" value="45"><span>min extra</span></div></div>
           </div>
         </div>
 

--- a/admin.html
+++ b/admin.html
@@ -341,6 +341,9 @@
           <option value="user_created">Utilizador criado</option>
           <option value="user_updated">Utilizador editado</option>
           <option value="user_deleted">Utilizador eliminado</option>
+          <option value="appt_created">Agendamento criado</option>
+          <option value="appt_updated">Agendamento editado</option>
+          <option value="appt_deleted">Agendamento eliminado</option>
         </select>
       </div>
       <div>
@@ -657,6 +660,9 @@
     user_created:   { label: '➕ Utilizador criado',  color: '#2563eb', bg: '#dbeafe' },
     user_updated:   { label: '✏️ Utilizador editado', color: '#d97706', bg: '#fef3c7' },
     user_deleted:   { label: '🗑️ Utilizador apagado', color: '#dc2626', bg: '#fee2e2' },
+    appt_created:   { label: '📅 Agendamento criado',  color: '#16a34a', bg: '#dcfce7' },
+    appt_updated:   { label: '✏️ Agendamento editado', color: '#d97706', bg: '#fef3c7' },
+    appt_deleted:   { label: '🗑️ Agendamento apagado', color: '#dc2626', bg: '#fee2e2' },
   };
 
   async function loadAuditLogs(page = 1) {

--- a/admin.html
+++ b/admin.html
@@ -237,6 +237,13 @@
           </div>
         </div>
 
+        <div class="settings-card" style="border:1px solid #fecaca;background:#fef2f2;">
+          <h3 style="margin-bottom:6px;color:#b91c1c;">🧹 Limpar importados por confirmar</h3>
+          <p style="font-size:13px;color:#6b7280;margin:0 0 14px;">Elimina permanentemente os serviços importados (cartões cinzas a piscar) que ainda estão por confirmar e cuja data já passou (até hoje, inclusive), em todas as lojas. Se voltarem a fazer falta, são reimportados pelo Excel.</p>
+          <button id="btnCleanupImported" onclick="cleanupImported()" style="background:#dc2626;color:#fff;border:none;padding:10px 18px;border-radius:8px;font-weight:700;font-size:14px;cursor:pointer;">🗑️ Eliminar importados por confirmar (data passada)</button>
+          <span id="cleanupImportedStatus" style="margin-left:12px;font-size:14px;display:none;"></span>
+        </div>
+
         <div style="margin-top:20px;">
           <button class="btn-primary" onclick="saveSettings()">💾 Guardar Configurações</button>
           <span id="settingsSaveStatus" style="margin-left:12px;color:#16a34a;font-size:14px;display:none;">✅ Guardado!</span>

--- a/index.html
+++ b/index.html
@@ -528,6 +528,7 @@
               <select id="appointmentVehicleType">
                 <option value="L">🚗 Ligeiro</option>
                 <option value="P">🚛 Pesado</option>
+                <option value="A">🚌 Autocarro</option>
               </select>
             </div>
             <div class="form-group"></div>

--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.portal_name||'')}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(getLocality(a))}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(a.client_name||'')}</td>
-        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;"><span style="background:${statusColor[s]||'#6B7280'};color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;mso-background-alt:${statusColor[s]||'#6B7280'};">${esc(statusLabel[s]||s)}</span></td>
+        <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;background:${statusColor[s]||'#6B7280'};color:#fff;font-weight:700;text-align:center;">${esc(statusLabel[s]||s)}</td>
         <td style="padding:6px 10px;border-bottom:1px solid #E2E8F0;">${esc(nota)}</td>
       </tr>`;
     }).join('');

--- a/multi-service-patch.js
+++ b/multi-service-patch.js
@@ -12,7 +12,7 @@ function getAllServices(a) {
 
 function getTotalServiceTime(a) {
   const vt = a.vehicleType || a.vehicle_type || 'L';
-  const svcTimes = { PB_L:90,LT_L:45,OC_L:60,REP_L:30,POL_L:45,RV_L:30,OUT_L:60, PB_P:120,LT_P:60,OC_P:90,REP_P:45,POL_P:60,RV_P:45,OUT_P:90, CALIB_EXTRA_L:30,CALIB_EXTRA_P:45 };
+  const svcTimes = (typeof SERVICE_TIMES !== 'undefined' && SERVICE_TIMES) ? SERVICE_TIMES : { PB_L:90,LT_L:45,OC_L:60,REP_L:30,POL_L:45,RV_L:30,OUT_L:60, PB_P:120,LT_P:60,OC_P:90,REP_P:45,POL_P:60,RV_P:45,OUT_P:90, PB_A:150,LT_A:75,OC_A:105,REP_A:45,POL_A:60,RV_A:60,OUT_A:90, CALIB_EXTRA_L:30,CALIB_EXTRA_P:45,CALIB_EXTRA_A:45 };
   const vtKey = (vt||'L').toUpperCase().charAt(0);
   return getAllServices(a).reduce((sum, s) => {
     const code = (s.service||'PB').toUpperCase().split('-')[0].split(' ')[0];

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -34,6 +34,28 @@ function getUserFromToken(event) {
   return jwt.verify(token, JWT_SECRET);
 }
 
+// Regista uma acção sobre agendamentos no audit_log. Nunca lança — falha de log
+// não pode quebrar a operação principal.
+async function auditLog({ user, action, entity_id, details, event }) {
+  try {
+    const ip = event?.headers?.['x-forwarded-for']?.split(',')[0]?.trim() || null;
+    const ua = event?.headers?.['user-agent'] || null;
+    await pool.query(
+      `INSERT INTO audit_log (user_id, username, action, entity, entity_id, details, ip, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        user?.userId || null,
+        user?.username || null,
+        action,
+        'appointment',
+        entity_id != null ? String(entity_id) : null,
+        details ? JSON.stringify(details) : null,
+        ip, ua
+      ]
+    );
+  } catch (e) { console.warn('[audit appointments]', e.message); }
+}
+
 exports.handler = async (event) => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
@@ -343,6 +365,15 @@ exports.handler = async (event) => {
         data.comp_sales_faturado === true
       ];
       const { rows } = await pool.query(q, v);
+      await auditLog({
+        user, action: 'appt_created', entity_id: rows[0].id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
+          locality: rows[0].locality, service: rows[0].service,
+          confirmed: rows[0].confirmed, portal_id: rows[0].portal_id,
+          portal: user?.portalName || null
+        }
+      });
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 
@@ -448,6 +479,17 @@ exports.handler = async (event) => {
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };
+      await auditLog({
+        user, action: 'appt_updated', entity_id: id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car,
+          date_de: existingDate || '—', date_para: newDate || '—',
+          date_mudou: dateChanged,
+          locality: rows[0].locality, confirmed: rows[0].confirmed,
+          status: rows[0].status, portal_id: rows[0].portal_id,
+          portal: user?.portalName || null
+        }
+      });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 
@@ -471,6 +513,14 @@ exports.handler = async (event) => {
       );
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };
       console.log(`✅ DELETE - ${id} eliminado | plate: ${rows[0].plate} | car: ${rows[0].car} | locality: ${rows[0].locality} | date: ${rows[0].date}`);
+      await auditLog({
+        user, action: 'appt_deleted', entity_id: id, event,
+        details: {
+          plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
+          locality: rows[0].locality, service: rows[0].service,
+          portal_id: rows[0].portal_id, portal: user?.portalName || null
+        }
+      });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
     }
 

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -387,7 +387,7 @@ exports.handler = async (event) => {
       const isAdmin = user.role === 'admin';
       const isCoord = user.role === 'coordinator' || user.role === 'coordenador';
       const checkResult = await pool.query(
-        'SELECT id, portal_id, executed, not_done_reason, not_done_at, glass_removed, glass_removed_date, date FROM appointments WHERE id = $1',
+        'SELECT id, portal_id, executed, not_done_reason, not_done_at, glass_removed, glass_removed_date, date, custom_service_time FROM appointments WHERE id = $1',
         [id]
       );
       if (checkResult.rows.length === 0) {
@@ -431,7 +431,7 @@ exports.handler = async (event) => {
           return_km = $25, return_time = $26, client_name = $27, damage_details = $28, glass_removed = $29, extra_services = $30,
           glass_removed_date = $31, n_obra = $32, updated_at = $33, not_done_at = $36, reception_ref = $37,
           comp_sales_desc = $38, comp_sales_nif = $39, comp_sales_name = $40, comp_sales_faturado = $41,
-          order_ref = $42, glass_eurocode = $43
+          order_ref = $42, glass_eurocode = $43, custom_service_time = $44
         WHERE id = $34 AND portal_id = $35
         RETURNING *
       `;
@@ -475,7 +475,12 @@ exports.handler = async (event) => {
         data.comp_sales_name !== undefined ? (data.comp_sales_name || null) : null,
         data.comp_sales_faturado !== undefined ? (!!data.comp_sales_faturado) : false,
         data.order_ref !== undefined ? normalizeOrderRef(data.order_ref) : null,
-        data.glass_eurocode !== undefined ? (data.glass_eurocode || null) : null
+        data.glass_eurocode !== undefined ? (data.glass_eurocode || null) : null,
+        // Preservar tempo personalizado: usar o valor enviado; se não vier no payload,
+        // manter o que já está na BD (evita perder o tempo em updates parciais).
+        data.custom_service_time !== undefined
+          ? (data.custom_service_time ? parseInt(data.custom_service_time) : null)
+          : (existing.custom_service_time || null)
       ];
       const { rows } = await pool.query(q, v);
       if (!rows.length) return { statusCode: 404, headers, body: JSON.stringify({ success: false, error: 'Agendamento não encontrado' }) };

--- a/netlify/functions/audit-log.js
+++ b/netlify/functions/audit-log.js
@@ -32,7 +32,7 @@ exports.handler = async (event) => {
     let i     = 1;
 
     if (action) { where.push(`action = $${i++}`); vals.push(action); }
-    if (user)   { where.push(`(username ILIKE $${i++} OR CAST(user_id AS TEXT) = $${i++})`); vals.push(`%${user}%`); vals.push(user); i++; }
+    if (user)   { where.push(`(username ILIKE $${i} OR CAST(user_id AS TEXT) = $${i+1})`); vals.push(`%${user}%`); vals.push(user); i += 2; }
 
     const whereClause = where.length ? 'WHERE ' + where.join(' AND ') : '';
 

--- a/netlify/functions/cleanup-imported.js
+++ b/netlify/functions/cleanup-imported.js
@@ -1,0 +1,71 @@
+// netlify/functions/cleanup-imported.js
+// Elimina permanentemente os serviços importados (auto_imported) que ainda
+// estão por confirmar e cuja data já passou (<= hoje) — os cartões cinzas a
+// piscar na agenda. Se voltarem a fazer falta, são reimportados pelo Excel.
+// Apenas administradores. Chamada manual via POST com token.
+
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Content-Type': 'application/json'
+};
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };
+  }
+
+  let user;
+  try {
+    const auth = event.headers.authorization || event.headers.Authorization || '';
+    user = jwt.verify(auth.replace('Bearer ', ''), JWT_SECRET);
+    if (user.role !== 'admin') throw new Error('Acesso negado: apenas administradores');
+  } catch (e) {
+    return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: e.message }) };
+  }
+
+  try {
+    // Cartões cinzas a piscar = importados, ainda por confirmar (status NE),
+    // não realizados, com data já passada (<= hoje).
+    const { rows } = await pool.query(`
+      DELETE FROM appointments
+      WHERE auto_imported = true
+        AND date IS NOT NULL
+        AND date <= CURRENT_DATE
+        AND executed IS NOT TRUE
+        AND (status IS NULL OR status = 'NE')
+      RETURNING id, plate, date, portal_id
+    `);
+
+    // Registar na auditoria
+    try {
+      await pool.query(
+        `INSERT INTO audit_log (user_id, username, action, entity, details, created_at)
+         VALUES ($1, $2, 'cleanup_imported', 'appointment', $3, NOW())`,
+        [user.userId || null, user.username || null, JSON.stringify({
+          removed: rows.length,
+          plates: rows.map(r => r.plate)
+        })]
+      );
+    } catch (e) { console.warn('[cleanup-imported audit]', e.message); }
+
+    console.log(`[cleanup-imported] ${rows.length} serviços importados por confirmar eliminados`);
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ success: true, removed: rows.length, items: rows })
+    };
+  } catch (e) {
+    console.error('[cleanup-imported]', e.message);
+    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: e.message }) };
+  }
+};

--- a/netlify/functions/import-services.js
+++ b/netlify/functions/import-services.js
@@ -59,6 +59,9 @@ exports.handler = async (event) => {
 
     const results = { created: 0, updated: 0, skipped: 0, errors: 0, details: [] };
 
+    // Data de hoje em formato YYYY-MM-DD (fuso servidor)
+    const todayStr = new Date().toISOString().slice(0, 10);
+
     // Garantir colunas car e n_obra em mycar_services
     try {
       await pool.query(`ALTER TABLE mycar_services ADD COLUMN IF NOT EXISTS car TEXT`);
@@ -168,16 +171,20 @@ exports.handler = async (event) => {
             updateVals.push(newStatusUpgrade);
           }
 
-          // Se NÃO está na agenda mas Excel tem data → colocar na agenda
+          // Se NÃO está na agenda mas Excel tem data → colocar na agenda apenas se a data for futura
           if (!hasDateInDB && hasDateInExcel) {
-            updateFields.push(`date = $${idx++}`);
-            updateVals.push(svc.date);
-            updateFields.push(`period = $${idx++}`);
-            updateVals.push(svc.period || null);
-            updateFields.push(`auto_imported = $${idx++}`);
-            updateVals.push(true);
-            updateFields.push(`confirmed = $${idx++}`);
-            updateVals.push(false);
+            const isFuture = svc.date > todayStr;
+            if (isFuture) {
+              updateFields.push(`date = $${idx++}`);
+              updateVals.push(svc.date);
+              updateFields.push(`period = $${idx++}`);
+              updateVals.push(svc.period || null);
+              updateFields.push(`auto_imported = $${idx++}`);
+              updateVals.push(true);
+              updateFields.push(`confirmed = $${idx++}`);
+              updateVals.push(false);
+            }
+            // Se data <= hoje: fica como pendente sem data na agenda
           }
           // Se JÁ está na agenda → nunca mexer em date/period/confirmed
 
@@ -203,7 +210,9 @@ exports.handler = async (event) => {
 
         } else {
           // ── SERVIÇO NOVO ──
-          const hasAutoDate = !!svc.date;
+          // Data só vai para a agenda se for futura; datas de hoje ou anteriores ficam como pendente
+          const isFutureDate = svc.date && svc.date > todayStr;
+          const hasAutoDate = isFutureDate;
 
           const insertStatus = svc.reception_ref ? 'ST' : (svc.order_ref ? 'VE' : (svc.status || 'NE'));
           await pool.query(
@@ -215,8 +224,8 @@ exports.handler = async (event) => {
               $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23
             ) RETURNING id`,
             [
-              svc.date || null,
-              svc.period || null,
+              isFutureDate ? svc.date : null,
+              isFutureDate ? (svc.period || null) : null,
               String(svc.plate).trim(),
               svc.car || null,
               svc.service || null,

--- a/netlify/functions/reports.js
+++ b/netlify/functions/reports.js
@@ -31,6 +31,11 @@ exports.handler = async (event) => {
     return { statusCode: 400, headers, body: JSON.stringify({ error: 'portal_id, date_from, date_to obrigatórios' }) };
   }
 
+  // Contabilizar apenas até à data de hoje — nunca contar serviços agendados
+  // para dias futuros. Se o período pedido terminar no passado, mantém-se.
+  const today = new Date().toISOString().slice(0, 10);
+  const effectiveDateTo = dateTo > today ? today : dateTo;
+
   // Detail list for a specific KPI card
   if (params.list) {
     const type = params.list; // agendados | realizados | nao_realizados
@@ -40,20 +45,20 @@ exports.handler = async (event) => {
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3 AND executed = true
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     } else if (type === 'nao_realizados') {
       q = `SELECT date, plate, car, service, locality, period, not_done_reason,
                   GREATEST(0, ROUND(EXTRACT(EPOCH FROM (updated_at - date::timestamp)) / 86400)::int) AS days_to_close
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3 AND executed = false
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     } else {
       q = `SELECT date, plate, car, service, locality, period, not_done_reason
            FROM appointments
            WHERE portal_id = $1 AND date BETWEEN $2 AND $3
            ORDER BY date ASC, plate ASC`;
-      vals = [portalId, dateFrom, dateTo];
+      vals = [portalId, dateFrom, effectiveDateTo];
     }
     try {
       const { rows } = await pool.query(q, vals);
@@ -74,7 +79,7 @@ exports.handler = async (event) => {
         COUNT(*) FILTER (WHERE date IS NULL) AS total_pendentes
       FROM appointments
       WHERE portal_id = $1
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 2. Por localidade
     const { rows: byLocality } = await pool.query(`
@@ -87,7 +92,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY locality
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 3. Por dia da semana
     const { rows: byWeekday } = await pool.query(`
@@ -100,7 +105,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY dow_num, dow_name
       ORDER BY dow_num
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 4. Por semana (evolução)
     const { rows: byWeek } = await pool.query(`
@@ -113,7 +118,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY week_start
       ORDER BY week_start
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 5. Por tipo de serviço
     const { rows: byService } = await pool.query(`
@@ -124,7 +129,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY service
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 6. Portal info
     const { rows: portalInfo } = await pool.query(
@@ -136,7 +141,7 @@ exports.handler = async (event) => {
       SELECT COUNT(DISTINCT date) AS dias_com_servicos
       FROM appointments
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 8. Totais de tempo (travel_time em minutos)
     const { rows: timeRows } = await pool.query(`
@@ -145,7 +150,7 @@ exports.handler = async (event) => {
         COUNT(*) FILTER (WHERE travel_time > 0) AS servicos_com_tempo
       FROM appointments
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 9. Serviços por comercial
     const { rows: byComercial } = await pool.query(`
@@ -166,7 +171,7 @@ exports.handler = async (event) => {
         AND a.commercial_user_id IS NOT NULL
       GROUP BY u.username
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 10. Motivos de não realização
     const { rows: byMotivo } = await pool.query(`
@@ -178,7 +183,7 @@ exports.handler = async (event) => {
         AND executed = false AND not_done_reason IS NOT NULL
       GROUP BY not_done_reason
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 11. Tempo de execução por tipo de serviço
     const { rows: byServiceTime } = await pool.query(`
@@ -191,7 +196,7 @@ exports.handler = async (event) => {
       WHERE portal_id = $1 AND date BETWEEN $2 AND $3
       GROUP BY service
       ORDER BY total DESC
-    `, [portalId, dateFrom, dateTo]);
+    `, [portalId, dateFrom, effectiveDateTo]);
 
     // 12. Equipa — check-in/check-out com serviços por dia
     let teamStats = [];
@@ -211,7 +216,7 @@ exports.handler = async (event) => {
         WHERE tc.portal_id = $1 AND tc.date BETWEEN $2::date AND $3::date
         GROUP BY tc.date, tc.checkin_at, tc.checkout_at, tc.checkin_auto, tc.checkout_auto
         ORDER BY tc.date ASC
-      `, [portalId, dateFrom, dateTo]);
+      `, [portalId, dateFrom, effectiveDateTo]);
       teamStats = rows;
     } catch(e) {
       console.error('teamStats query error:', e.message);

--- a/netlify/functions/settings.js
+++ b/netlify/functions/settings.js
@@ -18,9 +18,11 @@ function verifyToken(event) {
 
 // Valores default
 const DEFAULT_SETTINGS = {
-  serviceTimes: { 
-    PB_L: 90, LT_L: 45, OC_L: 60, REP_L: 30, POL_L: 45,
-    PB_P: 120, LT_P: 60, OC_P: 90, REP_P: 45, POL_P: 60
+  serviceTimes: {
+    PB_L: 90, LT_L: 45, OC_L: 60, REP_L: 30, POL_L: 45, RV_L: 30,
+    PB_P: 120, LT_P: 60, OC_P: 90, REP_P: 45, POL_P: 60, RV_P: 45,
+    PB_A: 150, LT_A: 75, OC_A: 105, REP_A: 45, POL_A: 60, RV_A: 60,
+    CALIB_EXTRA_L: 30, CALIB_EXTRA_P: 45, CALIB_EXTRA_A: 45
   },
   avgSpeedKmh: 50,
   fuelPer100km: 7.5,

--- a/script.js
+++ b/script.js
@@ -1033,9 +1033,11 @@ const ROUTE_CONFIG = {
 const SERVICE_TIMES = {
   PB_L: 90, LT_L: 45, OC_L: 60, REP_L: 30, POL_L: 45, RV_L: 30, OUT_L: 60,
   PB_P: 120, LT_P: 60, OC_P: 90, REP_P: 45, POL_P: 60, RV_P: 45, OUT_P: 90,
+  PB_A: 150, LT_A: 75, OC_A: 105, REP_A: 45, POL_A: 60, RV_A: 60, OUT_A: 90,
   // Tempo extra por calibragem ADAS (em minutos, somado ao serviço base)
   CALIB_EXTRA_L: 30,
-  CALIB_EXTRA_P: 45
+  CALIB_EXTRA_P: 45,
+  CALIB_EXTRA_A: 45
 };
 
 // Carregar configurações da API
@@ -1059,6 +1061,7 @@ async function loadRouteSettings() {
         // garantir que CALIB_EXTRA fica sempre disponível com defaults
         if (!SERVICE_TIMES.CALIB_EXTRA_L) SERVICE_TIMES.CALIB_EXTRA_L = 30;
         if (!SERVICE_TIMES.CALIB_EXTRA_P) SERVICE_TIMES.CALIB_EXTRA_P = 45;
+        if (!SERVICE_TIMES.CALIB_EXTRA_A) SERVICE_TIMES.CALIB_EXTRA_A = 45;
       }
     }
 

--- a/script.js
+++ b/script.js
@@ -2629,12 +2629,12 @@ function buildDesktopCard(a){
   const service = a.service || 'PB';
   const car = (a.car || '').toUpperCase();
   const clientNameStr = a.client_name ? a.client_name : '';
-  let _extraDisplay = '';
-  if (a.extra) {
+  let _extraDisplay = a.glass_eurocode || '';
+  if (!_extraDisplay && a.extra) {
     try {
       const _p = typeof a.extra === 'string' ? JSON.parse(a.extra) : a.extra;
-      _extraDisplay = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : '';
-    } catch(e) { _extraDisplay = ''; }
+      _extraDisplay = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : (typeof _p === 'string' ? _p : '');
+    } catch(e) { _extraDisplay = typeof a.extra === 'string' ? a.extra : ''; }
   }
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';


### PR DESCRIPTION
## Pedido\nEliminar os serviços importados (cartões cinzas a piscar, por confirmar) com data até hoje inclusive. Se voltarem a fazer falta, são reimportados pelo Excel.\n\n## Solução\n- **Novo endpoint** `cleanup-imported.js` (admin-only, POST): elimina permanentemente os agendamentos onde `auto_imported = true`, `date <= hoje`, `executed IS NOT TRUE` e `status NE/null` — em todas as lojas. Regista a ação no audit_log.\n- **Admin** (`admin.html` + `admin-script.js`): novo cartão "🧹 Limpar importados por confirmar" na secção Definições, com botão e confirmação. Mostra quantos foram eliminados.\n\nFica sob controlo do admin (carrega quando quiser, ex.: ao fim do dia). Posso transformar isto numa rotina automática diária se preferires.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_