### PR TITLE
Fix modelo IA descontinuado (análise de relatórios + assistente agenda)

### DIFF
--- a/netlify/functions/agenda-ai.js
+++ b/netlify/functions/agenda-ai.js
@@ -10,7 +10,7 @@ function callAnthropic(systemPrompt, messages) {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
 
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1000,
       system: systemPrompt,
       messages

--- a/netlify/functions/report-ai.js
+++ b/netlify/functions/report-ai.js
@@ -11,7 +11,7 @@ function callAnthropic(systemPrompt, messages) {
   return new Promise((resolve, reject) => {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1200,
       system: systemPrompt,
       messages


### PR DESCRIPTION
## Erro\nA análise IA do relatório devolvia `❌ model: claude-sonnet-4-20250514`.\n\n## Causa\nEsse ID de modelo foi descontinuado (retirou a 15/06/2026), por isso a API da Anthropic rejeita o pedido. O assistente da agenda (`agenda-ai.js`) usava o mesmo ID e estava igualmente a falhar.\n\n## Fix\nAtualizar ambas as funções para o ID atual `claude-sonnet-4-6`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_