### PR TITLE
Fix soma de tempos (timeline) + cache busting das correções

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2389,7 +2389,11 @@ function renderReport(data) {
                     const dias = !isNaN(grMs) ? Math.floor((Date.now() - grMs) / 86400000) : null;
                     const diasCor = dias === null ? '#64748b' : dias >= 14 ? '#dc2626' : dias >= 7 ? '#f59e0b' : '#2563eb';
                     const diasLabel = dias === null ? '?' : dias + 'd';
-                    const scheduledDate = a.date ? fmtD(a.date) : '<span style="color:#94a3b8;">—</span>';
+                    // "Reagendado" só conta se a data do agendamento for POSTERIOR à retirada.
+                    // Se for igual/anterior, ainda não houve reagendamento real → "—".
+                    const schedNorm = normDate(a.date);
+                    const isRescheduled = schedNorm && grNorm && schedNorm > grNorm;
+                    const scheduledDate = isRescheduled ? fmtD(a.date) : '<span style="color:#94a3b8;">—</span>';
                     return `<tr style="border-bottom:1px solid #f1f5f9;${i%2===0?'background:#fafafa':''}">
                       <td style="padding:10px 12px;font-weight:800;color:#1e293b;">${(a.plate||'').toUpperCase()}</td>
                       <td style="padding:10px 12px;color:#374151;">${(a.car||'').toUpperCase()}<br><span style="font-size:12px;color:#6b7280;">${a.service||''}</span></td>

--- a/index.html
+++ b/index.html
@@ -798,15 +798,15 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-23b"></script>
-  <script src="script-tail.js?v=2026-06-22k"></script>
+  <script src="script.js?v=2026-06-26a"></script>
+  <script src="script-tail.js?v=2026-06-26a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=7"></script>
   <script src="/campaign-popup.js?v=2026-06-22e"></script>
-  <script src="/multi-service-patch.js?v=2026-05-15b"></script>
+  <script src="/multi-service-patch.js?v=2026-06-26a"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
@@ -823,7 +823,7 @@
   <script src="agenda-bot.js?v=2026-06-23b"></script>
   <script src="powering-banner.js?v=2026-06-22b"></script>
   <script src="rota-do-dia-map.js?v=2026-06-15c"></script>
-  <script src="timeline-rota.js?v=2026-05-14g"></script>
+  <script src="timeline-rota.js?v=2026-06-26a"></script>
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>

--- a/netlify/functions/agenda-ai.js
+++ b/netlify/functions/agenda-ai.js
@@ -10,7 +10,7 @@ function callAnthropic(systemPrompt, messages) {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
 
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1000,
       system: systemPrompt,
       messages

--- a/netlify/functions/report-ai.js
+++ b/netlify/functions/report-ai.js
@@ -11,7 +11,7 @@ function callAnthropic(systemPrompt, messages) {
   return new Promise((resolve, reject) => {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1200,
       system: systemPrompt,
       messages

--- a/script-tail.js
+++ b/script-tail.js
@@ -245,11 +245,14 @@ async function renderMobileDay(){
 
   // Verificar se já existe ordem otimizada (sortIndex > 1 em algum item)
   const hasOptimizedOrder = itemsRaw.some(item => (item.sortIndex || 0) > 1);
-  
+  // Rota bloqueada pelo coordenador → respeitar SEMPRE a ordem manual (sortIndex),
+  // nunca reordenar automaticamente.
+  const routeLocked = typeof isDayRouteLocked === 'function' && isDayRouteLocked(iso);
+
   let items;
-  if (hasOptimizedOrder) {
-    // Se já tem ordem otimizada, usar essa ordem (respeitar sortIndex)
-    console.log('✅ MOBILE - Usando ordem otimizada (sortIndex)');
+  if (hasOptimizedOrder || routeLocked) {
+    // Ordem manual/otimizada ou rota bloqueada → respeitar sortIndex
+    console.log(routeLocked ? '🔒 MOBILE - Rota bloqueada, mantendo ordem do coordenador' : '✅ MOBILE - Usando ordem otimizada (sortIndex)');
     items = itemsRaw; // Já está ordenado por sortIndex na query acima
   } else {
     // Se não tem ordem otimizada, aplicar ordenação automática

--- a/script.js
+++ b/script.js
@@ -1106,7 +1106,10 @@ function getServiceTime(serviceCode, vehicleType, calibration, customTime) {
 // ===== MULTI-SERVIÇO: helpers =====
 function getAllServices(a) {
   const primary = a.service ? [{ service: a.service, custom_service_time: a.custom_service_time || null }] : [];
-  const extra = Array.isArray(a.extra_services) ? a.extra_services : [];
+  let extra = a.extra_services || [];
+  // extra_services pode vir como string JSON da API — parsear antes de usar
+  if (typeof extra === 'string') { try { extra = JSON.parse(extra); } catch(e) { extra = []; } }
+  if (!Array.isArray(extra)) extra = [];
   return [...primary, ...extra];
 }
 

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -90,10 +90,12 @@
       const travel = mesmoLocal ? 0 : validarTempoViagem(rawTravel, km);
       simCursor += travel;
       STEPS.push({ idx: i, type: 'viagem', start: simCursor - travel, end: simCursor, travel });
-      // Tempo de execução
-      const exec = (typeof window.getServiceTime === 'function')
-        ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
-        : 90;
+      // Tempo de execução — soma todos os serviços do card (multi-serviço)
+      const exec = (typeof window.getTotalServiceTime === 'function')
+        ? window.getTotalServiceTime(a)
+        : (typeof window.getServiceTime === 'function')
+          ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
+          : 90;
       STEPS.push({ idx: i, type: 'servico', start: simCursor, end: simCursor + exec, duration: exec, appt: a });
       simCursor += exec;
     });
@@ -146,9 +148,11 @@
       });
       cursor += travel;
 
-      const exec = (typeof window.getServiceTime === 'function')
-        ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
-        : 90;
+      const exec = (typeof window.getTotalServiceTime === 'function')
+        ? window.getTotalServiceTime(a)
+        : (typeof window.getServiceTime === 'function')
+          ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
+          : 90;
       events.push({
         type: 'servico',
         label: a.plate + ' — ' + (a.car || ''),


### PR DESCRIPTION
## Porque é que os dois problemas continuavam\nAs correções anteriores (soma de tempos multi-serviço e respeito pelo bloqueio de rota) foram aplicadas ao conteúdo dos ficheiros JS, mas o `index.html` carrega esses ficheiros com um parâmetro de versão (`?v=...`) para cache do browser. Como a versão não foi atualizada, o browser continuava a servir as versões **antigas em cache** — as correções nunca chegavam ao utilizador.\n\n## Alterações\n1. **Bug adicional na soma de tempos** (`timeline-rota.js`): a timeline da rota usava `getServiceTime` (só o serviço principal) em vez de `getTotalServiceTime` (soma todos os serviços do card). Corrigido.\n2. **Cache busting**: atualizada a versão de `script.js`, `script-tail.js`, `multi-service-patch.js` e `timeline-rota.js` para `2026-06-26a`, forçando o browser a carregar as versões novas com todas as correções:\n   - soma de tempos multi-serviço (`getAllServices` parseia `extra_services` em string)\n   - bloqueio de rota respeitado no mobile (não reordena)\n   - soma de tempos na timeline

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_