### PR TITLE
Aviso diário de serviços recusados por loja

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -2389,7 +2389,11 @@ function renderReport(data) {
                     const dias = !isNaN(grMs) ? Math.floor((Date.now() - grMs) / 86400000) : null;
                     const diasCor = dias === null ? '#64748b' : dias >= 14 ? '#dc2626' : dias >= 7 ? '#f59e0b' : '#2563eb';
                     const diasLabel = dias === null ? '?' : dias + 'd';
-                    const scheduledDate = a.date ? fmtD(a.date) : '<span style="color:#94a3b8;">—</span>';
+                    // "Reagendado" só conta se a data do agendamento for POSTERIOR à retirada.
+                    // Se for igual/anterior, ainda não houve reagendamento real → "—".
+                    const schedNorm = normDate(a.date);
+                    const isRescheduled = schedNorm && grNorm && schedNorm > grNorm;
+                    const scheduledDate = isRescheduled ? fmtD(a.date) : '<span style="color:#94a3b8;">—</span>';
                     return `<tr style="border-bottom:1px solid #f1f5f9;${i%2===0?'background:#fafafa':''}">
                       <td style="padding:10px 12px;font-weight:800;color:#1e293b;">${(a.plate||'').toUpperCase()}</td>
                       <td style="padding:10px 12px;color:#374151;">${(a.car||'').toUpperCase()}<br><span style="font-size:12px;color:#6b7280;">${a.service||''}</span></td>

--- a/excel-import-ui.js
+++ b/excel-import-ui.js
@@ -356,6 +356,21 @@ async function importData() {
   try {
     const results = await window.excelImporter.importData(processedData.data);
 
+    // Sincronizar RECUSADOS para o aviso diário das 9h (não altera a importação normal)
+    try {
+      const recus = processedData.recusados || [];
+      const pid = window.activePortalId || window.authClient?.getUser?.()?.portal?.id || window.portalConfig?.id;
+      const token = window.authClient?.getToken?.();
+      if (pid && token) {
+        await fetch('/.netlify/functions/recusados', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+          body: JSON.stringify({ portal_id: pid, recusados: recus })
+        });
+        console.log('✅ Recusados sincronizados:', recus.length);
+      }
+    } catch (e) { console.warn('Sync recusados falhou:', e); }
+
     // Mostrar resultados
     showImportResults(results);
 

--- a/excel-import.js
+++ b/excel-import.js
@@ -132,7 +132,8 @@ class ExcelImporter {
         return {
           data: processedData,
           errors: this.validationErrors,
-          ignored: results.ignored || []
+          ignored: results.ignored || [],
+          recusados: results.recusados || []
         };
         
       } catch (error) {

--- a/index.html
+++ b/index.html
@@ -798,15 +798,15 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-23b"></script>
-  <script src="script-tail.js?v=2026-06-22k"></script>
+  <script src="script.js?v=2026-06-26a"></script>
+  <script src="script-tail.js?v=2026-06-26a"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>
   <script src="/glass-removed-patch.js?v=5"></script>
   <script src="/vehicle-checkup-patch.js?v=7"></script>
   <script src="/campaign-popup.js?v=2026-06-22e"></script>
-  <script src="/multi-service-patch.js?v=2026-05-15b"></script>
+  <script src="/multi-service-patch.js?v=2026-06-26a"></script>
   <script src="vidros-retirados-panel.js?v=2"></script>
   <script src="coord-relatorio-patch.js?v=2026-05-01"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
@@ -823,7 +823,7 @@
   <script src="agenda-bot.js?v=2026-06-23b"></script>
   <script src="powering-banner.js?v=2026-06-22b"></script>
   <script src="rota-do-dia-map.js?v=2026-06-15c"></script>
-  <script src="timeline-rota.js?v=2026-05-14g"></script>
+  <script src="timeline-rota.js?v=2026-06-26a"></script>
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>

--- a/index.html
+++ b/index.html
@@ -812,9 +812,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="excel-templates.js?v=2026-04-09"></script>
   <script src="template-personalizado.js?v=2026-04-09"></script>
-  <script src="template-expressglass-completo.js?v=2026-06-22a"></script>
-  <script src="excel-import.js?v=2026-06-22a"></script>
-  <script src="excel-import-ui.js?v=2026-06-05a"></script>
+  <script src="template-expressglass-completo.js?v=2026-06-26a"></script>
+  <script src="excel-import.js?v=2026-06-26a"></script>
+  <script src="excel-import-ui.js?v=2026-06-26a"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="reports-widget.js?v=2026-06-09a"></script>
   <script src="glass-alert.js?v=2026-04-09"></script>
@@ -827,6 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
+  <script src="recusados-alert.js?v=2026-06-26a"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/netlify/functions/agenda-ai.js
+++ b/netlify/functions/agenda-ai.js
@@ -10,7 +10,7 @@ function callAnthropic(systemPrompt, messages) {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
 
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1000,
       system: systemPrompt,
       messages

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -34,6 +34,16 @@ function getUserFromToken(event) {
   return jwt.verify(token, JWT_SECRET);
 }
 
+// Devolve o nome do portal a partir do id. Usado na auditoria para registar o
+// portal REAL onde o agendamento foi gravado (não o portal de origem do utilizador).
+async function getPortalName(id) {
+  if (!id) return null;
+  try {
+    const { rows } = await pool.query('SELECT name FROM portals WHERE id = $1', [id]);
+    return rows[0]?.name || null;
+  } catch (e) { return null; }
+}
+
 // Regista uma acção sobre agendamentos no audit_log. Nunca lança — falha de log
 // não pode quebrar a operação principal.
 async function auditLog({ user, action, entity_id, details, event }) {
@@ -371,7 +381,7 @@ exports.handler = async (event) => {
           plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
           locality: rows[0].locality, service: rows[0].service,
           confirmed: rows[0].confirmed, portal_id: rows[0].portal_id,
-          portal: user?.portalName || null
+          portal: await getPortalName(rows[0].portal_id)
         }
       });
       return { statusCode: 201, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
@@ -492,7 +502,7 @@ exports.handler = async (event) => {
           date_mudou: dateChanged,
           locality: rows[0].locality, confirmed: rows[0].confirmed,
           status: rows[0].status, portal_id: rows[0].portal_id,
-          portal: user?.portalName || null
+          portal: await getPortalName(rows[0].portal_id)
         }
       });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };
@@ -523,7 +533,7 @@ exports.handler = async (event) => {
         details: {
           plate: rows[0].plate, car: rows[0].car, date: rows[0].date,
           locality: rows[0].locality, service: rows[0].service,
-          portal_id: rows[0].portal_id, portal: user?.portalName || null
+          portal_id: rows[0].portal_id, portal: await getPortalName(rows[0].portal_id)
         }
       });
       return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows[0] }) };

--- a/netlify/functions/recusados.js
+++ b/netlify/functions/recusados.js
@@ -1,0 +1,109 @@
+// netlify/functions/recusados.js
+// Gere os serviços RECUSADOS por loja (portal). Sincronizados na importação do
+// Excel (estado RECUSADO) e listados no aviso diário das 9h.
+const { Pool } = require('pg');
+const jwt = require('jsonwebtoken');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-production';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Content-Type': 'application/json'
+};
+
+function getUserFromToken(event) {
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) throw new Error('Não autenticado');
+  return jwt.verify(authHeader.substring(7), JWT_SECRET);
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers, body: '' };
+
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS recusados (
+        id SERIAL PRIMARY KEY,
+        portal_id INTEGER NOT NULL,
+        plate TEXT,
+        car TEXT,
+        n_obra TEXT,
+        data_obra DATE,
+        data_servico DATE,
+        client_name TEXT,
+        obs TEXT,
+        created_at TIMESTAMP DEFAULT NOW()
+      )
+    `);
+  } catch (e) { console.warn('recusados migration:', e.message); }
+
+  try {
+    const user = getUserFromToken(event);
+    const params = event.queryStringParameters || {};
+
+    // ---------- GET: listar recusados de um portal ----------
+    if (event.httpMethod === 'GET') {
+      const portalId = params.portal_id ? parseInt(params.portal_id) : (user.portalId || null);
+      if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'portal_id obrigatório' }) };
+      const { rows } = await pool.query(
+        `SELECT id, portal_id, plate, car, n_obra, data_obra::text, data_servico::text, client_name, obs
+         FROM recusados WHERE portal_id = $1 ORDER BY data_obra ASC NULLS LAST, plate ASC`,
+        [portalId]
+      );
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, data: rows }) };
+    }
+
+    // POST exige permissão de gestão (quem importa)
+    const isAllowed = ['admin', 'coordenador', 'coordinator', 'pesados_coord'].includes(user.role);
+    if (!isAllowed) return { statusCode: 403, headers, body: JSON.stringify({ success: false, error: 'Sem permissão' }) };
+
+    // ---------- POST: sincronizar recusados de um portal (substitui tudo) ----------
+    if (event.httpMethod === 'POST') {
+      const body = JSON.parse(event.body || '{}');
+      const portalId = body.portal_id ? parseInt(body.portal_id) : (user.portalId || null);
+      const lista = Array.isArray(body.recusados) ? body.recusados : [];
+      if (!portalId) return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'portal_id obrigatório' }) };
+
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        // Substituir o conjunto atual do portal pela lista do Excel (mantém em sincronia)
+        await client.query('DELETE FROM recusados WHERE portal_id = $1', [portalId]);
+        for (const r of lista) {
+          await client.query(
+            `INSERT INTO recusados (portal_id, plate, car, n_obra, data_obra, data_servico, client_name, obs)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+            [
+              portalId,
+              r.plate || null,
+              r.car || null,
+              r.n_obra || null,
+              r.data_obra || null,
+              r.data_servico || null,
+              r.client_name || null,
+              r.obs || null
+            ]
+          );
+        }
+        await client.query('COMMIT');
+      } catch (e) {
+        await client.query('ROLLBACK');
+        throw e;
+      } finally {
+        client.release();
+      }
+      return { statusCode: 200, headers, body: JSON.stringify({ success: true, count: lista.length }) };
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Método não permitido' }) };
+  } catch (err) {
+    console.error('recusados error:', err);
+    if (err.message === 'Não autenticado' || err.name === 'JsonWebTokenError' || err.name === 'TokenExpiredError') {
+      return { statusCode: 401, headers, body: JSON.stringify({ success: false, error: 'Não autenticado' }) };
+    }
+    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: err.message }) };
+  }
+};

--- a/netlify/functions/report-ai.js
+++ b/netlify/functions/report-ai.js
@@ -11,7 +11,7 @@ function callAnthropic(systemPrompt, messages) {
   return new Promise((resolve, reject) => {
     if (!ANTHROPIC_API_KEY) return reject(new Error('ANTHROPIC_API_KEY não configurada'));
     const body = JSON.stringify({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       max_tokens: 1200,
       system: systemPrompt,
       messages

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -1,0 +1,205 @@
+// recusados-alert.js
+// Aviso diário (a partir das 9h) com a listagem dos serviços RECUSADOS de cada
+// loja. Para um coordenador que trata de várias lojas, mostra um popup por loja.
+// Botões: Imprimir (lista) e Já tratei (só fecha o popup, não altera dados).
+(function () {
+  'use strict';
+
+  const DISMISS_PREFIX = 'recusadosDismissed_';
+  const ALERT_HOUR = 9; // a partir das 9h
+
+  function dayStr() { return new Date().toDateString(); }
+  function dismissKey(portalId) { return DISMISS_PREFIX + portalId + '_' + dayStr(); }
+  function isDismissed(portalId) { return !!localStorage.getItem(dismissKey(portalId)); }
+  function markDismissed(portalId) { try { localStorage.setItem(dismissKey(portalId), '1'); } catch (e) {} }
+
+  function isDebug() {
+    return new URLSearchParams(window.location.search).get('debugRecusados') === '1';
+  }
+
+  function diasAberto(dataObra) {
+    if (!dataObra) return null;
+    const s = String(dataObra).slice(0, 10);
+    const d = new Date(s + 'T00:00:00');
+    if (isNaN(d)) return null;
+    const hoje = new Date(); hoje.setHours(0, 0, 0, 0);
+    return Math.max(0, Math.floor((hoje - d) / 86400000));
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    const s = String(iso).slice(0, 10);
+    const d = new Date(s + 'T12:00:00');
+    return isNaN(d) ? s : d.toLocaleDateString('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  }
+
+  // Lojas que o utilizador trata (próprias). Coordenador → todas as que gere.
+  function getManagedPortals() {
+    const u = window.authClient?.getUser?.();
+    if (!u) return [];
+    const list = []; const seen = new Set();
+    const add = (p) => { if (p && p.id && !seen.has(p.id)) { seen.add(p.id); list.push({ id: p.id, name: p.name || ('Loja ' + p.id) }); } };
+    if (Array.isArray(u.portals)) u.portals.forEach(add);
+    add(u.portal);
+    return list;
+  }
+
+  async function fetchRecusados(portalId) {
+    try {
+      const token = window.authClient?.getToken?.() || localStorage.getItem('eg_auth_token');
+      if (!token) return [];
+      const resp = await fetch('/.netlify/functions/recusados?portal_id=' + portalId, {
+        headers: { Authorization: 'Bearer ' + token }
+      });
+      const data = await resp.json();
+      return (data.success && Array.isArray(data.data)) ? data.data : [];
+    } catch (e) { console.warn('[Recusados] fetch erro:', e); return []; }
+  }
+
+  function injectStyles() {
+    if (document.getElementById('recusadosStyles')) return;
+    const s = document.createElement('style');
+    s.id = 'recusadosStyles';
+    s.textContent = `
+      @keyframes recusPulse { 0%,100%{transform:scale(1)} 50%{transform:scale(1.04)} }
+      @keyframes recusFade { from{opacity:0} to{opacity:1} }
+      #recusadosOverlay { position:fixed; inset:0; background:rgba(0,0,0,.88); z-index:1000000;
+        display:flex; align-items:center; justify-content:center; padding:18px; animation:recusFade .25s ease-in; }
+      #recusadosBox { background:#fff; border:7px solid #dc2626; border-radius:18px; max-width:600px; width:100%;
+        text-align:center; padding:30px 22px 24px; box-shadow:0 25px 80px rgba(220,38,38,.5); max-height:92vh; overflow-y:auto; }
+      #recusadosBox .rc-icon { font-size:56px; margin-bottom:4px; }
+      #recusadosBox .rc-title { font-size:30px; font-weight:900; text-transform:uppercase; color:#dc2626;
+        line-height:1.1; margin:0 0 4px; animation:recusPulse .8s infinite; }
+      #recusadosBox .rc-loja { font-size:18px; font-weight:800; color:#1e293b; margin:0 0 14px; }
+      #recusadosList { text-align:left; background:#fef2f2; border:1.5px solid #fecaca; border-radius:10px;
+        padding:6px 10px; margin-bottom:18px; max-height:320px; overflow-y:auto; }
+      .rc-item { display:flex; align-items:center; gap:10px; flex-wrap:wrap; padding:9px 4px;
+        border-bottom:1px solid #fecaca; }
+      .rc-item:last-child { border-bottom:none; }
+      .rc-plate { font-weight:900; font-size:16px; color:#0f172a; letter-spacing:.5px; }
+      .rc-car { font-size:13px; color:#475569; font-weight:600; }
+      .rc-obs { font-size:11px; color:#94a3b8; width:100%; }
+      .rc-dias { margin-left:auto; background:#dc2626; color:#fff; font-weight:900; font-size:15px;
+        padding:4px 12px; border-radius:20px; white-space:nowrap; }
+      .rc-dias.amber { background:#f59e0b; } .rc-dias.blue { background:#2563eb; }
+      #recusadosBox .rc-btns { display:flex; gap:12px; justify-content:center; flex-wrap:wrap; }
+      #recusadosBox .rc-btns button { border:none; border-radius:12px; cursor:pointer; font-size:16px;
+        font-weight:800; padding:13px 28px; }
+      #recusBtnPrint { background:#1e40af; color:#fff; } #recusBtnPrint:hover { background:#1e3a8a; }
+      #recusBtnOk { background:#16a34a; color:#fff; } #recusBtnOk:hover { background:#15803d; }
+      @media(max-width:480px){ #recusadosBox .rc-title{font-size:23px} #recusadosBox .rc-loja{font-size:15px}
+        #recusadosBox .rc-btns button{padding:12px 18px;font-size:14px} }
+    `;
+    document.head.appendChild(s);
+  }
+
+  function buildListHTML(items) {
+    return items.map(r => {
+      const d = diasAberto(r.data_obra);
+      const cls = d === null ? 'blue' : d >= 14 ? '' : d >= 7 ? 'amber' : 'blue';
+      const diasLabel = d === null ? '? dias' : d + (d === 1 ? ' dia' : ' dias');
+      return `<div class="rc-item">
+        <span class="rc-plate">${(r.plate || '—').toUpperCase()}</span>
+        <span class="rc-car">${(r.car || '').toUpperCase()}</span>
+        <span class="rc-dias ${cls}" title="Aberto em ${fmtDate(r.data_obra)}">⏱ ${diasLabel}</span>
+        ${r.obs ? `<span class="rc-obs">📝 ${r.obs}</span>` : ''}
+      </div>`;
+    }).join('');
+  }
+
+  function printList(lojaName, items) {
+    const rows = items.map(r => {
+      const d = diasAberto(r.data_obra);
+      return `<tr>
+        <td style="font-weight:700;">${(r.plate || '—').toUpperCase()}</td>
+        <td>${(r.car || '').toUpperCase()}</td>
+        <td>${r.client_name || ''}</td>
+        <td style="text-align:center;">${fmtDate(r.data_obra)}</td>
+        <td style="text-align:center;font-weight:700;">${d === null ? '—' : d}</td>
+        <td>${r.obs || ''}</td>
+      </tr>`;
+    }).join('');
+    const html = `<!DOCTYPE html><html lang="pt-PT"><head><meta charset="UTF-8">
+      <title>Recusados — ${lojaName}</title>
+      <style>@page{margin:14mm;size:A4 portrait;}
+        body{font-family:Arial,sans-serif;color:#111;}
+        h1{font-size:20px;margin:0 0 2px;color:#dc2626;}
+        .meta{font-size:12px;color:#555;margin-bottom:14px;}
+        table{width:100%;border-collapse:collapse;font-size:12px;}
+        th{background:#dc2626;color:#fff;padding:7px 8px;text-align:left;}
+        td{padding:6px 8px;border-bottom:1px solid #e5e7eb;}</style>
+      </head><body>
+      <h1>🚫 Serviços Recusados — ${lojaName}</h1>
+      <div class="meta">${new Date().toLocaleDateString('pt-PT',{day:'2-digit',month:'long',year:'numeric'})} · ${items.length} recusado(s)</div>
+      <table><thead><tr><th>Matrícula</th><th>Carro</th><th>Cliente</th><th>Aberto em</th><th>Dias</th><th>Observações</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+      <script>window.onload=function(){window.print();}<\/script>
+      </body></html>`;
+    const w = window.open('', '_blank');
+    if (w) { w.document.write(html); w.document.close(); }
+  }
+
+  // Mostra os popups em fila (um por loja)
+  function showQueue(queue) {
+    if (!queue.length) return;
+    injectStyles();
+    const { portalId, lojaName, items } = queue[0];
+
+    if (document.getElementById('recusadosOverlay')) return;
+    const overlay = document.createElement('div');
+    overlay.id = 'recusadosOverlay';
+    overlay.innerHTML = `
+      <div id="recusadosBox">
+        <div class="rc-icon">🚫</div>
+        <h1 class="rc-title">${items.length} Recusado${items.length > 1 ? 's' : ''}!</h1>
+        <div class="rc-loja">📍 ${lojaName}</div>
+        <div id="recusadosList">${buildListHTML(items)}</div>
+        <div class="rc-btns">
+          <button id="recusBtnPrint">🖨️ Imprimir</button>
+          <button id="recusBtnOk">✅ Já tratei</button>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+
+    document.getElementById('recusBtnPrint').onclick = () => printList(lojaName, items);
+    document.getElementById('recusBtnOk').onclick = () => {
+      markDismissed(portalId);
+      overlay.remove();
+      showQueue(queue.slice(1)); // próxima loja
+    };
+  }
+
+  async function check() {
+    if (!window.authClient?.getUser?.()) return;
+    const now = new Date();
+    if (!isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
+
+    const portais = getManagedPortals();
+    if (!portais.length) return;
+
+    const queue = [];
+    for (const p of portais) {
+      if (!isDebug() && isDismissed(p.id)) continue;
+      const items = await fetchRecusados(p.id);
+      if (items.length > 0) queue.push({ portalId: p.id, lojaName: p.name, items });
+    }
+    if (queue.length) showQueue(queue);
+  }
+
+  function waitForData(fn, tries) {
+    tries = tries || 0;
+    if (window.authClient?.getUser?.()) { fn(); return; }
+    if (tries < 20) setTimeout(() => waitForData(fn, tries + 1), 800);
+  }
+
+  function init() {
+    waitForData(check);
+    // Reverificar de hora a hora (apanha a transição das 9h se a app ficar aberta)
+    setInterval(() => waitForData(check), 60 * 60 * 1000);
+    document.addEventListener('portalReady', () => setTimeout(() => waitForData(check), 1200));
+  }
+
+  console.log('[Recusados] script carregado');
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/script-tail.js
+++ b/script-tail.js
@@ -245,11 +245,14 @@ async function renderMobileDay(){
 
   // Verificar se já existe ordem otimizada (sortIndex > 1 em algum item)
   const hasOptimizedOrder = itemsRaw.some(item => (item.sortIndex || 0) > 1);
-  
+  // Rota bloqueada pelo coordenador → respeitar SEMPRE a ordem manual (sortIndex),
+  // nunca reordenar automaticamente.
+  const routeLocked = typeof isDayRouteLocked === 'function' && isDayRouteLocked(iso);
+
   let items;
-  if (hasOptimizedOrder) {
-    // Se já tem ordem otimizada, usar essa ordem (respeitar sortIndex)
-    console.log('✅ MOBILE - Usando ordem otimizada (sortIndex)');
+  if (hasOptimizedOrder || routeLocked) {
+    // Ordem manual/otimizada ou rota bloqueada → respeitar sortIndex
+    console.log(routeLocked ? '🔒 MOBILE - Rota bloqueada, mantendo ordem do coordenador' : '✅ MOBILE - Usando ordem otimizada (sortIndex)');
     items = itemsRaw; // Já está ordenado por sortIndex na query acima
   } else {
     // Se não tem ordem otimizada, aplicar ordenação automática

--- a/script.js
+++ b/script.js
@@ -1106,7 +1106,10 @@ function getServiceTime(serviceCode, vehicleType, calibration, customTime) {
 // ===== MULTI-SERVIÇO: helpers =====
 function getAllServices(a) {
   const primary = a.service ? [{ service: a.service, custom_service_time: a.custom_service_time || null }] : [];
-  const extra = Array.isArray(a.extra_services) ? a.extra_services : [];
+  let extra = a.extra_services || [];
+  // extra_services pode vir como string JSON da API — parsear antes de usar
+  if (typeof extra === 'string') { try { extra = JSON.parse(extra); } catch(e) { extra = []; } }
+  if (!Array.isArray(extra)) extra = [];
   return [...primary, ...extra];
 }
 

--- a/template-expressglass-completo.js
+++ b/template-expressglass-completo.js
@@ -102,7 +102,12 @@ class ExpressglassFileProcessor {
     result.startTime = row[20] || '';
     result.endTime = row[21] || '';
     result.damage_details = (row[23] || '').toString().trim() || null;
-    
+
+    // Data de abertura da obra (coluna 4 / D) — usada para contar dias em aberto nos recusados
+    result.data_obra = this.formatDate(row[3]);
+    // Observações (coluna 10 / J)
+    result.obs = (row[9] || '').toString().trim() || null;
+
     return result;
   }
   
@@ -203,7 +208,8 @@ class ExpressglassFileProcessor {
     const results = {
       success: [],
       errors: [],
-      ignored: []
+      ignored: [],
+      recusados: []  // alimenta o aviso diário das 9h (não altera a importação normal)
     };
 
     const ALLOWED_STATUSES = new Set([
@@ -248,6 +254,19 @@ class ExpressglassFileProcessor {
           row: index + 2,
           data: processed
         });
+
+        // Recolher RECUSADOS para o aviso diário (além da importação normal)
+        if (phcStatus === 'RECUSADO') {
+          results.recusados.push({
+            plate: processed.plate || null,
+            car: processed.car || null,
+            n_obra: processed.n_obra || null,
+            data_obra: processed.data_obra || null,
+            data_servico: processed.serviceDate || null,
+            client_name: processed.client_name || null,
+            obs: processed.obs || null
+          });
+        }
 
       } catch (error) {
         results.errors.push({

--- a/timeline-rota.js
+++ b/timeline-rota.js
@@ -90,10 +90,12 @@
       const travel = mesmoLocal ? 0 : validarTempoViagem(rawTravel, km);
       simCursor += travel;
       STEPS.push({ idx: i, type: 'viagem', start: simCursor - travel, end: simCursor, travel });
-      // Tempo de execução
-      const exec = (typeof window.getServiceTime === 'function')
-        ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
-        : 90;
+      // Tempo de execução — soma todos os serviços do card (multi-serviço)
+      const exec = (typeof window.getTotalServiceTime === 'function')
+        ? window.getTotalServiceTime(a)
+        : (typeof window.getServiceTime === 'function')
+          ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
+          : 90;
       STEPS.push({ idx: i, type: 'servico', start: simCursor, end: simCursor + exec, duration: exec, appt: a });
       simCursor += exec;
     });
@@ -146,9 +148,11 @@
       });
       cursor += travel;
 
-      const exec = (typeof window.getServiceTime === 'function')
-        ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
-        : 90;
+      const exec = (typeof window.getTotalServiceTime === 'function')
+        ? window.getTotalServiceTime(a)
+        : (typeof window.getServiceTime === 'function')
+          ? window.getServiceTime(a.service, a.vehicleType || a.vehicle_type, a.calibration)
+          : 90;
       events.push({
         type: 'servico',
         label: a.plate + ' — ' + (a.car || ''),


### PR DESCRIPTION
## Pedido\nNa importação, registar os serviços com estado **RECUSADO** por loja e, a partir das 9h, mostrar um aviso grande com a listagem, os dias que cada um está em aberto, e dois botões: Imprimir e Já tratei (só fecha o popup).\n\n## Implementação\n_(A importação normal não foi alterada — apenas alimentada a nova funcionalidade.)_\n\n- **Backend** `recusados.js` (nova função + tabela `recusados`): GET lista por portal; POST sincroniza os recusados de um portal (substitui o conjunto, mantendo em sincronia com o Excel).\n- **Importação** (`template-expressglass-completo.js`): captura a `data_obra` (dia de abertura, coluna D) e recolhe as linhas com estado RECUSADO; `excel-import.js`/`excel-import-ui.js` propagam e sincronizam esses recusados para o portal importado, após a importação.\n- **Aviso** `recusados-alert.js`: a partir das 9h, mostra um popup vermelho e bem destacado, por loja, com a lista (matrícula, carro, **dias em aberto** desde a `data_obra`, observações). Botões **🖨️ Imprimir** (gera a lista) e **✅ Já tratei** (só fecha; reaparece no dia seguinte se ainda houver). Um coordenador que trata de várias lojas recebe um popup por cada loja, em fila.\n\nPara testar sem esperar pelas 9h: adicionar `?debugRecusados=1` ao URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_