### PR TITLE
Recusados: mostrar logo após importação e cobrir loja ativa/admin

### DIFF
--- a/excel-import-ui.js
+++ b/excel-import-ui.js
@@ -368,6 +368,8 @@ async function importData() {
           body: JSON.stringify({ portal_id: pid, recusados: recus })
         });
         console.log('✅ Recusados sincronizados:', recus.length);
+        // Re-verificar logo para mostrar o aviso sem ser preciso recarregar
+        setTimeout(() => { try { window._recusadosCheck?.(); } catch (e) {} }, 800);
       }
     } catch (e) { console.warn('Sync recusados falhou:', e); }
 

--- a/index.html
+++ b/index.html
@@ -827,7 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
-  <script src="recusados-alert.js?v=2026-06-26b"></script>
+  <script src="recusados-alert.js?v=2026-06-26c"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -34,6 +34,7 @@
   }
 
   // Lojas que o utilizador trata (próprias). Coordenador → todas as que gere.
+  // Inclui sempre a loja ativa (cobre admin e a loja onde se está a importar).
   function getManagedPortals() {
     const u = window.authClient?.getUser?.();
     if (!u) return [];
@@ -41,6 +42,8 @@
     const add = (p) => { if (p && p.id && !seen.has(p.id)) { seen.add(p.id); list.push({ id: p.id, name: p.name || ('Loja ' + p.id) }); } };
     if (Array.isArray(u.portals)) u.portals.forEach(add);
     add(u.portal);
+    // Loja atualmente ativa (importante para admin e para a loja em uso)
+    if (window.activePortalId) add({ id: window.activePortalId, name: window.portalConfig?.name });
     return list;
   }
 
@@ -169,17 +172,17 @@
     };
   }
 
-  async function check() {
+  async function check(force) {
     if (!window.authClient?.getUser?.()) return;
     const now = new Date();
-    if (!isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
+    if (!force && !isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
 
     const portais = getManagedPortals();
     if (!portais.length) return;
 
     const queue = [];
     for (const p of portais) {
-      if (!isDebug() && isDismissed(p.id)) continue;
+      if (!force && !isDebug() && isDismissed(p.id)) continue;
       const items = await fetchRecusados(p.id);
       if (items.length > 0) queue.push({ portalId: p.id, lojaName: p.name, items });
     }
@@ -198,6 +201,9 @@
     setInterval(() => waitForData(check), 60 * 60 * 1000);
     document.addEventListener('portalReady', () => setTimeout(() => waitForData(check), 1200));
   }
+
+  // Exposto para re-verificar imediatamente após uma importação (força mostrar)
+  window._recusadosCheck = function () { waitForData(() => check(true)); };
 
   console.log('[Recusados] script carregado');
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Porque não aparecia\n1. O popup só verificava os recusados **ao carregar a página** — depois da importação não voltava a verificar.\n2. Para **admin** (sem loja própria atribuída) a lista de lojas vinha vazia → nenhum popup.\n\n## Fix\n- `getManagedPortals()` inclui sempre a **loja ativa** (`activePortalId`) — cobre admin e a loja onde se está a importar.\n- Após a sincronização dos recusados na importação, chama `window._recusadosCheck()` que **força** mostrar o aviso imediatamente (ignora a hora e o "já tratei"), sem ser preciso recarregar.\n- O agendamento normal das 9h mantém-se.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_