### PR TITLE
Recusados também na Sincronização Excel multi-portal

### DIFF
--- a/admin-script.js
+++ b/admin-script.js
@@ -1170,6 +1170,7 @@ async function startSync() {
 
   // Agrupar serviços por portal
   const byPortal = {};
+  const recusadosByPortal = {}; // alimenta o aviso diário das 9h (não altera a importação)
   importExcelData.forEach(row => {
     const code = String(row[nmdosCol] || '').trim();
     const portalInfo = codeToPortal[code];
@@ -1220,6 +1221,17 @@ async function startSync() {
       order_ref: encColSync >= 0 && row[encColSync] ? String(row[encColSync]).trim().replace(/\.0$/, '') : null,
       reception_ref: recColSync >= 0 && row[recColSync] ? String(row[recColSync]).trim().replace(/\.0$/, '') : null
     });
+
+    // RECUSADOS → aviso diário das 9h (além da importação normal)
+    if (phcStatus === 'RECUSADO') {
+      if (!recusadosByPortal[portalInfo.id]) recusadosByPortal[portalInfo.id] = [];
+      recusadosByPortal[portalInfo.id].push({
+        plate, car, n_obra: n_obra || null,
+        data_obra: dataObraCol >= 0 ? excelDateToYMD(row[dataObraCol]) : null,
+        data_servico: dataServicoCol >= 0 ? excelDateToYMD(row[dataServicoCol]) : null,
+        client_name: client_name || null, obs: obs || null
+      });
+    }
   });
 
   const portalIds = Object.keys(byPortal);
@@ -1269,6 +1281,18 @@ async function startSync() {
       allErrorSamples.push('Erro de rede: ' + err.message);
     }
     done++;
+  }
+
+  // Sincronizar RECUSADOS por portal (alimenta o aviso das 9h; substitui o conjunto de cada loja)
+  document.getElementById('importProgressText').textContent = 'A sincronizar recusados...';
+  for (const portalId of portalIds) {
+    try {
+      await authClient.authenticatedFetch('/.netlify/functions/recusados', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ portal_id: parseInt(portalId), recusados: recusadosByPortal[portalId] || [] })
+      });
+    } catch (e) { console.warn('Sync recusados portal', portalId, e); }
   }
 
   document.getElementById('importProgressBar').style.width = '100%';

--- a/admin.html
+++ b/admin.html
@@ -676,7 +676,7 @@
     }
   </style>
   <script src="auth-client.js"></script>
-  <script src="admin-script.js?v=2026-06-26a"></script>
+  <script src="admin-script.js?v=2026-06-26b"></script>
   <script>
   // ── Auditoria ─────────────────────────────────────────────────────────────
   let auditPage = 1;

--- a/excel-import-ui.js
+++ b/excel-import-ui.js
@@ -368,6 +368,8 @@ async function importData() {
           body: JSON.stringify({ portal_id: pid, recusados: recus })
         });
         console.log('✅ Recusados sincronizados:', recus.length);
+        // Re-verificar logo para mostrar o aviso sem ser preciso recarregar
+        setTimeout(() => { try { window._recusadosCheck?.(); } catch (e) {} }, 800);
       }
     } catch (e) { console.warn('Sync recusados falhou:', e); }
 

--- a/index.html
+++ b/index.html
@@ -827,7 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
-  <script src="recusados-alert.js?v=2026-06-26b"></script>
+  <script src="recusados-alert.js?v=2026-06-26c"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -34,6 +34,7 @@
   }
 
   // Lojas que o utilizador trata (próprias). Coordenador → todas as que gere.
+  // Inclui sempre a loja ativa (cobre admin e a loja onde se está a importar).
   function getManagedPortals() {
     const u = window.authClient?.getUser?.();
     if (!u) return [];
@@ -41,6 +42,8 @@
     const add = (p) => { if (p && p.id && !seen.has(p.id)) { seen.add(p.id); list.push({ id: p.id, name: p.name || ('Loja ' + p.id) }); } };
     if (Array.isArray(u.portals)) u.portals.forEach(add);
     add(u.portal);
+    // Loja atualmente ativa (importante para admin e para a loja em uso)
+    if (window.activePortalId) add({ id: window.activePortalId, name: window.portalConfig?.name });
     return list;
   }
 
@@ -169,17 +172,17 @@
     };
   }
 
-  async function check() {
+  async function check(force) {
     if (!window.authClient?.getUser?.()) return;
     const now = new Date();
-    if (!isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
+    if (!force && !isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
 
     const portais = getManagedPortals();
     if (!portais.length) return;
 
     const queue = [];
     for (const p of portais) {
-      if (!isDebug() && isDismissed(p.id)) continue;
+      if (!force && !isDebug() && isDismissed(p.id)) continue;
       const items = await fetchRecusados(p.id);
       if (items.length > 0) queue.push({ portalId: p.id, lojaName: p.name, items });
     }
@@ -198,6 +201,9 @@
     setInterval(() => waitForData(check), 60 * 60 * 1000);
     document.addEventListener('portalReady', () => setTimeout(() => waitForData(check), 1200));
   }
+
+  // Exposto para re-verificar imediatamente após uma importação (força mostrar)
+  window._recusadosCheck = function () { waitForData(() => check(true)); };
 
   console.log('[Recusados] script carregado');
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Porque não apareceu\nA "Sincronizar com Excel" (sincronização global de todas as lojas de uma vez, no admin) é um fluxo **diferente** do import manual por loja. O hook dos recusados só estava no import manual.\n\n## Fix\nNo fluxo de sincronização multi-portal (`admin-script.js`), recolher as linhas com estado **RECUSADO** por portal (com `data_obra` para contar os dias) e, no fim, sincronizar cada loja com `/recusados`. Portais presentes no Excel sem recusados ficam limpos (substituição do conjunto).\n\nA importação/sincronização normal não foi alterada.\n\n## Como testar\n1. Faz a "Sincronizar com Excel" no admin (refresh forçado antes).\n2. Abre a agenda de uma loja com recusados (ex.: Pesados Norte) com `?debugRecusados=1` no fim do URL → o popup "Recusados Pendentes" aparece.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_