### PR TITLE
TEMPORÁRIO: popup recusados às 22:55 para teste

### DIFF
--- a/index.html
+++ b/index.html
@@ -827,7 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
-  <script src="recusados-alert.js?v=2026-06-26c"></script>
+  <script src="recusados-alert.js?v=2026-06-26d"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -7,6 +7,7 @@
 
   const DISMISS_PREFIX = 'recusadosDismissed_';
   const ALERT_HOUR = 9; // a partir das 9h
+  const TEST_MIN_OF_DAY = 22 * 60 + 55; // TEMPORÁRIO: aparecer a partir das 22:55
 
   function dayStr() { return new Date().toDateString(); }
   function dismissKey(portalId) { return DISMISS_PREFIX + portalId + '_' + dayStr(); }
@@ -175,7 +176,9 @@
   async function check(force) {
     if (!window.authClient?.getUser?.()) return;
     const now = new Date();
-    if (!force && !isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
+    // TEMPORÁRIO: a partir das 22:55 (em vez das 9h)
+    const nowMin = now.getHours() * 60 + now.getMinutes();
+    if (!force && !isDebug() && nowMin < TEST_MIN_OF_DAY) return;
 
     const portais = getManagedPortals();
     if (!portais.length) return;
@@ -197,8 +200,8 @@
 
   function init() {
     waitForData(check);
-    // Reverificar de hora a hora (apanha a transição das 9h se a app ficar aberta)
-    setInterval(() => waitForData(check), 60 * 60 * 1000);
+    // TEMPORÁRIO: reverificar a cada minuto (apanha a transição das 22:55 com a app aberta)
+    setInterval(() => waitForData(check), 60 * 1000);
     document.addEventListener('portalReady', () => setTimeout(() => waitForData(check), 1200));
   }
 


### PR DESCRIPTION
Temporário para teste: o aviso de recusados aparece a partir das **22:55** (em vez das 9h) e verifica a cada minuto. Depois do teste reponho as 9h.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_