### PR TITLE
Recusados: diagnóstico em modo debug

### DIFF
--- a/index.html
+++ b/index.html
@@ -827,7 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
-  <script src="recusados-alert.js?v=2026-06-26d"></script>
+  <script src="recusados-alert.js?v=2026-06-26e"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -181,15 +181,21 @@
     if (!force && !isDebug() && nowMin < TEST_MIN_OF_DAY) return;
 
     const portais = getManagedPortals();
-    if (!portais.length) return;
+    const diag = [];
+    if (!portais.length) {
+      if (isDebug()) alert('[Recusados] Nenhuma loja detetada para este utilizador.\nactivePortalId=' + window.activePortalId);
+      return;
+    }
 
     const queue = [];
     for (const p of portais) {
-      if (!force && !isDebug() && isDismissed(p.id)) continue;
-      const items = await fetchRecusados(p.id);
+      const dismissed = !force && !isDebug() && isDismissed(p.id);
+      const items = dismissed ? [] : await fetchRecusados(p.id);
+      diag.push(p.name + ' (id ' + p.id + '): ' + items.length + (dismissed ? ' [já tratei]' : ''));
       if (items.length > 0) queue.push({ portalId: p.id, lojaName: p.name, items });
     }
     if (queue.length) showQueue(queue);
+    else if (isDebug()) alert('[Recusados] Sem recusados a mostrar.\n\nLojas verificadas:\n' + diag.join('\n'));
   }
 
   function waitForData(fn, tries) {


### PR DESCRIPTION
Com `?debugRecusados=1`, se não houver popup, mostra um alerta a dizer que lojas foram verificadas e quantos recusados cada uma tem — para diagnosticar porque não aparece.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_