### PR TITLE
Recusados: repor aviso diário às 9h

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,8 +798,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26a"></script>
-  <script src="script-tail.js?v=2026-06-26a"></script>
+  <script src="script.js?v=2026-06-26b"></script>
+  <script src="script-tail.js?v=2026-06-26b"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>
@@ -827,7 +827,7 @@
   <script src="commercial-requests-poll.js?v=2026-04-17"></script>
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
-  <script src="recusados-alert.js?v=2026-06-26e"></script>
+  <script src="recusados-alert.js?v=2026-06-26f"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -344,11 +344,18 @@ exports.handler = async (event) => {
           $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40
         ) RETURNING *
       `;
+      // Nunca gravar o JSON interno (eurocode/photo_url/history) no campo notas
+      const cleanNotes = (function() {
+        const n = data.notes || null;
+        if (!n) return n;
+        if (n.includes('"eurocode":') || n.includes('"photo_url":') || n.includes('"history":')) return null;
+        return n;
+      })();
       const v = [
         data.date || null, data.period || null,
         String(data.plate).trim(), String(data.car).trim(),
         data.service || null, data.locality || null, data.status || 'NE',
-        data.notes || null, data.address || null, data.extra || null,
+        cleanNotes, data.address || null, data.extra || null,
         data.phone || null, data.km || null, data.sortIndex || 1,
         data.glassOrdered || false,
         data.vehicleType || data.vehicle_type || 'L',

--- a/recusados-alert.js
+++ b/recusados-alert.js
@@ -7,7 +7,6 @@
 
   const DISMISS_PREFIX = 'recusadosDismissed_';
   const ALERT_HOUR = 9; // a partir das 9h
-  const TEST_MIN_OF_DAY = 22 * 60 + 55; // TEMPORÁRIO: aparecer a partir das 22:55
 
   function dayStr() { return new Date().toDateString(); }
   function dismissKey(portalId) { return DISMISS_PREFIX + portalId + '_' + dayStr(); }
@@ -176,9 +175,7 @@
   async function check(force) {
     if (!window.authClient?.getUser?.()) return;
     const now = new Date();
-    // TEMPORÁRIO: a partir das 22:55 (em vez das 9h)
-    const nowMin = now.getHours() * 60 + now.getMinutes();
-    if (!force && !isDebug() && nowMin < TEST_MIN_OF_DAY) return;
+    if (!force && !isDebug() && now.getHours() < ALERT_HOUR) return; // só a partir das 9h
 
     const portais = getManagedPortals();
     const diag = [];
@@ -206,8 +203,8 @@
 
   function init() {
     waitForData(check);
-    // TEMPORÁRIO: reverificar a cada minuto (apanha a transição das 22:55 com a app aberta)
-    setInterval(() => waitForData(check), 60 * 1000);
+    // Reverificar de hora a hora (apanha a transição das 9h se a app ficar aberta)
+    setInterval(() => waitForData(check), 60 * 60 * 1000);
     document.addEventListener('portalReady', () => setTimeout(() => waitForData(check), 1200));
   }
 

--- a/script-tail.js
+++ b/script-tail.js
@@ -90,7 +90,9 @@ const telBtn = phone ? `
   let _extraDisp = '';
   if (a.extra) { try { const _p = typeof a.extra === 'string' ? JSON.parse(a.extra) : a.extra; _extraDisp = (typeof _p === 'object' && _p !== null) ? (_p.eurocode || '') : ''; } catch(e) { _extraDisp = ''; } }
   const _mRole = window.authClient?.getUser?.()?.role;
-  const notes = [a.client_name, _extraDisp, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
+  // Não mostrar notas que contenham o JSON interno (eurocode/photo_url/history)
+  const _mNotesClean = (a.notes && /"eurocode"|"photo_url"|"history"/.test(a.notes)) ? null : a.notes;
+  const notes = [a.client_name, _extraDisp, _mNotesClean, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).map(t => `<div class="m-info">${t}</div>`).join('');
   const mEncRecFooter = ''; // movido para o semáforo de stock (coluna direita)
   const damageRow = a.damage_details ? `<div class="m-info" style="font-style:italic;opacity:0.85;">🔍 ${a.damage_details}</div>` : '';
   const compSalesBadge = a.comp_sales_desc
@@ -1300,7 +1302,8 @@ function bootApp() {
       service:get('appointmentService'),
       locality:get('appointmentLocality'),
       period: (document.getElementById('appointmentPeriod')?.value || null),
-      notes:  get('appointmentNotes'),
+      // Nunca gravar o JSON interno (eurocode/photo_url/history) no campo notas
+      notes:  (function(){ const n = get('appointmentNotes'); return (n && /"eurocode"|"photo_url"|"history"/.test(n)) ? '' : n; })(),
       address:get('appointmentAddress'),
       phone:  get('appointmentPhone'),
       extra:  (function() {

--- a/script.js
+++ b/script.js
@@ -2395,7 +2395,8 @@ function editAppointment(id) {
   if (document.getElementById('appointmentPeriod')) {
     document.getElementById('appointmentPeriod').value = appointment.period || 'Manhã';
   }
-  document.getElementById('appointmentNotes').value = appointment.notes || '';
+  // Não carregar notas contaminadas com o JSON interno (eurocode/photo_url/history)
+  document.getElementById('appointmentNotes').value = (appointment.notes && /"eurocode"|"photo_url"|"history"/.test(appointment.notes)) ? '' : (appointment.notes || '');
   document.getElementById('appointmentAddress').value = appointment.address || '';
   document.getElementById('appointmentPhone').value = appointment.phone || '';
   if (document.getElementById('appointmentClientName')) document.getElementById('appointmentClientName').value = appointment.client_name || '';
@@ -2645,9 +2646,11 @@ function buildDesktopCard(a){
   const userRole = window.authClient?.getUser()?.role;
   const canSeeUnconfirmed = userRole === 'admin' || userRole === 'coordenador';
   const isRecalibra = window.portalConfig?.portalType === 'recalibra';
+  // Não mostrar notas que contenham o JSON interno (eurocode/photo_url/history)
+  const _notesClean = (a.notes && /"eurocode"|"photo_url"|"history"/.test(a.notes)) ? null : a.notes;
   const sub = loja
-    ? [clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
-    : [isRecalibra ? null : a.locality, clientNameStr, _extraDisplay, a.notes, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
+    ? [clientNameStr, _extraDisplay, _notesClean, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ')
+    : [isRecalibra ? null : a.locality, clientNameStr, _extraDisplay, _notesClean, a.n_obra ? `FS${a.n_obra}` : null].filter(Boolean).join(' | ');
   const _recDateFmt = a.reception_date ? new Date(String(a.reception_date).slice(0,10)+'T12:00:00').toLocaleDateString('pt-PT',{day:'2-digit',month:'2-digit',year:'2-digit'}) : null;
   const encRecFooter = (a.order_ref || a.reception_ref || a.reception_date) ? `
     <div style="margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:2px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.85);">


### PR DESCRIPTION
Fim do modo de teste: o aviso de recusados volta a aparecer **a partir das 9:00** (uma vez por dia, por loja) e a verificação volta a ser de hora a hora. O `?debugRecusados=1` continua disponível para testar a qualquer hora.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_