### PR TITLE
Fix Recalibra: cards desapareciam no mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,8 +798,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26c"></script>
-  <script src="script-tail.js?v=2026-06-26c"></script>
+  <script src="script.js?v=2026-06-26d"></script>
+  <script src="script-tail.js?v=2026-06-26d"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -225,6 +225,7 @@ async function renderMobileDay(){
   const list  = document.getElementById('mobileDayList');
   const label = document.getElementById('mobileDayLabel');
   if(!list || !label) return;
+  const isRecalibra = window.portalConfig?.portalType === 'recalibra';
 
   const iso = localISO(currentMobileDay);
   const weekday = currentMobileDay.toLocaleDateString('pt-PT',{ weekday:'long' });


### PR DESCRIPTION
A variável `isRecalibra` era usada no `renderMobileDay` mas só estava definida no `buildMobileCard`, causando um erro que fazia desaparecer todos os cards na vista mobile. Definida agora no início do `renderMobileDay`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_