### PR TITLE
Recalibra: gravar hora + esconder semáforo de stock

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,8 +798,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26d"></script>
-  <script src="script-tail.js?v=2026-06-26d"></script>
+  <script src="script.js?v=2026-06-26e"></script>
+  <script src="script-tail.js?v=2026-06-26e"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>

--- a/script-tail.js
+++ b/script-tail.js
@@ -50,7 +50,7 @@ const telBtn = phone ? `
   const _semLabel = { NE: 'S/STOCK', VE: 'ENC.', ST: 'STOCK' }[_st] || 'S/STOCK';
   const _numBtns = [wazeBtn, mapsBtn, telBtn].filter(Boolean).length;
   const _semTop = 10 + _numBtns * 36;
-  const stockSemaphore = `
+  const stockSemaphore = isRecalibra ? '' : `
     <div style="position:absolute;top:${_semTop}px;right:10px;display:flex;flex-direction:column;align-items:flex-end;gap:3px;z-index:5;">
       <div style="display:flex;flex-direction:column;align-items:center;gap:3px;background:rgba(0,0,0,0.35);border-radius:16px;padding:6px 5px 4px;">
         ${_lights.map(l => `<div style="width:14px;height:14px;border-radius:50%;background:${_st===l.s ? l.on : 'rgba(255,255,255,0.12)'};${_st===l.s ? `box-shadow:0 0 7px 2px ${l.glow};` : ''}"></div>`).join('')}

--- a/script.js
+++ b/script.js
@@ -1121,7 +1121,7 @@ function getTotalServiceTime(a) {
 
 // ── RECALIBRA: seletor de hora (blocos de 1h), guardado no campo period ──────
 window.openRecalibraHourPicker = function(id) {
-  const appt = (window.appointments || []).find(a => String(a.id) === String(id));
+  const appt = (appointments || []).find(a => String(a.id) === String(id));
   if (!appt) return;
   const cur = appt.period || '';
   const hours = [];
@@ -1150,17 +1150,17 @@ window.openRecalibraHourPicker = function(id) {
 };
 
 window.setRecalibraHour = async function(id, hour) {
-  const i = (window.appointments || []).findIndex(a => String(a.id) === String(id));
+  const i = (appointments || []).findIndex(a => String(a.id) === String(id));
   if (i < 0) return;
-  const prev = window.appointments[i].period;
-  window.appointments[i].period = hour || null;
+  const prev = appointments[i].period;
+  appointments[i].period = hour || null;
   // Re-render otimista
   try { if (typeof renderAll === 'function') renderAll(); } catch(e) {}
   try { if (typeof renderMobileDay === 'function') renderMobileDay(); } catch(e) {}
   try {
-    await window.apiClient.updateAppointment(id, { ...window.appointments[i], period: hour || null });
+    await window.apiClient.updateAppointment(id, { ...appointments[i], period: hour || null });
   } catch (e) {
-    window.appointments[i].period = prev;
+    appointments[i].period = prev;
     try { if (typeof showToast === 'function') showToast('Erro ao gravar a hora', 'error'); } catch(_) {}
     try { if (typeof renderAll === 'function') renderAll(); } catch(_) {}
     try { if (typeof renderMobileDay === 'function') renderMobileDay(); } catch(_) {}
@@ -2678,7 +2678,7 @@ function buildDesktopCard(a){
   const g = gradFromBase(base);
   const textColor = textColorForBg(base);
   const loja = isLoja();
-  const bar = loja ? '' : `border-left:5px solid ${statusBarColors[a.status] || '#475569'}`;
+  const bar = (loja || window.portalConfig?.portalType === 'recalibra') ? '' : `border-left:5px solid ${statusBarColors[a.status] || '#475569'}`;
   // Nova hierarquia: matrícula em Barlow Condensed, badge serviço, carro secundário
   const plate = (a.plate || '').toUpperCase();
   const service = a.service || 'PB';


### PR DESCRIPTION
## Correções\n1. **Hora não gravava** — o seletor usava `window.appointments`, que é uma referência diferente da variável `appointments` usada no render, por isso não encontrava o agendamento. Agora usa a variável correta e grava.\n2. **Semáforo de stock** — escondido nos cards do **Recalibra** (mobile: widget "S/STOCK"; desktop: barra de cor por estado). Apenas no Recalibra; as outras vistas mantêm-se.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_