### PR TITLE
Fix Recalibra: permitir hora no campo period

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,7 +798,7 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26f"></script>
+  <script src="script.js?v=2026-06-26g"></script>
   <script src="script-tail.js?v=2026-06-26e"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>

--- a/netlify/functions/appointments.js
+++ b/netlify/functions/appointments.js
@@ -131,6 +131,12 @@ exports.handler = async (event) => {
     await pool.query(`ALTER TABLE appointments ADD CONSTRAINT appointments_service_check CHECK (service IS NULL OR service IN ('PB', 'LT', 'OC', 'REP', 'POL', 'RV', 'OUT', 'CAL'))`);
   } catch(migErr) { console.warn('Migration service_check warning:', migErr.message); }
 
+  // Migração: permitir hora (HH:MM) no period, além de Manhã/Tarde (Recalibra usa hora)
+  try {
+    await pool.query(`ALTER TABLE appointments DROP CONSTRAINT IF EXISTS appointments_period_check`);
+    await pool.query(`ALTER TABLE appointments ADD CONSTRAINT appointments_period_check CHECK (period IS NULL OR period IN ('Manhã', 'Tarde') OR period ~ '^[0-9]{1,2}:[0-9]{2}$')`);
+  } catch(migErr) { console.warn('Migration period_check warning:', migErr.message); }
+
   try {
     const user = getUserFromToken(event);
     let portalId = user.portalId;

--- a/script.js
+++ b/script.js
@@ -1162,7 +1162,7 @@ window.setRecalibraHour = async function(id, hour) {
   } catch (e) {
     appointments[i].period = prev;
     console.error('[Recalibra] erro ao gravar hora:', e);
-    try { if (typeof showToast === 'function') showToast('Erro ao gravar a hora: ' + (e && e.message ? e.message : e), 'error'); } catch(_) {}
+    try { if (typeof showToast === 'function') showToast('Erro ao gravar a hora', 'error'); } catch(_) {}
     try { if (typeof renderAll === 'function') renderAll(); } catch(_) {}
     try { if (typeof renderMobileDay === 'function') renderMobileDay(); } catch(_) {}
   }


### PR DESCRIPTION
## Causa\nA gravação da hora falhava com `appointments_period_check` — a coluna `period` tinha uma CHECK constraint que só permitia 'Manhã'/'Tarde', e o Recalibra grava a hora ("HH:MM") nesse campo.\n\n## Fix\nMigração que substitui a constraint para aceitar **NULL, 'Manhã', 'Tarde' ou HH:MM** (`^[0-9]{1,2}:[0-9]{2}$`). Não afeta as outras vistas. Reposta também a mensagem de erro amigável.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_