### PR TITLE
Recalibra semana: dados ao vivo (corrige Paços de Ferreira na quarta)

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26k"></script>
+  <script src="script.js?v=2026-06-26l"></script>
   <script src="script-tail.js?v=2026-06-26j"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
@@ -829,7 +829,7 @@
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
   <script src="recusados-alert.js?v=2026-06-26g"></script>
-  <script src="recalibra-week.js?v=2026-06-26b"></script>
+  <script src="recalibra-week.js?v=2026-06-26c"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recalibra-week.js
+++ b/recalibra-week.js
@@ -42,9 +42,13 @@
   const fmt = h => String(h).padStart(2, '0') + ':00';
 
   // Mapa: para uma data, que horas estão ocupadas e por quem
+  function liveAppointments() {
+    return (typeof window.getLiveAppointments === 'function') ? (window.getLiveAppointments() || []) : (window.appointments || []);
+  }
+
   function occupancyFor(dateIso) {
     const map = {}; // hour -> {plate, locality}
-    (window.appointments || []).forEach(a => {
+    liveAppointments().forEach(a => {
       if (a.date !== dateIso) return;
       if (!a.period || !/^[0-9]/.test(a.period)) return;
       const p = String(a.period).split('-').map(s => parseInt(s, 10));
@@ -52,7 +56,11 @@
       if (p.length === 2 && !isNaN(p[0]) && !isNaN(p[1])) { lo = p[0]; hi = p[1]; }
       else if (p.length === 1 && !isNaN(p[0])) { lo = hi = p[0]; }
       else return;
-      for (let h = lo; h <= hi; h++) map[h] = { plate: (a.plate || '').toUpperCase(), locality: (a.locality || '').toUpperCase() };
+      const entry = { plate: (a.plate || '').toUpperCase(), locality: (a.locality || '').toUpperCase() };
+      for (let h = lo; h <= hi; h++) {
+        // Em caso de sobreposição, preferir o que tem loja definida
+        if (!map[h] || (!map[h].locality && entry.locality)) map[h] = entry;
+      }
     });
     return map;
   }

--- a/script.js
+++ b/script.js
@@ -1119,6 +1119,9 @@ function getTotalServiceTime(a) {
     sum + getServiceTime(s.service, vt, i === 0 ? a.calibration : false, s.custom_service_time), 0);
 }
 
+// Devolve sempre o array de agendamentos ao vivo (não uma cópia desatualizada)
+window.getLiveAppointments = function () { return appointments; };
+
 // ── RECALIBRA: seletor de hora (blocos de 1h), seleção múltipla CONTÍGUA ──────
 // Guardado no campo period: "09:00" (1 bloco) ou "09:00-11:00" (intervalo seguido).
 window.openRecalibraHourPicker = function(id) {


### PR DESCRIPTION
## Problema\nNa vista de semana, a quarta-feira mostrava 83-VX-51 (sem loja) em vez do serviço real BB-99-OR (Paços de Ferreira). A vista lia `window.appointments`, uma cópia que podia estar desatualizada.\n\n## Fix\n- A vista de semana passa a ler os agendamentos **ao vivo** (mesmo array que a agenda usa), via novo `window.getLiveAppointments()`.\n- Em caso de sobreposição no mesmo bloco, prefere o serviço **com loja definida**.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_