### PR TITLE
Recalibra: esconder botões Vendas/Rotas/Timeline no mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
           </button>
         </div>
-        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
+        <div id="mobileActionRow" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:6px;width:100%;box-sizing:border-box;">
           <button id="btnVendasCompl" class="m-report-btn" onclick="openVendasComplPanel()" style="color:#fbbf24;min-width:0;padding-left:4px;padding-right:4px;position:relative;">
             💰
             <span id="vendasComplBadge" style="display:none;position:absolute;top:-4px;right:-4px;min-width:16px;height:16px;background:#ef4444;color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:16px;text-align:center;padding:0 2px;"></span>
@@ -829,7 +829,7 @@
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
   <script src="recusados-alert.js?v=2026-06-26g"></script>
-  <script src="recalibra-week.js?v=2026-06-26c"></script>
+  <script src="recalibra-week.js?v=2026-06-26d"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recalibra-week.js
+++ b/recalibra-week.js
@@ -144,14 +144,15 @@
   window.openRecalibraWeek = open;
 
   function updateButton() {
+    const rec = isRecalibra();
     const btn = document.getElementById('btnRecalibraWeek');
-    if (!btn) return;
-    if (isRecalibra()) {
-      btn.style.display = '';
-      if (!btn._bound) { btn._bound = true; btn.onclick = open; }
-    } else {
-      btn.style.display = 'none';
+    if (btn) {
+      btn.style.display = rec ? '' : 'none';
+      if (rec && !btn._bound) { btn._bound = true; btn.onclick = open; }
     }
+    // No Recalibra, esconder os 3 botões (Vendas / Calcular Rotas / Timeline)
+    const row = document.getElementById('mobileActionRow');
+    if (row) row.style.display = rec ? 'none' : '';
   }
 
   function init() {


### PR DESCRIPTION
No portal Recalibra (mobile), esconde os 3 botões por baixo da data — Vendas, Calcular Rotas e Timeline — que não são precisos. O botão "Ver semana" mantém-se. Apenas no Recalibra; outros portais mantêm os botões.

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_