### PR TITLE
Fix: botões da agenda mobile empilhados nas outras lojas

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
   <script src="recusados-alert.js?v=2026-06-26g"></script>
-  <script src="recalibra-week.js?v=2026-06-26d"></script>
+  <script src="recalibra-week.js?v=2026-06-26e"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recalibra-week.js
+++ b/recalibra-week.js
@@ -151,8 +151,9 @@
       if (rec && !btn._bound) { btn._bound = true; btn.onclick = open; }
     }
     // No Recalibra, esconder os 3 botões (Vendas / Calcular Rotas / Timeline)
+    // Nos outros portais repor a grelha de 3 colunas (não 'block')
     const row = document.getElementById('mobileActionRow');
-    if (row) row.style.display = rec ? 'none' : '';
+    if (row) row.style.display = rec ? 'none' : 'grid';
   }
 
   function init() {


### PR DESCRIPTION
## Problema\nAo esconder os botões no Recalibra, ao reativá-los nos outros portais usava-se `display=''`, o que apagava o `display:grid` inline e fazia os botões (Vendas/Calcular Rotas/Timeline) empilharem na vertical.\n\n## Fix\nNos portais não-Recalibra, repor explicitamente `display:grid` (mantém as 3 colunas).

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_