### PR TITLE
Recalibra: permite zoom com os dedos na vista de semana

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,7 +829,7 @@
   <script src="weekly-reminder.js?v=2026-06-12a"></script>
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
   <script src="recusados-alert.js?v=2026-06-26g"></script>
-  <script src="recalibra-week.js?v=2026-07-01a"></script>
+  <script src="recalibra-week.js?v=2026-07-01b"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/recalibra-week.js
+++ b/recalibra-week.js
@@ -77,7 +77,24 @@
     return list;
   }
 
-  function close() { document.getElementById('recWeekOverlay')?.remove(); }
+  // Permitir zoom com os dedos APENAS enquanto a vista de semana está aberta.
+  // A app tem maximum-scale=1 (zoom desativado); libertamos ao abrir e
+  // repomos ao fechar, para não ficar zoom acidental no resto da agenda.
+  const VIEWPORT_ZOOM = 'width=device-width, initial-scale=1.0, maximum-scale=5, user-scalable=yes';
+  let _viewportPrev = null;
+  function enableZoom() {
+    const m = document.querySelector('meta[name=viewport]');
+    if (!m) return;
+    if (_viewportPrev === null) _viewportPrev = m.getAttribute('content');
+    m.setAttribute('content', VIEWPORT_ZOOM);
+  }
+  function restoreZoom() {
+    const m = document.querySelector('meta[name=viewport]');
+    if (m && _viewportPrev !== null) m.setAttribute('content', _viewportPrev);
+    _viewportPrev = null;
+  }
+
+  function close() { restoreZoom(); document.getElementById('recWeekOverlay')?.remove(); }
 
   function render() {
     let overlay = document.getElementById('recWeekOverlay');
@@ -169,6 +186,7 @@
   function open() {
     const base = (typeof currentMobileDay !== 'undefined' && currentMobileDay) ? currentMobileDay : new Date();
     weekCursor = mondayOf(base);
+    enableZoom();
     render();
   }
   window.openRecalibraWeek = open;


### PR DESCRIPTION
## Resumo

No mobile não era possível fazer pinch-zoom na vista de semana do Recalibra. A app define `maximum-scale=1` no viewport, o que desativa o zoom com os dedos em toda a aplicação.

Esta alteração liberta o zoom **apenas enquanto a vista de semana está aberta**:
- Ao abrir, o viewport passa a `maximum-scale=5, user-scalable=yes`.
- Ao fechar (× , botão Fechar ou toque no fundo), repõe-se o viewport original, evitando zoom acidental no resto da agenda.

## Ficheiros alterados

- `recalibra-week.js` — helpers `enableZoom()` / `restoreZoom()`, chamados em `open()` e `close()`.
- `index.html` — cache-busting `recalibra-week.js?v=2026-07-01b`.

## Testes

- Verificação manual da lógica de troca/reposição do viewport ao abrir e fechar a janela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_