### PR TITLE
Vidros Retirados: adiciona botão na versão mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,9 @@
           <button id="btnRececaoVidrosMobile" style="display:none;" class="guia-at-upload-btn" onclick="window.glassReception?.openCoordPanel()" title="Painel de Receção de Vidros">
             📦 Receção Vidros
           </button>
+          <button id="btnVidrosRetiradosMobile" style="display:none;background:#f59e0b;color:#fff;border-color:#f59e0b;" class="guia-at-upload-btn" onclick="window._openVidrosPanel?.()" title="Ver vidros retirados">
+            🪟 Vidros Retirados
+          </button>
           <button id="btnHistoricoMobile" style="display:none;" class="guia-at-upload-btn" onclick="window.historicoModal?.open()" title="Histórico de Serviços">
             🕘 Histórico
           </button>
@@ -3871,6 +3874,8 @@
       if (btn) btn.style.display = '';
       const mobileBtn = document.getElementById('btnRececaoVidrosMobile');
       if (mobileBtn) mobileBtn.style.display = '';
+      const vrMobileBtn = document.getElementById('btnVidrosRetiradosMobile');
+      if (vrMobileBtn) vrMobileBtn.style.display = '';
       _pollPendingBadge();
       setInterval(_pollPendingBadge, 60000);
       setTimeout(_checkGlassAlerts, 4000);


### PR DESCRIPTION
## Resumo

O menu **Vidros Retirados** só estava disponível no cabeçalho da versão desktop. Passa a existir também no mobile.

- Novo botão `🪟 Vidros Retirados` na barra de ações mobile (`guiaATUploadArea`), ao lado de `📦 Receção Vidros`.
- Visível para **coordenadores/admins** (mesma barra onde estão Receção Vidros e Histórico).
- Abre o mesmo painel do desktop via `window._openVidrosPanel()`.

## Ficheiros alterados

- `index.html` — botão `btnVidrosRetiradosMobile` + toggle de visibilidade em `_initVisibility`.

## Testes

- Verificação manual: o botão mobile chama o mesmo painel já usado no desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_