### PR TITLE
Elimina de vez o JSON interno dos cards (todos os campos de texto)

### DIFF
--- a/coord-day-view.js
+++ b/coord-day-view.js
@@ -45,7 +45,9 @@
     try {
       const resp = await window.authClient.authenticatedFetch('/.netlify/functions/appointments?portal_id=' + p.id);
       const data = await resp.json();
-      dataByPortal[p.id] = (data && data.success && Array.isArray(data.data)) ? data.data : [];
+      const arr = (data && data.success && Array.isArray(data.data)) ? data.data : [];
+      if (typeof window.sanitizeAppointmentText === 'function') arr.forEach(window.sanitizeAppointmentText);
+      dataByPortal[p.id] = arr;
     } catch (e) {
       console.warn('[coord-day-view] erro portal', p.name, e);
       dataByPortal[p.id] = [];

--- a/index.html
+++ b/index.html
@@ -803,8 +803,8 @@
 
   <script src="portal-init.js?v=2026-05-15h"></script>
   <script src="api.js?v=2026-04-09"></script>
-  <script src="script.js?v=2026-06-26l"></script>
-  <script src="script-tail.js?v=2026-06-26j"></script>
+  <script src="script.js?v=2026-07-01d"></script>
+  <script src="script-tail.js?v=2026-07-01d"></script>
   <script src="portal-consult-patch.js?v=2"></script>
   <script src="transfer-sm-patch.js?v=2"></script>
   <script src="close-request-patch.js?v=1"></script>
@@ -834,7 +834,7 @@
   <script src="route-optimization-alert.js?v=2026-06-15c"></script>
   <script src="recusados-alert.js?v=2026-06-26g"></script>
   <script src="recalibra-week.js?v=2026-07-01c"></script>
-  <script src="coord-day-view.js?v=2026-07-01b"></script>
+  <script src="coord-day-view.js?v=2026-07-01c"></script>
 
   <script>
     function fillPrintSectionsSafely(){

--- a/script-tail.js
+++ b/script-tail.js
@@ -387,11 +387,10 @@ window.reloadAppointments = async function() {
   try {
     const raw = await window.apiClient.getAppointments();
     appointments = raw.map(a => {
-      var _notes = a.notes || '';
-      if (_notes && (_notes.includes('"eurocode":') || _notes.includes('"photo_url":') || _notes.includes('"history":'))) _notes = '';
+      if (typeof window.sanitizeAppointmentText === 'function') window.sanitizeAppointmentText(a);
       return {
         ...a,
-        notes: _notes || null,
+        notes: a.notes || null,
         date: a.date ? String(a.date).slice(0,10) : null,
         address: a.address || a.morada || a.addr || null,
         sortIndex: a.sortIndex || a.sortindex || 1,
@@ -1045,8 +1044,8 @@ async function _silentRefreshAppointments() {
       if (a.sortIndex === null || a.sortIndex === undefined) {
         a.sortIndex = (a.sortindex !== null && a.sortindex !== undefined) ? a.sortindex : 1;
       }
-      // Clean notes if it accidentally contains extra JSON (eurocode/photo_url/history)
-      if (a.notes && (a.notes.includes('"eurocode":') || a.notes.includes('"photo_url":') || a.notes.includes('"history":'))) a.notes = '';
+      // Limpar o blob interno de todos os campos de texto (notes, client_name, …)
+      if (typeof window.sanitizeAppointmentText === 'function') window.sanitizeAppointmentText(a);
     });
     // Replace the module-level appointments array in-place so renderAll() picks it up
     appointments.length = 0;
@@ -1436,8 +1435,7 @@ function bootApp() {
         // Re-fetch completo e redesenha
         appointments = await window.apiClient.getAppointments();
         appointments = appointments.map(a => {
-          var _n = a.notes || '';
-          if (_n && (_n.includes('"eurocode":') || _n.includes('"photo_url":') || _n.includes('"history":'))) a = { ...a, notes: null };
+          if (typeof window.sanitizeAppointmentText === 'function') window.sanitizeAppointmentText(a);
           return { ...a, date: a.date ? String(a.date).slice(0, 10) : null, address: a.address || a.morada || a.addr || null, sortIndex: a.sortIndex || 1, id: a.id ?? (Date.now() + Math.random()) };
         });
         // Fallback: se o novo serviço ainda não chegou na re-fetch, adicionar manualmente

--- a/script.js
+++ b/script.js
@@ -1023,6 +1023,30 @@ function getCardBaseColor(a) {
   return getLocColor(a.locality);
 }
 
+// Remove o JSON interno (eurocode/photo_url/history) de QUALQUER campo de
+// texto — em dados antigos este blob chegou a ficar gravado em notes ou até
+// no client_name, aparecendo nos cards. Preserva o resto do texto e limpa
+// separadores órfãos. Usado centralmente para todos os cards.
+function stripInternalJson(s) {
+  if (!s || typeof s !== 'string') return s;
+  if (s.indexOf('"eurocode"') === -1 && s.indexOf('"photo_url"') === -1 && s.indexOf('"history"') === -1) return s;
+  let out = s.replace(/\{[^{}]*"(?:eurocode|photo_url|history)"[^{}]*\}/g, '');
+  out = out.replace(/\s*\|\s*\|\s*/g, ' | ').replace(/^\s*\|\s*/, '').replace(/\s*\|\s*$/, '').trim();
+  return out;
+}
+window.stripInternalJson = stripInternalJson;
+
+// Limpa o blob interno de todos os campos de texto de um agendamento (mutação
+// no próprio objeto). Seguro chamar em qualquer path de carregamento/sync.
+function sanitizeAppointmentText(a) {
+  if (!a || typeof a !== 'object') return a;
+  ['notes', 'client_name', 'car', 'locality', 'damage_details', 'comp_sales_desc', 'comp_sales_name'].forEach(f => {
+    if (typeof a[f] === 'string') a[f] = stripInternalJson(a[f]);
+  });
+  return a;
+}
+window.sanitizeAppointmentText = sanitizeAppointmentText;
+
 // === TOTALIZADOR DIÁRIO (SM) ===
 // Configurações default (serão sobrescritas pela API)
 const ROUTE_CONFIG = {
@@ -1961,12 +1985,17 @@ async function load(){
       if (a.extra && typeof a.extra === 'string') {
         try { _extraObj = JSON.parse(a.extra); } catch(e) { _extraObj = null; }
       }
-      // Clean notes: if it accidentally contains the extra JSON, clear it
-      let _notes = a.notes || '';
-      if (_notes.includes('"eurocode":') || _notes.includes('"photo_url":') || _notes.includes('"history":')) _notes = '';
+      // Limpar o JSON interno (eurocode/photo_url/history) de todos os campos
+      // de texto onde possa ter ficado gravado em dados antigos.
       return {
         ...a,
-        notes: _notes,
+        notes: stripInternalJson(a.notes || ''),
+        client_name: stripInternalJson(a.client_name),
+        car: stripInternalJson(a.car),
+        locality: stripInternalJson(a.locality),
+        damage_details: stripInternalJson(a.damage_details),
+        comp_sales_desc: stripInternalJson(a.comp_sales_desc),
+        comp_sales_name: stripInternalJson(a.comp_sales_name),
         address: a.address || a.morada || a.addr || null,
         createdAt: a.createdAt || a.created_at || null,
         extra_services: extras,


### PR DESCRIPTION
## Problema

O JSON interno `{"eurocode":"","photo_url":"","history":"…coordenador: Criado"}` continuava a aparecer nos cards, apesar das várias limpezas anteriores.

**Causa:** todas as limpezas existentes só olhavam para o campo `notes`. Em dados antigos, o blob ficou gravado também **noutros campos** (ex.: `client_name`, como `Teresa Mora | {blob} | PEDIDVID`), por isso escapava a todas as limpezas e continuava visível.

## Solução

Um stripper central `stripInternalJson()` que **remove o blob de qualquer campo de texto**, preservando o resto (ex.: `Teresa Mora | {blob} | PEDIDVID` → `Teresa Mora | PEDIDVID`) e limpando separadores `|` órfãos.

- `sanitizeAppointmentText(a)` aplica-o a: `notes`, `client_name`, `car`, `locality`, `damage_details`, `comp_sales_desc`, `comp_sales_name`.
- Aplicado em **todos** os paths de carregamento/sincronização de agendamentos (`script.js` normalização + os 3 paths de `script-tail.js`) e na **Vista por Dia** (`coord-day-view.js`).
- Como corre no carregamento, cobre automaticamente todos os renderizadores (desktop, mobile, vista por dia) e o modal de edição (que lê do array já limpo), evitando também que o blob seja regravado ao editar.

## Ficheiros alterados

- `script.js` — `stripInternalJson()` + `sanitizeAppointmentText()` (globais) e normalização a limpar todos os campos.
- `script-tail.js` — 3 paths de load/sync passam a usar o sanitizador.
- `coord-day-view.js` — sanitiza os dados obtidos por portal.
- `index.html` — cache-busting de `script.js`, `script-tail.js`, `coord-day-view.js`.

## Testes

- `node --check` aos ficheiros.
- Teste do regex com a string exata do card (blob no meio, blob puro, nota normal, blob com eurocode preenchido).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_