### PR TITLE
MyCar: importa emails encaminhados (matrícula no assunto) + erro claro

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -739,6 +739,23 @@ function authHeaders() {
   return { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` };
 }
 
+// Lê JSON com segurança: se o servidor devolver HTML (timeout/erro de
+// plataforma), dá uma mensagem clara em vez de "Unexpected token '<'".
+async function safeJson(res) {
+  const txt = await res.text();
+  try {
+    return JSON.parse(txt);
+  } catch {
+    if (!res.ok) {
+      if (res.status === 502 || res.status === 504 || res.status === 500) {
+        throw new Error('O servidor demorou demasiado ou falhou. Tenta novamente daqui a pouco.');
+      }
+      throw new Error(`Erro do servidor (${res.status}).`);
+    }
+    throw new Error('Resposta inválida do servidor.');
+  }
+}
+
 // ─── STATE ────────────────────────────────────────────────────────────────────
 let allServices   = [];  // todos os serviços carregados
 let currentPlate  = null; // matrícula aberta no detalhe
@@ -766,7 +783,7 @@ async function loadServices() {
   try {
     const res = await fetch(`${API_BASE}/mycar-services`, { headers: authHeaders() });
     if (res.status === 401) { logout(); return; }
-    const json = await res.json();
+    const json = await safeJson(res);
     if (!json.success) throw new Error(json.error);
     allServices = json.data;
     updateStats();
@@ -1014,7 +1031,7 @@ async function updateStatus(id, status, workType) {
       headers: authHeaders(),
       body: JSON.stringify(body)
     });
-    const json = await res.json();
+    const json = await safeJson(res);
     if (!json.success) throw new Error(json.error);
 
     // Atualizar estado local
@@ -1036,7 +1053,7 @@ async function toggleInTreatment(matricula, checked) {
       headers: authHeaders(),
       body: JSON.stringify({ matricula, in_treatment: checked })
     });
-    const json = await res.json();
+    const json = await safeJson(res);
     if (!json.success) throw new Error(json.error);
     allServices.filter(s => s.matricula.toUpperCase() === matricula.toUpperCase())
                .forEach(s => { s.in_treatment = checked; });
@@ -1056,7 +1073,7 @@ async function saveObsTecnico(id) {
       headers: authHeaders(),
       body: JSON.stringify({ id, status: svc.status, obs_tecnico })
     });
-    const json = await res.json();
+    const json = await safeJson(res);
     if (!json.success) throw new Error(json.error);
     const idx = allServices.findIndex(s => s.id === id);
     if (idx >= 0) allServices[idx] = json.data;
@@ -1079,7 +1096,7 @@ async function checkEmail() {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
     });
-    const data = await res.json();
+    const data = await safeJson(res);
     if (data.success) {
       const msg = data.processed > 0
         ? `✅ ${data.processed} serviço(s) importado(s)!`
@@ -1219,7 +1236,7 @@ async function doImport() {
         headers: authHeaders(),
         body: JSON.stringify(body)
       });
-      const json = await res.json();
+      const json = await safeJson(res);
       if (!json.success) throw new Error(json.error);
       toast(`${json.count} serviço(s) importado(s) com sucesso`, 'success');
 
@@ -1242,7 +1259,7 @@ async function doImport() {
         headers: authHeaders(),
         body: JSON.stringify(body)
       });
-      const json = await res.json();
+      const json = await safeJson(res);
       if (!json.success) throw new Error(json.error);
       toast(`Serviço adicionado: ${plate}`, 'success');
     }

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -37,6 +37,21 @@ function parseValor(str) {
   return isNaN(v) ? null : v;
 }
 
+// Extrai matrícula/VIN do assunto quando o email não traz tabela HTML
+// (encaminhados com os dados em imagem, ex.: "FW: BM-79-LI",
+//  "FW: BL-45-HM | WF0PXX...", "FW: M-049245//LSJW94393RG049245").
+function extractIdFromSubject(subject) {
+  if (!subject) return null;
+  const s = subject.toUpperCase();
+  // Matrícula PT: XX-XX-XX (letras/dígitos)
+  const plate = s.match(/\b([A-Z0-9]{2}-[A-Z0-9]{2}-[A-Z0-9]{2})\b/);
+  if (plate) return plate[1];
+  // VIN: 17 caracteres (sem I, O, Q)
+  const vin = s.match(/\b([A-HJ-NPR-Z0-9]{17})\b/);
+  if (vin) return vin[1];
+  return null;
+}
+
 // Lê a tabela HTML do email (incluindo emails encaminhados/FW) e devolve array de serviços
 function parseTableHtml(html) {
   if (!html) return [];
@@ -269,11 +284,20 @@ async function runPoller() {
       const tableCount = $dbg ? $dbg('table').length : 0;
       console.log(`📧 "${subject}" | html:${!!html} | tabelas:${tableCount} | from:${from}`);
 
-      const services = html ? parseTableHtml(html) : [];
+      let services = html ? parseTableHtml(html) : [];
 
+      // Fallback: sem tabela → tentar extrair a matrícula/VIN do assunto.
+      // Estes emails encaminhados trazem os dados em imagem, por isso entra
+      // só a matrícula (pendente) para o coordenador tratar manualmente.
       if (services.length === 0) {
-        console.log(`⏭️ Sem tabela de serviços: "${subject}" (tabelas:${tableCount})`);
-        continue;
+        const subjId = extractIdFromSubject(subject);
+        if (subjId) {
+          services = [{ matricula: subjId, descricao: null, valor: null, eurocode: null, ne: null }];
+          console.log(`🔤 Matrícula extraída do assunto: ${subjId} ("${subject}")`);
+        } else {
+          console.log(`⏭️ Sem tabela nem matrícula no assunto: "${subject}" (tabelas:${tableCount})`);
+          continue;
+        }
       }
 
       for (const svc of services) {


### PR DESCRIPTION
## Problema

Os emails de hoje (muitos) não entravam na app MyCar Center. São **encaminhados** ("FW:") com a **matrícula/VIN no assunto** e os dados em **imagem**. O poller só importava serviços a partir de **tabelas HTML** com coluna "Matrícula", por isso estes eram todos ignorados ("Sem tabela de serviços"). Daí também o erro `Unexpected token '<' … is not valid JSON` (o servidor devolvia uma página HTML).

## Solução

- **Poller (`mycar-gmail-poller.js`)**: quando o email não traz tabela, extrai do assunto a matrícula PT (`XX-XX-XX`) ou o VIN (17 caracteres) e cria uma entrada **pendente** para o coordenador tratar manualmente. Reutiliza a deduplicação por matrícula+assunto (não duplica).
- **Frontend (`mycar.html`)**: novo `safeJson()` — quando o servidor devolve HTML (timeout/erro de plataforma), mostra uma mensagem clara ("O servidor demorou demasiado ou falhou. Tenta novamente…") em vez do críptico `Unexpected token '<'`.

## Notas

- Nestes emails a matrícula entra sem os detalhes (carro/eurocode ficam vazios, pois estão na imagem) — o objetivo é garantir que **entram na app** para gestão. Se quiseres extrair também os dados das imagens (OCR), é um passo seguinte.
- Testado o extrator com os assuntos reais da caixa de entrada (matrícula e VIN) e com assuntos não-veículo (devolve `null`, não importa lixo).

## Ficheiros alterados

- `netlify/functions/mycar-gmail-poller.js` — `extractIdFromSubject()` + fallback no import.
- `mycar.html` — `safeJson()` e uso nas chamadas à API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_