### PR TITLE
MyCar: importa emails por lotes (evita timeout do Verificar Email)

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -1092,22 +1092,29 @@ async function checkEmail() {
 
   try {
     const token = localStorage.getItem('eg_auth_token');
-    const res = await fetch('/.netlify/functions/mycar-gmail-poller', {
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
-    });
-    const data = await safeJson(res);
-    if (data.success) {
-      const msg = data.processed > 0
-        ? `✅ ${data.processed} serviço(s) importado(s)!`
-        : '📭 Sem emails novos';
-      toast(msg);
+    let totalImported = 0;
+    let remaining = 0;
+    // Processa por lotes: continua a chamar enquanto o servidor indicar que
+    // ainda há emails por processar (limite por segurança).
+    for (let i = 0; i < 30; i++) {
+      const res = await fetch('/.netlify/functions/mycar-gmail-poller', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
+      });
+      const data = await safeJson(res);
+      if (!data.success) { toast('❌ ' + (data.error || 'Erro ao verificar email')); break; }
+      totalImported += (data.processed || 0);
+      remaining = data.remaining || 0;
       if (data.processed > 0) await loadServices();
-    } else {
-      toast('❌ ' + (data.error || 'Erro ao verificar email'));
+      if (remaining > 0) {
+        btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="animation:spin 1s linear infinite"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg> ${remaining} por processar…`;
+        continue;
+      }
+      break;
     }
+    toast(totalImported > 0 ? `✅ ${totalImported} serviço(s) importado(s)!` : '📭 Sem emails novos');
   } catch (e) {
-    toast('❌ Erro: ' + e.message);
+    toast(`Erro: ${e.message}`, 'error');
   } finally {
     btn.disabled = false;
     btn.innerHTML = orig;

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -185,7 +185,14 @@ async function ensureTable(client) {
   await client.query(`ALTER TABLE mycar_services ADD CONSTRAINT mycar_services_status_check CHECK (status IN ('pendente', 'encomendado', 'realizado', 'faturado', 'rejeitado'))`);
 }
 
-// Liga ao Gmail via IMAP e devolve emails dos últimos 3 dias
+// Máximo de emails processados por execução — evita esgotar o tempo limite
+// da função. O cron (a cada 15 min) e novos cliques em "Verificar Email"
+// esvaziam o resto, lote a lote.
+const MAX_PER_RUN = 12;
+
+// Liga ao Gmail via IMAP e devolve um LOTE de emails não-lidos (os mais
+// antigos primeiro), marcando-os como lidos para o lote seguinte avançar.
+// Devolve { emails, totalUnseen }.
 function fetchUnseenEmails() {
   return new Promise((resolve, reject) => {
     if (!GMAIL_USER || !GMAIL_PASSWORD) {
@@ -210,16 +217,18 @@ function fetchUnseenEmails() {
       imap.openBox('INBOX', false, (err) => {
         if (err) { imap.end(); reject(err); return; }
 
-        // Pesquisar emails dos últimos 3 dias (apanha emails já lidos que falharam o parse)
-        const since = new Date();
-        since.setDate(since.getDate() - 3);
-        imap.search([['SINCE', since]], (err, uids) => {
+        // Só emails NÃO LIDOS — cada execução trata um lote e marca-os como
+        // lidos, por isso o próximo lote avança sem reprocessar.
+        imap.search(['UNSEEN'], (err, uids) => {
           if (err) { imap.end(); reject(err); return; }
-          if (!uids || uids.length === 0) { imap.end(); resolve([]); return; }
+          if (!uids || uids.length === 0) { imap.end(); resolve({ emails: [], totalUnseen: 0 }); return; }
 
-          console.log(`📬 ${uids.length} email(s) encontrado(s) nos últimos 3 dias`);
+          const totalUnseen = uids.length;
+          const batch = uids.slice(0, MAX_PER_RUN); // os mais antigos primeiro
+          console.log(`📬 ${totalUnseen} não-lido(s); a processar lote de ${batch.length}`);
 
-          const fetch = imap.fetch(uids, { bodies: '', markSeen: false });
+          // markSeen:true → marca como lido ao buscar, evitando reprocessar
+          const fetch = imap.fetch(batch, { bodies: '', markSeen: true });
           const pending = [];
 
           fetch.on('message', (msg) => {
@@ -240,7 +249,7 @@ function fetchUnseenEmails() {
               emails.push(parsed);
             }
             imap.end();
-            resolve(emails);
+            resolve({ emails, totalUnseen });
           });
 
           fetch.once('error', (err) => { imap.end(); reject(err); });
@@ -259,12 +268,15 @@ const JWT_SECRET = process.env.JWT_SECRET || 'expressglass-secret-key-change-in-
 async function runPoller() {
   console.log('🔄 Mycar Gmail Poller: início');
 
-  const emails = await fetchUnseenEmails();
+  const { emails, totalUnseen } = await fetchUnseenEmails();
 
   if (emails.length === 0) {
     console.log('📭 Sem emails novos');
-    return { processed: 0, emails: 0 };
+    return { processed: 0, emails: 0, remaining: 0 };
   }
+
+  // Quantos ficam por processar em execuções seguintes (lote/cron)
+  const remaining = Math.max(0, totalUnseen - emails.length);
 
   const client = await pool.connect();
   try {
@@ -323,8 +335,8 @@ async function runPoller() {
       }
     }
 
-    console.log(`📊 Total: ${totalImported} serviço(s) de ${emails.length} email(s)`);
-    return { processed: totalImported, emails: emails.length };
+    console.log(`📊 Total: ${totalImported} serviço(s) de ${emails.length} email(s) | ${remaining} por processar`);
+    return { processed: totalImported, emails: emails.length, remaining };
 
   } finally {
     client.release();


### PR DESCRIPTION
## Problema

O botão **"Verificar Email"** esgotava o tempo limite do servidor: o poller tentava processar **todos** os emails dos últimos 3 dias (muitos, com imagens) numa só chamada → timeout (agora mostrado como "O servidor demorou demasiado ou falhou").

## Solução

Processamento **por lotes**:

- **Poller (`mycar-gmail-poller.js`)**: procura apenas emails **NÃO LIDOS**, processa um lote (`MAX_PER_RUN = 12`) dos mais antigos e marca-os como **lidos** (`markSeen`), evitando reprocessar. Devolve `remaining` (quantos faltam).
- **Frontend (`mycar.html`)**: o "Verificar Email" **encadeia lotes automaticamente** até esvaziar o backlog, mostrando "X por processar…" no botão (com limite de segurança de 30 iterações).
- O **cron de 15 min** continua a esvaziar sozinho o que faltar.

## Notas

- A mudança para "só não-lidos + marcar lido" torna cada execução curta e o progresso durável (não reprocessa os últimos 3 dias todas as vezes).
- Combina com o PR anterior (extração da matrícula do assunto), por isso quase todos os emails geram uma entrada.

## Ficheiros alterados

- `netlify/functions/mycar-gmail-poller.js` — busca UNSEEN + lote + `remaining`.
- `mycar.html` — `checkEmail()` encadeia lotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_