### PR TITLE
MyCar: importação muito mais rápida (só cabeçalhos, lotes de 100)

### DIFF
--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -188,7 +188,7 @@ async function ensureTable(client) {
 // Máximo de emails processados por execução — evita esgotar o tempo limite
 // da função. O cron (a cada 15 min) e novos cliques em "Verificar Email"
 // esvaziam o resto, lote a lote.
-const MAX_PER_RUN = 12;
+const MAX_PER_RUN = 100;
 
 // Liga ao Gmail via IMAP e devolve um LOTE de emails não-lidos (os mais
 // antigos primeiro), marcando-os como lidos para o lote seguinte avançar.
@@ -227,8 +227,10 @@ function fetchUnseenEmails() {
           const batch = uids.slice(0, MAX_PER_RUN); // os mais antigos primeiro
           console.log(`📬 ${totalUnseen} não-lido(s); a processar lote de ${batch.length}`);
 
-          // markSeen:true → marca como lido ao buscar, evitando reprocessar
-          const fetch = imap.fetch(batch, { bodies: '', markSeen: true });
+          // Só CABEÇALHOS (assunto/from/data) — a matrícula vem do assunto, por
+          // isso não descarregamos o corpo com as imagens (muito mais rápido).
+          // markSeen:true → marca como lido, evitando reprocessar.
+          const fetch = imap.fetch(batch, { bodies: 'HEADER.FIELDS (SUBJECT FROM DATE)', markSeen: true });
           const pending = [];
 
           fetch.on('message', (msg) => {
@@ -236,7 +238,7 @@ function fetchUnseenEmails() {
               const chunks = [];
               msg.on('body', (stream) => {
                 stream.on('data', chunk => chunks.push(chunk));
-                stream.once('end', () => res(Buffer.concat(chunks)));
+                stream.once('end', () => res(Buffer.concat(chunks).toString('utf8')));
               });
               msg.once('attributes', () => {});
             });
@@ -244,9 +246,15 @@ function fetchUnseenEmails() {
           });
 
           fetch.once('end', async () => {
-            for (const raw of await Promise.all(pending)) {
-              const parsed = await simpleParser(raw);
-              emails.push(parsed);
+            for (const rawHeader of await Promise.all(pending)) {
+              const h = Imap.parseHeader(rawHeader);
+              emails.push({
+                subject: (h.subject && h.subject[0]) || '',
+                from: { text: (h.from && h.from[0]) || '' },
+                date: (h.date && h.date[0]) ? new Date(h.date[0]) : new Date(),
+                html: '',
+                text: ''
+              });
             }
             imap.end();
             resolve({ emails, totalUnseen });


### PR DESCRIPTION
## Contexto

Havia **~494 emails não-lidos** em atraso. A importação por lotes já funcionava, mas era lenta porque, para cada email, descarregava o **corpo completo com as imagens** antes de ler o assunto.

## Solução

Como a matrícula/VIN está no **assunto**, deixa de ser preciso descarregar o corpo:

- **Poller**: passa a buscar apenas os **CABEÇALHOS** (`HEADER.FIELDS (SUBJECT FROM DATE)`) via IMAP e extrai a matrícula do assunto (`Imap.parseHeader`). Sem descarregar imagens → cada email fica quase instantâneo.
- **Lote sobe para 100** por execução (`MAX_PER_RUN = 100`), drenando o backlog em poucas passagens (o "Verificar Email" continua a encadear até 0).
- Continua a marcar como lido (`markSeen`) para não reprocessar.

## Nota

- Nesta abordagem os detalhes (carro/eurocode) não vêm preenchidos — estão dentro das imagens. O objetivo é meter as matrículas na app depressa. OCR das imagens fica como passo seguinte, se quiseres.

## Ficheiros alterados

- `netlify/functions/mycar-gmail-poller.js` — fetch só de cabeçalhos + lote 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_