### PR TITLE
MyCar: diagnóstico no import (mostra lidos/tabela/atualizados)

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -1098,6 +1098,8 @@ async function checkEmail() {
     const token = localStorage.getItem('eg_auth_token');
     let totalImported = 0;
     let remaining = 0;
+    let totalRead = 0;
+    const agg = { withTable: 0, viaSubject: 0, noId: 0, inserted: 0, updated: 0, skipped: 0, htmlVazio: 0 };
     // Processa por lotes: continua a chamar enquanto o servidor indicar que
     // ainda há emails por processar (limite por segurança).
     for (let i = 0; i < 60; i++) {
@@ -1108,7 +1110,9 @@ async function checkEmail() {
       const data = await safeJson(res);
       if (!data.success) { toast('❌ ' + (data.error || 'Erro ao verificar email')); break; }
       totalImported += (data.processed || 0);
+      totalRead += (data.emails || 0);
       remaining = data.remaining || 0;
+      if (data.stats) for (const k in agg) agg[k] += (data.stats[k] || 0);
       if (data.processed > 0) await loadServices();
       if (remaining > 0) {
         btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="animation:spin 1s linear infinite"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg> ${remaining} por processar…`;
@@ -1116,7 +1120,14 @@ async function checkEmail() {
       }
       break;
     }
-    toast(totalImported > 0 ? `✅ ${totalImported} serviço(s) importado(s)!` : '📭 Sem emails novos');
+    if (totalImported > 0) {
+      toast(`✅ ${totalImported} serviço(s) (${agg.inserted} novos, ${agg.updated} atualizados)`);
+    } else if (totalRead > 0) {
+      // Nada importado mas houve emails lidos — mostrar diagnóstico
+      toast(`📭 ${totalRead} lido(s): ${agg.withTable} c/ tabela, ${agg.viaSubject} p/ assunto, ${agg.skipped} já existiam, ${agg.htmlVazio} sem HTML`, 'info');
+    } else {
+      toast('📭 Sem emails não-lidos (usa "Recuperar detalhes")', 'info');
+    }
   } catch (e) {
     toast(`Erro: ${e.message}`, 'error');
   } finally {

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -314,6 +314,7 @@ async function runPoller() {
     await ensureTable(client);
     const portalId = await getMycaPortalId(client);
     let totalImported = 0;
+    const stats = { withTable: 0, viaSubject: 0, noId: 0, inserted: 0, updated: 0, skipped: 0, htmlVazio: 0 };
 
     for (const email of emails) {
       const subject  = email.subject || '';
@@ -325,19 +326,21 @@ async function runPoller() {
 
       const $dbg = html ? cheerio.load(html) : null;
       const tableCount = $dbg ? $dbg('table').length : 0;
+      if (!html) stats.htmlVazio++;
       console.log(`📧 "${subject}" | html:${!!html} | tabelas:${tableCount} | from:${from}`);
 
       let services = html ? parseTableHtml(html) : [];
+      if (services.length > 0) stats.withTable++;
 
       // Fallback: sem tabela → tentar extrair a matrícula/VIN do assunto.
-      // Estes emails encaminhados trazem os dados em imagem, por isso entra
-      // só a matrícula (pendente) para o coordenador tratar manualmente.
       if (services.length === 0) {
         const subjId = extractIdFromSubject(subject);
         if (subjId) {
           services = [{ matricula: subjId, descricao: null, valor: null, eurocode: null, ne: null }];
+          stats.viaSubject++;
           console.log(`🔤 Matrícula extraída do assunto: ${subjId} ("${subject}")`);
         } else {
+          stats.noId++;
           console.log(`⏭️ Sem tabela nem matrícula no assunto: "${subject}" (tabelas:${tableCount})`);
           continue;
         }
@@ -365,9 +368,10 @@ async function runPoller() {
                WHERE id = $5`,
               [svc.descricao, svc.valor, svc.eurocode, wip, e.id]
             );
-            totalImported++;
+            totalImported++; stats.updated++;
             console.log(`🔧 Detalhes preenchidos: ${svc.matricula} | ${svc.descricao} | €${svc.valor}`);
           } else {
+            stats.skipped++;
             console.log(`⏭️ Duplicado ignorado: ${svc.matricula} / "${subject}"`);
           }
           continue;
@@ -381,13 +385,13 @@ async function runPoller() {
           [svc.matricula, svc.descricao, svc.valor, svc.eurocode,
            from, subject, date, portalId, wip, body || null]
         );
-        totalImported++;
+        totalImported++; stats.inserted++;
         console.log(`✅ Importado: ${svc.matricula} | ${svc.descricao} | €${svc.valor}`);
       }
     }
 
-    console.log(`📊 Total: ${totalImported} serviço(s) de ${emails.length} email(s) | ${remaining} por processar`);
-    return { processed: totalImported, emails: emails.length, remaining };
+    console.log(`📊 Total: ${totalImported} | lidos:${emails.length} | ${JSON.stringify(stats)} | ${remaining} por processar`);
+    return { processed: totalImported, emails: emails.length, remaining, stats };
 
   } finally {
     client.release();


### PR DESCRIPTION
## Objetivo

Perceber porque os detalhes não estão a entrar. O poller passa a devolver **estatísticas** por execução e o frontend mostra-as no aviso quando nada é importado.

- Poller devolve `stats`: `withTable`, `viaSubject`, `noId`, `inserted`, `updated`, `skipped`, `htmlVazio`.
- Frontend ("Verificar Email"/"Recuperar detalhes") mostra, quando importa 0:
  - "📭 N lido(s): X c/ tabela, Y p/ assunto, Z já existiam, W sem HTML"
  - ou "Sem emails não-lidos (usa Recuperar detalhes)".

Assim distinguimos rapidamente as causas: sem não-lidos vs. lidos-mas-sem-tabela-no-HTML vs. já-existiam.

## Ficheiros alterados

- `netlify/functions/mycar-gmail-poller.js` — contadores + `stats` na resposta.
- `mycar.html` — agrega `stats` e mostra no aviso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_