### PR TITLE
MyCar: import robusto (assunto+tabela, casar por assunto, lote 8, tolera erros)

### DIFF
--- a/mycar.html
+++ b/mycar.html
@@ -1102,13 +1102,21 @@ async function checkEmail() {
     const agg = { withTable: 0, viaSubject: 0, noId: 0, inserted: 0, updated: 0, skipped: 0, htmlVazio: 0 };
     // Processa por lotes: continua a chamar enquanto o servidor indicar que
     // ainda há emails por processar (limite por segurança).
-    for (let i = 0; i < 60; i++) {
-      const res = await fetch('/.netlify/functions/mycar-gmail-poller', {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
-      });
-      const data = await safeJson(res);
-      if (!data.success) { toast('❌ ' + (data.error || 'Erro ao verificar email')); break; }
+    let erros = 0;
+    for (let i = 0; i < 80; i++) {
+      let data;
+      try {
+        const res = await fetch('/.netlify/functions/mycar-gmail-poller', {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' }
+        });
+        data = await safeJson(res);
+      } catch (err) {
+        // Erro transitório (ex.: timeout de um lote) — tenta continuar
+        if (++erros >= 5) { toast('❌ ' + err.message, 'error'); break; }
+        continue;
+      }
+      if (!data.success) { if (++erros >= 5) { toast('❌ ' + (data.error || 'Erro ao verificar email'), 'error'); break; } continue; }
       totalImported += (data.processed || 0);
       totalRead += (data.emails || 0);
       remaining = data.remaining || 0;

--- a/netlify/functions/mycar-gmail-poller.js
+++ b/netlify/functions/mycar-gmail-poller.js
@@ -188,7 +188,7 @@ async function ensureTable(client) {
 // Máximo de emails processados por execução — evita esgotar o tempo limite
 // da função. O cron (a cada 15 min) e novos cliques em "Verificar Email"
 // esvaziam o resto, lote a lote.
-const MAX_PER_RUN = 15;
+const MAX_PER_RUN = 8;
 
 // Liga ao Gmail via IMAP e devolve um LOTE de emails não-lidos (os mais
 // antigos primeiro), marcando-os como lidos para o lote seguinte avançar.
@@ -317,6 +317,7 @@ async function runPoller() {
     const stats = { withTable: 0, viaSubject: 0, noId: 0, inserted: 0, updated: 0, skipped: 0, htmlVazio: 0 };
 
     for (const email of emails) {
+     try {
       const subject  = email.subject || '';
       const from     = email.from?.text || '';
       const date     = email.date || new Date();
@@ -324,55 +325,57 @@ async function runPoller() {
       const wip      = extractWip(subject);
       const body     = cleanEmailBody(email.text || '');
 
-      const $dbg = html ? cheerio.load(html) : null;
-      const tableCount = $dbg ? $dbg('table').length : 0;
       if (!html) stats.htmlVazio++;
-      console.log(`📧 "${subject}" | html:${!!html} | tabelas:${tableCount} | from:${from}`);
 
-      let services = html ? parseTableHtml(html) : [];
-      if (services.length > 0) stats.withTable++;
+      // Matrícula/VIN vem do ASSUNTO (fiável); os detalhes (serviço/valor/
+      // eurocode) vêm da TABELA no corpo. Juntamos os dois.
+      const subjId = extractIdFromSubject(subject);
+      const tableRows = html ? parseTableHtml(html) : [];
+      if (tableRows.length > 0) stats.withTable++;
 
-      // Fallback: sem tabela → tentar extrair a matrícula/VIN do assunto.
-      if (services.length === 0) {
-        const subjId = extractIdFromSubject(subject);
-        if (subjId) {
-          services = [{ matricula: subjId, descricao: null, valor: null, eurocode: null, ne: null }];
-          stats.viaSubject++;
-          console.log(`🔤 Matrícula extraída do assunto: ${subjId} ("${subject}")`);
-        } else {
-          stats.noId++;
-          console.log(`⏭️ Sem tabela nem matrícula no assunto: "${subject}" (tabelas:${tableCount})`);
-          continue;
-        }
+      let services;
+      if (tableRows.length > 0) {
+        services = tableRows.map(r => ({
+          matricula: (r.matricula && r.matricula.length >= 4) ? r.matricula : subjId,
+          descricao: r.descricao, valor: r.valor, eurocode: r.eurocode, ne: r.ne
+        })).filter(s => s.matricula);
+      } else if (subjId) {
+        services = [{ matricula: subjId, descricao: null, valor: null, eurocode: null, ne: null }];
+        stats.viaSubject++;
+      } else {
+        stats.noId++;
+        continue; // não é um email de serviço MyCar
       }
+      if (services.length === 0) { stats.noId++; continue; }
+      console.log(`📧 "${subject}" | tabela:${tableRows.length} | serviços:${services.length}`);
 
       for (const svc of services) {
+        // Casar por ASSUNTO (um email = um orçamento) para atualizar a
+        // entrada certa mesmo que a matrícula tenha entrado diferente antes.
         const { rows: existing } = await client.query(
-          `SELECT id, descricao, valor, eurocode FROM mycar_services WHERE matricula = $1 AND email_subject = $2 LIMIT 1`,
-          [svc.matricula, subject]
+          `SELECT id, descricao, valor, eurocode FROM mycar_services WHERE email_subject = $1 LIMIT 1`,
+          [subject]
         );
         if (existing.length > 0) {
-          // Já existe. Se entrou antes sem detalhes (só matrícula) e agora
-          // temos a tabela, preenche o que falta (recupera os detalhes).
           const e = existing[0];
           const temNovos = svc.descricao || svc.valor != null || svc.eurocode;
           const faltava  = !e.descricao && e.valor == null && !e.eurocode;
           if (temNovos && faltava) {
             await client.query(
               `UPDATE mycar_services
-                 SET descricao = COALESCE($1, descricao),
-                     valor     = COALESCE($2, valor),
-                     eurocode  = COALESCE($3, eurocode),
-                     notas     = COALESCE(notas, $4),
+                 SET matricula = $1,
+                     descricao = COALESCE($2, descricao),
+                     valor     = COALESCE($3, valor),
+                     eurocode  = COALESCE($4, eurocode),
+                     notas     = COALESCE(notas, $5),
                      updated_at = NOW()
-               WHERE id = $5`,
-              [svc.descricao, svc.valor, svc.eurocode, wip, e.id]
+               WHERE id = $6`,
+              [svc.matricula, svc.descricao, svc.valor, svc.eurocode, wip, e.id]
             );
             totalImported++; stats.updated++;
             console.log(`🔧 Detalhes preenchidos: ${svc.matricula} | ${svc.descricao} | €${svc.valor}`);
           } else {
             stats.skipped++;
-            console.log(`⏭️ Duplicado ignorado: ${svc.matricula} / "${subject}"`);
           }
           continue;
         }
@@ -388,6 +391,10 @@ async function runPoller() {
         totalImported++; stats.inserted++;
         console.log(`✅ Importado: ${svc.matricula} | ${svc.descricao} | €${svc.valor}`);
       }
+     } catch (emailErr) {
+       stats.erros = (stats.erros || 0) + 1;
+       console.error('⚠️ Erro a processar email:', emailErr.message);
+     }
     }
 
     console.log(`📊 Total: ${totalImported} | lidos:${emails.length} | ${JSON.stringify(stats)} | ${remaining} por processar`);


### PR DESCRIPTION
## Diagnóstico

O aviso mostrou: **"45 lidos: 3 c/ tabela, 2 p/ assunto, 5 já existiam, 0 sem HTML"** + um **"Erro ao verificar email"** a meio. Ou seja: a tabela é encontrada, mas um lote estourava o tempo e **parava todo o processo**; e as 3 com tabela casavam com entradas que já tinham detalhes (ignoradas).

## Correções

- **Junta assunto + tabela** por email: matrícula do **assunto** (fiável) + serviço/valor/eurocode da **tabela** do corpo.
- **Casa a entrada por ASSUNTO** (um email = um orçamento) em vez de por matrícula — atualiza a matrícula e preenche os detalhes em falta, evitando duplicados quando a matrícula tinha entrado diferente (ex.: VIN vs. matrícula) e recuperando os que entraram só com matrícula.
- **Cada email num try/catch**: um erro num email já não trava o lote inteiro (conta em `stats.erros`).
- **Lote desce para 8** (evita o timeout ao descarregar os corpos).
- **Frontend tolerante a erros**: um erro transitório num lote faz retry (até 5) em vez de parar o processo à primeira; loop até 80.

## Como testar

1. **"Recuperar detalhes"** → deve agora percorrer tudo sem parar e preencher serviço/valor/eurocode.
2. O aviso final mostra novos/atualizados.

## Ficheiros alterados

- `netlify/functions/mycar-gmail-poller.js` — assunto+tabela, upsert por assunto, try/catch por email, lote 8.
- `mycar.html` — drain tolerante a erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012pvjJzpXpaM7YHhagF8ZEc)_